### PR TITLE
Added fields to python sdk for completeness

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "narada"
-version = "0.1.6"
+version = "0.1.7"
 description = "Python client SDK for Narada"
 license = "Apache-2.0"
 readme = "README.md"

--- a/src/narada/__init__.py
+++ b/src/narada/__init__.py
@@ -14,7 +14,7 @@ from narada.window import (
     ResponseContent,
 )
 
-__version__ = "0.1.6"
+__version__ = "0.1.7"
 
 
 __all__ = [

--- a/src/narada/models.py
+++ b/src/narada/models.py
@@ -4,6 +4,7 @@ from typing import Literal, TypeAlias
 
 UserResourceCredentials: TypeAlias = dict[Literal["salesforce", "jira"], dict[str, str]]
 
+
 class RemoteDispatchChatHistoryItem(BaseModel):
     role: Literal["user", "assistant"]
     content: str

--- a/src/narada/models.py
+++ b/src/narada/models.py
@@ -1,0 +1,9 @@
+from pydantic import BaseModel
+from typing import Literal, TypeAlias
+
+
+UserResourceCredentials: TypeAlias = dict[Literal["salesforce", "jira"], dict[str, str]]
+
+class RemoteDispatchChatHistoryItem(BaseModel):
+    role: Literal["user", "assistant"]
+    content: str

--- a/src/narada/models.py
+++ b/src/narada/models.py
@@ -1,10 +1,11 @@
-from pydantic import BaseModel
-from typing import Literal, TypeAlias
+from typing import Literal, TypedDict
 
 
-UserResourceCredentials: TypeAlias = dict[Literal["salesforce", "jira"], dict[str, str]]
+class UserResourceCredentials(TypedDict, total=False):
+    salesforce: dict[str, str]
+    jira: dict[str, str]
 
 
-class RemoteDispatchChatHistoryItem(BaseModel):
+class RemoteDispatchChatHistoryItem(TypedDict):
     role: Literal["user", "assistant"]
     content: str

--- a/src/narada/window.py
+++ b/src/narada/window.py
@@ -119,6 +119,7 @@ class BrowserWindow:
         if previous_request_id is not None:
             body["previousRequestId"] = previous_request_id
         if chat_history is not None:
+            # Converts the Pydantic models to dictionaries (not directly serializable)
             body["chatHistory"] = [item.model_dump() for item in chat_history]
         if additional_context is not None:
             body["additionalContext"] = additional_context

--- a/src/narada/window.py
+++ b/src/narada/window.py
@@ -67,6 +67,13 @@ class BrowserWindow:
         clear_chat: bool | None = None,
         generate_gif: bool | None = None,
         output_schema: None = None,
+        previous_request_id: str | None = None,
+        chat_history: list[RemoteDispatchChatHistoryItem] | None = None,
+        additional_context: dict[str, str] | None = None,
+        time_zone: str = "America/Los_Angeles",
+        user_resource_credentials: UserResourceCredentials | None = None,
+        callback_url: str | None = None,
+        callback_secret: str | None = None,
         timeout: int = 120,
     ) -> Response[None]: ...
 
@@ -78,6 +85,13 @@ class BrowserWindow:
         clear_chat: bool | None = None,
         generate_gif: bool | None = None,
         output_schema: type[_StructuredOutput],
+        previous_request_id: str | None = None,
+        chat_history: list[RemoteDispatchChatHistoryItem] | None = None,
+        additional_context: dict[str, str] | None = None,
+        time_zone: str = "America/Los_Angeles",
+        user_resource_credentials: UserResourceCredentials | None = None,
+        callback_url: str | None = None,
+        callback_secret: str | None = None,
         timeout: int = 120,
     ) -> Response[_StructuredOutput]: ...
 
@@ -88,7 +102,6 @@ class BrowserWindow:
         clear_chat: bool | None = None,
         generate_gif: bool | None = None,
         output_schema: type[BaseModel] | None = None,
-        timeout: int = 120,
         previous_request_id: str | None = None,
         chat_history: list[RemoteDispatchChatHistoryItem] | None = None,
         additional_context: dict[str, str] | None = None,
@@ -96,6 +109,7 @@ class BrowserWindow:
         user_resource_credentials: UserResourceCredentials | None = None,
         callback_url: str | None = None,
         callback_secret: str | None = None,
+        timeout: int = 120,
     ) -> Response:
         deadline = time.monotonic() + timeout
 
@@ -119,8 +133,7 @@ class BrowserWindow:
         if previous_request_id is not None:
             body["previousRequestId"] = previous_request_id
         if chat_history is not None:
-            # Converts the Pydantic models to dictionaries (not directly serializable)
-            body["chatHistory"] = [item.model_dump() for item in chat_history]
+            body["chatHistory"] = chat_history
         if additional_context is not None:
             body["additionalContext"] = additional_context
         if user_resource_credentials is not None:
@@ -128,7 +141,7 @@ class BrowserWindow:
         if callback_url is not None:
             body["callbackUrl"] = callback_url
         if callback_secret is not None:
-            body["callbackSecret"] = callback_secret        
+            body["callbackSecret"] = callback_secret
 
         try:
             async with aiohttp.ClientSession() as session:

--- a/uv.lock
+++ b/uv.lock
@@ -359,7 +359,7 @@ wheels = [
 
 [[package]]
 name = "narada"
-version = "0.1.6"
+version = "0.1.7"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Added the following fields:

```
previousRequestId: str | None = None
chatHistory: list[RemoteDispatchChatHistoryItem] | None = None
additionalContext: dict[str, str] | None = None
timeZone: str = "America/Los_Angeles"
userResourceCredentials: UserResourceCredentials | None = None
callbackUrl: str | None = None
callbackSecret: str | None = None
```

to the `dispatch_request` method in the python SDK for completeness. Added a `models.py` file for necessary classes for chat history and user credentials.