### PR TITLE
Handle new error case where the extension is not signed in

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "narada"
-version = "0.1.2"
+version = "0.1.3"
 description = "Python client SDK for Narada"
 license = "Apache-2.0"
 readme = "README.md"

--- a/src/narada/__init__.py
+++ b/src/narada/__init__.py
@@ -10,7 +10,7 @@ from narada.errors import (
 )
 from narada.window import BrowserWindow
 
-__version__ = "0.1.0"
+__version__ = "0.1.3"
 
 
 __all__ = [

--- a/src/narada/__init__.py
+++ b/src/narada/__init__.py
@@ -1,7 +1,9 @@
 from narada.client import Narada
 from narada.config import BrowserConfig
 from narada.errors import (
+    NaradaError,
     NaradaExtensionMissingError,
+    NaradaExtensionUnauthenticatedError,
     NaradaInitializationError,
     NaradaTimeoutError,
     NaradaUnsupportedBrowserError,
@@ -13,10 +15,12 @@ __version__ = "0.1.0"
 
 __all__ = [
     "BrowserConfig",
-    "Narada",
-    "NaradaExtensionMissingError",
-    "NaradaInitializationError",
     "BrowserWindow",
+    "Narada",
+    "NaradaError",
+    "NaradaExtensionMissingError",
+    "NaradaExtensionUnauthenticatedError",
+    "NaradaInitializationError",
     "NaradaTimeoutError",
     "NaradaUnsupportedBrowserError",
 ]

--- a/src/narada/errors.py
+++ b/src/narada/errors.py
@@ -14,5 +14,9 @@ class NaradaExtensionMissingError(NaradaError):
     pass
 
 
+class NaradaExtensionUnauthenticatedError(NaradaError):
+    pass
+
+
 class NaradaInitializationError(NaradaError):
     pass

--- a/uv.lock
+++ b/uv.lock
@@ -329,7 +329,7 @@ wheels = [
 
 [[package]]
 name = "narada"
-version = "0.1.0"
+version = "0.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Raises an `NaradaExtensionUnauthenticated` error when the extension is not signed in.