### PR TITLE
Improve browser launching behavior

### DIFF
--- a/packages/narada-pyodide/pyproject.toml
+++ b/packages/narada-pyodide/pyproject.toml
@@ -1,7 +1,7 @@
 
 [project]
 name = "narada-pyodide"
-version = "0.0.19"
+version = "0.0.20"
 description = "Pyodide-compatible Python client SDK for Narada"
 license = "Apache-2.0"
 readme = "README.md"

--- a/packages/narada/pyproject.toml
+++ b/packages/narada/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "narada"
-version = "0.1.17"
+version = "0.1.18"
 description = "Python client SDK for Narada"
 license = "Apache-2.0"
 readme = "README.md"

--- a/packages/narada/src/narada/client.py
+++ b/packages/narada/src/narada/client.py
@@ -142,6 +142,8 @@ class Narada:
             f"--user-data-dir={config.user_data_dir}",
             f"--profile-directory={config.profile_directory}",
             f"--remote-debugging-port={config.cdp_port}",
+            "--no-default-browser-check",
+            "--no-first-run",
             "--new-window",
             tagged_initialization_url,
             # TODO: This is needed if we don't use CDP but let Playwright manage the browser.

--- a/packages/narada/src/narada/client.py
+++ b/packages/narada/src/narada/client.py
@@ -173,8 +173,8 @@ class Narada:
 
         logging.debug("Browser process started with PID: %s", browser_process.pid)
 
-        # We need to wait a bit before connecting to the browser over CDP for the initial page to
-        # open. Otherwise Playwright just sees an empty context with no pages.
+        # We need to wait a bit for the initial page to open before connecting to the browser over
+        # CDP, otherwise Playwright can see an empty context with no pages.
         await asyncio.sleep(1)
 
         context = None

--- a/uv.lock
+++ b/uv.lock
@@ -309,7 +309,7 @@ wheels = [
 
 [[package]]
 name = "narada"
-version = "0.1.17"
+version = "0.1.18"
 source = { editable = "packages/narada" }
 dependencies = [
     { name = "aiohttp" },
@@ -351,7 +351,7 @@ requires-dist = [{ name = "pydantic", specifier = "==2.10.6" }]
 
 [[package]]
 name = "narada-pyodide"
-version = "0.0.19"
+version = "0.0.20"
 source = { editable = "packages/narada-pyodide" }
 dependencies = [
     { name = "narada-core" },


### PR DESCRIPTION
- Skip useless Chrome screens on launch
- Wait a bit before connecting over CDP to Chrome for the initial page to load