### PR TITLE
Properly inject Pyodide globals for passing in parent run IDs

### DIFF
--- a/packages/narada-pyodide/pyproject.toml
+++ b/packages/narada-pyodide/pyproject.toml
@@ -1,7 +1,7 @@
 
 [project]
 name = "narada-pyodide"
-version = "0.0.22"
+version = "0.0.23"
 description = "Pyodide-compatible Python client SDK for Narada"
 license = "Apache-2.0"
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -351,7 +351,7 @@ requires-dist = [{ name = "pydantic", specifier = "==2.10.6" }]
 
 [[package]]
 name = "narada-pyodide"
-version = "0.0.22"
+version = "0.0.23"
 source = { editable = "packages/narada-pyodide" }
 dependencies = [
     { name = "narada-core" },


### PR DESCRIPTION
It turned out the globals set via `pyodide.globals.set()` is not accessible with the `globals()` Python helper at import time.