### PR TITLE
Support attaching to existing browser window

### DIFF
--- a/examples/existing_browser.py
+++ b/examples/existing_browser.py
@@ -1,0 +1,69 @@
+import asyncio
+import subprocess
+import sys
+
+from narada import Narada
+from narada.config import BrowserConfig
+
+
+async def launch_browser(config: BrowserConfig) -> None:
+    browser_args = [
+        f"--user-data-dir={config.user_data_dir}",
+        f"--profile-directory={config.profile_directory}",
+        f"--remote-debugging-port={config.cdp_port}",
+        "--no-default-browser-check",
+        "--no-first-run",
+    ]
+
+    # Launch an independent browser process which will not be killed when the current program exits.
+    if sys.platform == "win32":
+        subprocess.Popen(
+            [config.executable_path, *browser_args],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            creationflags=subprocess.CREATE_NEW_PROCESS_GROUP
+            | subprocess.DETACHED_PROCESS,
+        )
+    else:
+        await asyncio.create_subprocess_exec(
+            config.executable_path,
+            *browser_args,
+            stdin=asyncio.subprocess.DEVNULL,
+            stdout=asyncio.subprocess.DEVNULL,
+            stderr=asyncio.subprocess.DEVNULL,
+            start_new_session=True,
+        )
+
+
+async def main() -> None:
+    config = BrowserConfig()
+
+    # Step 1: Launch browser outside of Narada SDK. In practice, the browser can be launched in any
+    # way, as long as CDP is enabled.
+    print(f"Launching browser with CDP port {config.cdp_port}...")
+    await launch_browser(config)
+
+    # Wait a bit for the browser to be ready.
+    await asyncio.sleep(5)
+
+    # Step 2: Use Narada SDK to attach to the existing browser.
+    print("Connecting to existing browser with Narada SDK...")
+    async with Narada() as narada:
+        # Attach to the existing browser window.
+        window = await narada.initialize_in_existing_browser_window(config)
+
+        print(f"Successfully attached to browser window: {window.browser_window_id}")
+
+        # Run a task in this browser window
+        response = await window.agent(
+            prompt='Search for "LLM Compiler" on Google and open the first arXiv paper on the results page, then open the PDF. Then download the PDF of the paper.',
+            # Optionally generate a GIF of the agent's actions
+            generate_gif=True,
+        )
+
+        print("Response:", response.model_dump_json(indent=2))
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/packages/narada/pyproject.toml
+++ b/packages/narada/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "narada"
-version = "0.1.18"
+version = "0.1.19"
 description = "Python client SDK for Narada"
 license = "Apache-2.0"
 readme = "README.md"

