### PR TITLE
Remove emojis from CLI output

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "narada"
-version = "0.1.9"
+version = "0.1.10"
 description = "Python client SDK for Narada"
 license = "Apache-2.0"
 readme = "README.md"

--- a/src/narada/__init__.py
+++ b/src/narada/__init__.py
@@ -16,7 +16,7 @@ from narada.window import (
     ResponseContent,
 )
 
-__version__ = "0.1.9"
+__version__ = "0.1.10"
 
 
 __all__ = [

--- a/src/narada/client.py
+++ b/src/narada/client.py
@@ -102,7 +102,7 @@ class Narada:
             except _ShouldRetryCreateProcess as e:
                 if config.interactive:
                     self._console.input(
-                        "\n:wrench: [bold blue]New extension installation detected. Press Enter to "
+                        "\n> [bold blue]New extension installation detected. Press Enter to "
                         "relaunch the browser and continue.[/bold blue]"
                     )
 
@@ -213,7 +213,7 @@ class Narada:
 
         if config.interactive:
             self._console.print(
-                "\n:rocket: Initialization successful. Browser window ID: "
+                "\n> Initialization successful. Browser window ID: "
                 f"{browser_window_id}\n",
                 style="bold green",
             )
@@ -313,13 +313,13 @@ class Narada:
                     )
                 except NaradaExtensionMissingError:
                     self._console.input(
-                        "\n:wrench: [bold blue]The Narada Enterprise extension is not installed. "
+                        "\n> [bold blue]The Narada Enterprise extension is not installed. "
                         "Please follow the instructions in the browser window to install it first, "
                         "then press Enter to continue.[/bold blue]",
                     )
                 except NaradaExtensionUnauthenticatedError:
                     self._console.input(
-                        "\n:lock: [bold blue]Please sign in to the Narada extension first, then "
+                        "\n> [bold blue]Please sign in to the Narada extension first, then "
                         "press Enter to continue.[/bold blue]",
                     )
 
@@ -331,7 +331,7 @@ class Narada:
 
         except TargetClosedError:
             self._console.print(
-                "\n:warning: It seems the Narada automation page was closed. Please retry the "
+                "\n> It seems the Narada automation page was closed. Please retry the "
                 "action and keep the Narada web page open.",
                 style="bold red",
             )

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.11"
 
 [[package]]
@@ -359,7 +359,7 @@ wheels = [
 
 [[package]]
 name = "narada"
-version = "0.1.9"
+version = "0.1.10"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
The emojis have been breaking some environments that don't support rendering emojis, such as certain terminals on Windows.