### PR TITLE
Navigate to the `customToken` URL when spinning up a Narada instance

### DIFF
--- a/packages/narada/src/narada/config.py
+++ b/packages/narada/src/narada/config.py
@@ -29,6 +29,5 @@ class BrowserConfig:
     profile_directory: str = "Default"
     cdp_port: int = 9222
     initialization_url: str = "https://app.narada.ai/initialize"
-    backend_api_base_url: str = "https://app.narada.ai/fast/v2"
     extension_id: str = "bhioaidlggjdkheaajakomifblpjmokn"
     interactive: bool = True


### PR DESCRIPTION
Add the `customToken` that is retrieved from the `apiKey` to the URL when initiating the Narada instance. This allows the frontend to sign in automatically rather than waiting for user input to sign in.