### PR TITLE
Expose agent usage data

### DIFF
--- a/examples/choose_agent.py
+++ b/examples/choose_agent.py
@@ -10,12 +10,9 @@ async def main() -> None:
         window = await narada.open_and_initialize_browser_window()
 
         # Choose a specific agent to handle the task. By default, the Operator agent is used.
-        response = await window.dispatch_request(
-            prompt="Tell me a joke.", agent=Agent.GENERALIST
-        )
+        response = await window.agent(prompt="Tell me a joke.", agent=Agent.GENERALIST)
 
-        assert response["response"] is not None
-        print("Response:", response["response"]["text"])
+        print("Response:", response.model_dump_json(indent=2))
 
 
 if __name__ == "__main__":

--- a/examples/custom_agent.py
+++ b/examples/custom_agent.py
@@ -15,13 +15,12 @@ async def main() -> None:
         # https://app.narada.ai/agent-builder/agents/demo%2540narada.ai%3Agreeter-agent
         custom_agent = "/demo@narada.ai/greeter-agent"
         user_query = "John Doe"
-        response = await window.dispatch_request(
+        response = await window.agent(
             prompt=user_query,
             agent=custom_agent,
         )
 
-        assert response["response"] is not None
-        print("Response:", response["response"]["text"])
+        print("Response:", response.model_dump_json(indent=2))
 
 
 if __name__ == "__main__":

--- a/examples/multiple_windows.py
+++ b/examples/multiple_windows.py
@@ -1,15 +1,16 @@
 import asyncio
 
-from narada import Narada, Response
+from narada import Narada
+from narada.actions.models import AgentResponse
 
 
 async def main() -> None:
     # Initialize the Narada client.
     async with Narada() as narada:
         # Helper function to run a task in a new browser window.
-        async def run_task(prompt: str) -> Response:
+        async def run_task(prompt: str) -> AgentResponse:
             window = await narada.open_and_initialize_browser_window()
-            return await window.dispatch_request(prompt=prompt)
+            return await window.agent(prompt=prompt)
 
         # Run multiple tasks in parallel.
         responses = await asyncio.gather(
@@ -25,8 +26,7 @@ async def main() -> None:
         )
 
         for i, response in enumerate(responses):
-            assert response["response"] is not None
-            print(f"Response {i + 1}: {response['response']['text']}\n")
+            print(f"Response #{i + 1}: {response.model_dump_json(indent=2)}\n")
 
 
 if __name__ == "__main__":

--- a/examples/remote_browser.py
+++ b/examples/remote_browser.py
@@ -12,15 +12,14 @@ async def main() -> None:
     window = RemoteBrowserWindow(browser_window_id=browser_window_id)
 
     # Run a task on another machine.
-    response = await window.dispatch_request(
+    response = await window.agent(
         prompt=(
             'Search for "LLM Compiler" on Google and open the first arXiv paper on the results '
             "page, then tell me who the authors are."
         )
     )
 
-    assert response["response"] is not None
-    print("Response:", response["response"]["text"])
+    print("Response:", response.model_dump_json(indent=2))
 
 
 if __name__ == "__main__":

--- a/examples/single_window.py
+++ b/examples/single_window.py
@@ -10,14 +10,13 @@ async def main() -> None:
         window = await narada.open_and_initialize_browser_window()
 
         # Run a task in this browser window.
-        response = await window.dispatch_request(
+        response = await window.agent(
             prompt='Search for "LLM Compiler" on Google and open the first arXiv paper on the results page, then open the PDF. Then download the PDF of the paper.',
             # Optionally generate a GIF of the agent's actions.
             generate_gif=True,
         )
 
-        assert response["response"] is not None
-        print("Response:", response["response"]["text"])
+        print("Response:", response.model_dump_json(indent=2))
 
 
 if __name__ == "__main__":

--- a/examples/structured_output.py
+++ b/examples/structured_output.py
@@ -1,9 +1,8 @@
 import asyncio
 
 import rich
-from pydantic import BaseModel, Field
-
 from narada import Narada
+from pydantic import BaseModel, Field
 
 
 class PaperInfo(BaseModel):
@@ -26,7 +25,7 @@ async def main() -> None:
         window = await narada.open_and_initialize_browser_window()
 
         # Run a task in this browser window.
-        response = await window.dispatch_request(
+        response = await window.agent(
             prompt=(
                 'Search for "LLM Compiler" on Google and open the first arXiv paper on the results '
                 "page. Then extract the paper info from the arXiv page in the given format."
@@ -34,8 +33,7 @@ async def main() -> None:
             output_schema=PaperInfo,
         )
 
-        assert response["response"] is not None
-        rich.print("Response:", response["response"]["structuredOutput"])
+        rich.print("Response:", response.structured_output)
 
 
 if __name__ == "__main__":

--- a/examples/timeout_handling.py
+++ b/examples/timeout_handling.py
@@ -12,14 +12,13 @@ async def main() -> None:
         max_attempts = 3
         for attempt in range(max_attempts):
             try:
-                response = await window.dispatch_request(
+                response = await window.agent(
                     prompt='Search for "random number between 1 and 5" on Google and extract the generated number from the search result page. Output just the number.',
                     # Force a timeout on the first attempt to demonstrate timeout handling.
                     timeout=3 if attempt == 0 else 120,
                 )
 
-                assert response["response"] is not None
-                print("Response:", response["response"]["text"])
+                print("Response:", response.model_dump_json(indent=2))
             except NaradaTimeoutError:
                 # Give up after `max_attempts` attempts.
                 if attempt == max_attempts - 1:

--- a/packages/narada-pyodide/pyproject.toml
+++ b/packages/narada-pyodide/pyproject.toml
@@ -1,7 +1,7 @@
 
 [project]
 name = "narada-pyodide"
-version = "0.0.14"
+version = "0.0.15"
 description = "Pyodide-compatible Python client SDK for Narada"
 license = "Apache-2.0"
 readme = "README.md"

--- a/packages/narada-pyodide/src/narada/actions/models.py
+++ b/packages/narada-pyodide/src/narada/actions/models.py
@@ -8,10 +8,16 @@ from pydantic import BaseModel
 _MaybeStructuredOutput = TypeVar("_MaybeStructuredOutput", bound=BaseModel | None)
 
 
+class AgentUsage(BaseModel):
+    actions: int
+    credits: int
+
+
 class AgentResponse(BaseModel, Generic[_MaybeStructuredOutput]):
     status: Literal["success", "error", "input-required"]
     text: str
     structured_output: _MaybeStructuredOutput | None
+    usage: AgentUsage
 
 
 class GoToUrlRequest(BaseModel):

--- a/packages/narada-pyodide/src/narada/window.py
+++ b/packages/narada-pyodide/src/narada/window.py
@@ -13,6 +13,7 @@ from pyodide.http import pyfetch
 
 from narada.actions.models import (
     AgentResponse,
+    AgentUsage,
     ExtensionActionRequest,
     ExtensionActionResponse,
     GoToUrlRequest,
@@ -39,12 +40,18 @@ class ResponseContent(TypedDict, Generic[_MaybeStructuredOutput]):
     structuredOutput: _MaybeStructuredOutput
 
 
+class Usage(TypedDict):
+    actions: int
+    credits: int
+
+
 class Response(TypedDict, Generic[_MaybeStructuredOutput]):
     requestId: str
     status: Literal["success", "error"]
     response: ResponseContent[_MaybeStructuredOutput] | None
     createdAt: str
     completedAt: str | None
+    usage: Usage
 
 
 _ResponseModel = TypeVar("_ResponseModel", bound=BaseModel)
@@ -301,6 +308,7 @@ class BaseBrowserWindow(ABC):
             status=remote_dispatch_response["status"],
             text=response_content["text"],
             structured_output=response_content.get("structuredOutput"),
+            usage=AgentUsage.model_validate(remote_dispatch_response["usage"]),
         )
 
     async def go_to_url(

--- a/packages/narada/pyproject.toml
+++ b/packages/narada/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "narada"
-version = "0.1.12"
+version = "0.1.13"
 description = "Python client SDK for Narada"
 license = "Apache-2.0"
 readme = "README.md"

--- a/packages/narada/src/narada/actions/models.py
+++ b/packages/narada/src/narada/actions/models.py
@@ -8,10 +8,16 @@ from pydantic import BaseModel
 _MaybeStructuredOutput = TypeVar("_MaybeStructuredOutput", bound=BaseModel | None)
 
 
+class AgentUsage(BaseModel):
+    actions: int
+    credits: int
+
+
 class AgentResponse(BaseModel, Generic[_MaybeStructuredOutput]):
     status: Literal["success", "error", "input-required"]
     text: str
     structured_output: _MaybeStructuredOutput | None
+    usage: AgentUsage
 
 
 class GoToUrlRequest(BaseModel):

--- a/packages/narada/src/narada/window.py
+++ b/packages/narada/src/narada/window.py
@@ -11,6 +11,7 @@ from pydantic import BaseModel
 
 from narada.actions.models import (
     AgentResponse,
+    AgentUsage,
     ExtensionActionRequest,
     ExtensionActionResponse,
     GoToUrlRequest,
@@ -33,12 +34,18 @@ class ResponseContent(TypedDict, Generic[_MaybeStructuredOutput]):
     structuredOutput: _MaybeStructuredOutput
 
 
+class Usage(TypedDict):
+    actions: int
+    credits: int
+
+
 class Response(TypedDict, Generic[_MaybeStructuredOutput]):
     requestId: str
     status: Literal["success", "error", "input-required"]
     response: ResponseContent[_MaybeStructuredOutput] | None
     createdAt: str
     completedAt: str | None
+    usage: Usage
 
 
 _ResponseModel = TypeVar("_ResponseModel", bound=BaseModel)
@@ -254,6 +261,7 @@ class BaseBrowserWindow(ABC):
             status=remote_dispatch_response["status"],
             text=response_content["text"],
             structured_output=response_content.get("structuredOutput"),
+            usage=AgentUsage.model_validate(remote_dispatch_response["usage"]),
         )
 
     async def go_to_url(

--- a/uv.lock
+++ b/uv.lock
@@ -308,7 +308,7 @@ wheels = [
 
 [[package]]
 name = "narada"
-version = "0.1.12"
+version = "0.1.13"
 source = { editable = "packages/narada" }
 dependencies = [
     { name = "aiohttp" },
@@ -339,7 +339,7 @@ dev = [
 
 [[package]]
 name = "narada-pyodide"
-version = "0.0.14"
+version = "0.0.15"
 source = { editable = "packages/narada-pyodide" }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
1. Expose a `usage` field in `AgentResponse`
2. Update all examples to move from legacy `dispatch_request` API to new `agent` API
3. Bump versions for both `narada` and `narada-pyodide`