--- a/packages/narada/src/narada/client.py
+++ b/packages/narada/src/narada/client.py
@@ -18,7 +18,6 @@ from narada_core.errors import (
 )
 from playwright._impl._errors import Error as PlaywrightError
 from playwright.async_api import (
-    Browser,
     ElementHandle,
     Page,
     Playwright,
@@ -39,20 +38,6 @@ from narada.window import LocalBrowserWindow, create_side_panel_url
 class _LaunchBrowserResult:
     browser_window_id: str
     side_panel_page: Page
-
-
-class _ShouldRetryCreateProcess(Exception):
-    browser: Browser
-    browser_process: asyncio.subprocess.Process | subprocess.Popen[bytes]
-
-    def __init__(
-        self,
-        browser: Browser,
-        browser_process: asyncio.subprocess.Process | subprocess.Popen[bytes],
-    ) -> None:
-        super().__init__()
-        self.browser = browser
-        self.browser_process = browser_process
 
 
 class Narada:
@@ -92,37 +77,11 @@ class Narada:
 
         config = config or BrowserConfig()
 
-        launch_browser_result = None
-        while launch_browser_result is None:
-            try:
-                launch_browser_result = await self._launch_browser(playwright, config)
-            except _ShouldRetryCreateProcess as e:
-                if config.interactive:
-                    self._console.input(
-                        "\n> [bold blue]New extension installation detected. Press Enter to "
-                        "relaunch the browser and continue.[/bold blue]"
-                    )
-
-                # Close the CDP connection to the browser.
-                await e.browser.close()
-
-                # Gracefully terminate the browser process.
-                e.browser_process.terminate()
-                if isinstance(e.browser_process, asyncio.subprocess.Process):
-                    await e.browser_process.wait()
-                else:
-                    await asyncio.get_running_loop().run_in_executor(
-                        None, e.browser_process.wait
-                    )
-
+        launch_browser_result = await self._launch_browser(playwright, config)
         side_panel_page = launch_browser_result.side_panel_page
         browser_window_id = launch_browser_result.browser_window_id
 
-        # Revert the download behavior to the default behavior for the extension, otherwise our
-        # extension cannot download files.
-        cdp_session = await side_panel_page.context.new_cdp_session(side_panel_page)
-        await cdp_session.send("Page.setDownloadBehavior", {"behavior": "default"})
-        await cdp_session.detach()
+        await self._fix_download_behavior(side_panel_page)
 
         return LocalBrowserWindow(
             api_key=self._api_key,
@@ -156,21 +115,13 @@ class Narada:
         initialization_page = await context.new_page()
         await initialization_page.goto(tagged_initialization_url)
 
-        # Wait for the browser window ID to be available, potentially letting the user respond to
-        # recoverable errors interactively.
-        if config.interactive:
-            browser_window_id = await self._wait_for_browser_window_id_interactively(
-                initialization_page
-            )
-        else:
-            browser_window_id = await Narada._wait_for_browser_window_id(
-                initialization_page,
-            )
+        browser_window_id = await self._wait_for_browser_window_id(
+            initialization_page, config
+        )
 
         # Playwright seems unable to pick up the side panel page that is automatically opened by the
-        # initialization page when attaching to an existing browser window. We need to establish a
-        # new CDP connection to the browser *after* the side panel page is opened for Playwright to
-        # see it.
+        # initialization page. We need to establish a new CDP connection to the browser *after* the
+        # side panel page is opened for Playwright to see it.
         await browser.close()
         browser = await playwright.chromium.connect_over_cdp(config.cdp_url)
         context = browser.contexts[0]
@@ -178,17 +129,10 @@ class Narada:
         side_panel_url = create_side_panel_url(config, browser_window_id)
         side_panel_page = next(p for p in context.pages if p.url == side_panel_url)
 
-        # Revert the download behavior to the default behavior for the extension, otherwise our
-        # extension cannot download files.
-        cdp_session = await side_panel_page.context.new_cdp_session(side_panel_page)
-        await cdp_session.send("Page.setDownloadBehavior", {"behavior": "default"})
-        await cdp_session.detach()
+        await self._fix_download_behavior(side_panel_page)
 
         if config.interactive:
-            self._console.print(
-                "\n[bold]>[/bold] [bold green]Initialization successful. Browser window ID: "
-                f"{browser_window_id}[/bold green]\n",
-            )
+            self._print_success_message(browser_window_id)
 
         return LocalBrowserWindow(
             api_key=self._api_key,
@@ -243,10 +187,10 @@ class Narada:
 
         # We need to wait a bit for the initial page to open before connecting to the browser over
         # CDP, otherwise Playwright can see an empty context with no pages.
-        await asyncio.sleep(1)
+        await asyncio.sleep(2)
 
-        context = None
-        initialization_page = None
+        browser_window_id = None
+        side_panel_page = None
         max_cdp_connect_attempts = 10
         for attempt in range(max_cdp_connect_attempts):
             try:
@@ -256,7 +200,7 @@ class Narada:
                 # Retry a few times before giving up.
                 if attempt == max_cdp_connect_attempts - 1:
                     raise
-                await asyncio.sleep(3)
+                await asyncio.sleep(2)
                 continue
 
             # Grab the browser window ID from the page we just opened.
@@ -265,7 +209,16 @@ class Narada:
                 (p for p in context.pages if p.url == tagged_initialization_url), None
             )
             if initialization_page is not None:
-                break
+                browser_window_id = await self._wait_for_browser_window_id(
+                    initialization_page, config
+                )
+
+                side_panel_url = create_side_panel_url(config, browser_window_id)
+                side_panel_page = next(
+                    (p for p in context.pages if p.url == side_panel_url), None
+                )
+                if side_panel_page is not None:
+                    break
 
             if attempt == max_cdp_connect_attempts - 1:
                 raise NaradaTimeoutError("Timed out waiting for initialization page")
@@ -275,32 +228,11 @@ class Narada:
             await asyncio.sleep(3)
 
         # These are impossible as we would've raised an exception above otherwise.
-        assert context is not None
-        assert initialization_page is not None
-
-        # Wait for the browser window ID to be available, potentially letting the user respond to
-        # recoverable errors interactively.
-        if config.interactive:
-            browser_window_id = await self._wait_for_browser_window_id_interactively(
-                initialization_page
-            )
-        else:
-            browser_window_id = await Narada._wait_for_browser_window_id(
-                initialization_page,
-            )
-
-        side_panel_url = create_side_panel_url(config, browser_window_id)
-        side_panel_page = next(
-            (p for p in context.pages if p.url == side_panel_url), None
-        )
-        if side_panel_page is None:
-            raise _ShouldRetryCreateProcess(browser, browser_process)
+        assert browser_window_id is not None
+        assert side_panel_page is not None
 
         if config.interactive:
-            self._console.print(
-                "\n[bold]>[/bold] [bold green]Initialization successful. Browser window ID: "
-                f"{browser_window_id}[/bold green]\n",
-            )
+            self._print_success_message(browser_window_id)
 
         return _LaunchBrowserResult(
             browser_window_id=browser_window_id,
@@ -319,7 +251,9 @@ class Narada:
             return None
 
     @staticmethod
-    async def _wait_for_browser_window_id(page: Page, *, timeout: int = 15_000) -> str:
+    async def _wait_for_browser_window_id_silently(
+        page: Page, *, timeout: int = 15_000
+    ) -> str:
         selectors = [
             Narada._BROWSER_WINDOW_ID_SELECTOR,
             Narada._UNSUPPORTED_BROWSER_INDICATOR_SELECTOR,
@@ -392,7 +326,7 @@ class Narada:
         try:
             while True:
                 try:
-                    return await Narada._wait_for_browser_window_id(
+                    return await Narada._wait_for_browser_window_id_silently(
                         page, timeout=per_attempt_timeout
                     )
                 except NaradaExtensionMissingError:
@@ -419,3 +353,34 @@ class Narada:
                 "retry the action and keep the Narada web page open.[/bold red]",
             )
             sys.exit(1)
+
+    async def _wait_for_browser_window_id(
+        self,
+        initialization_page: Page,
+        config: BrowserConfig,
+    ) -> str:
+        """Waits for the browser window ID to be available, potentially letting the user respond to
+        recoverable errors interactively.
+        """
+        if config.interactive:
+            return await self._wait_for_browser_window_id_interactively(
+                initialization_page
+            )
+        else:
+            return await Narada._wait_for_browser_window_id_silently(
+                initialization_page
+            )
+
+    async def _fix_download_behavior(self, side_panel_page: Page) -> None:
+        """Reverts the download behavior to the default behavior for the extension, otherwise our
+        extension cannot download files.
+        """
+        cdp_session = await side_panel_page.context.new_cdp_session(side_panel_page)
+        await cdp_session.send("Page.setDownloadBehavior", {"behavior": "default"})
+        await cdp_session.detach()
+
+    def _print_success_message(self, browser_window_id: str) -> None:
+        self._console.print(
+            "\n[bold]>[/bold] [bold green]Initialization successful. Browser window ID: "
+            f"{browser_window_id}[/bold green]\n",
+        )

--- a/packages/narada/src/narada/config.py
+++ b/packages/narada/src/narada/config.py
@@ -27,7 +27,12 @@ class BrowserConfig:
     executable_path: str = field(default_factory=_default_executable_path)
     user_data_dir: str = field(default_factory=_default_user_data_dir)
     profile_directory: str = "Default"
+    cdp_host: str = "http://localhost"
     cdp_port: int = 9222
     initialization_url: str = "https://app.narada.ai/initialize"
     extension_id: str = "bhioaidlggjdkheaajakomifblpjmokn"
     interactive: bool = True
+
+    @property
+    def cdp_url(self) -> str:
+        return f"{self.cdp_host}:{self.cdp_port}"

--- a/uv.lock
+++ b/uv.lock
@@ -309,7 +309,7 @@ wheels = [
 
 [[package]]
 name = "narada"
-version = "0.1.18"
+version = "0.1.19"
 source = { editable = "packages/narada" }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
- Support attaching to existing browser window.
- Eliminate the need to relaunch the browser after the user first installs the extension.

Added test/example in `examples/existing_browser.py`.