### PR TITLE
Correctly handle process spawning on Windows

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "narada"
-version = "0.1.10"
+version = "0.1.11"
 description = "Python client SDK for Narada"
 license = "Apache-2.0"
 readme = "README.md"

--- a/src/narada/__init__.py
+++ b/src/narada/__init__.py
@@ -16,7 +16,7 @@ from narada.window import (
     ResponseContent,
 )
 
-__version__ = "0.1.10"
+__version__ = "0.1.11"
 
 
 __all__ = [

--- a/uv.lock
+++ b/uv.lock
@@ -359,7 +359,7 @@ wheels = [
 
 [[package]]
 name = "narada"
-version = "0.1.10"
+version = "0.1.11"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
`asyncio.subprocess` cannot actually spawn a detached process on Windows. It seems the only way to do it right now is to use the `subprocess.Popen` class instead.