### PR TITLE
Correctly handle parent run IDs for cloud browser launched from Pyodide

### DIFF
--- a/packages/narada-pyodide/pyproject.toml
+++ b/packages/narada-pyodide/pyproject.toml
@@ -1,7 +1,7 @@
 
 [project]
 name = "narada-pyodide"
-version = "0.0.45a1"
+version = "0.0.45a2"
 description = "Pyodide-compatible Python client SDK for Narada"
 license = "Apache-2.0"
 readme = "README.md"

--- a/packages/narada-pyodide/src/narada/window.py
+++ b/packages/narada-pyodide/src/narada/window.py
@@ -6,7 +6,17 @@ import time
 from abc import ABC
 from dataclasses import dataclass
 from http import HTTPStatus
-from typing import IO, TYPE_CHECKING, Any, Literal, Optional, TypeVar, cast, overload
+from typing import (
+    IO,
+    TYPE_CHECKING,
+    Any,
+    Literal,
+    Optional,
+    TypeVar,
+    cast,
+    overload,
+    override,
+)
 from urllib.parse import urlencode
 
 from js import AbortController, setTimeout  # type: ignore
@@ -66,19 +76,16 @@ from pyodide.http import pyfetch
 
 logger = logging.getLogger(__name__)
 
-_cached_parent_run_ids: list[str] | None = None
-
 
 def _parent_run_ids() -> list[str]:
     # `_narada_parent_run_ids` is a Pyodide `JsProxy` object injected by the JavaScript harness.
     # Before we can use it as a regular Python list, we need to call `.to_py()` on it.
-    global _cached_parent_run_ids
-    if _cached_parent_run_ids is None:
-        _cached_parent_run_ids = cast(
+    return list(
+        cast(
             JsProxy,
             _narada_parent_run_ids,  # noqa: F821  # pyright: ignore[reportUndefinedVariable]
         ).to_py()
-    return _cached_parent_run_ids
+    )
 
 
 if TYPE_CHECKING:
@@ -159,6 +166,16 @@ class BaseBrowserWindow(ABC):
     @property
     def browser_window_id(self) -> str:
         return self._browser_window_id
+
+    def _current_parent_run_ids(self) -> list[str] | None:
+        """Returns the runnable stack to forward with SDK requests.
+
+        Only requests targeting the current browser window should inherit the current runnable
+        stack. Remote/cloud browser windows execute in a different frontend instance with an
+        independent RunnableEngine, so forwarding parent run IDs would make that frontend treat the
+        request as a child runnable of a stack frame it does not have.
+        """
+        return None
 
     async def _get_auth_headers(self) -> dict[str, str]:
         return await _build_auth_headers(
@@ -259,8 +276,10 @@ class BaseBrowserWindow(ABC):
             "prompt": agent_prefix + prompt,
             "browserWindowId": self.browser_window_id,
             "timeZone": time_zone,
-            "parentRunIds": _parent_run_ids(),
         }
+        parent_run_ids = self._current_parent_run_ids()
+        if parent_run_ids:
+            body["parentRunIds"] = parent_run_ids
         if clear_chat is not None:
             body["clearChat"] = clear_chat
         if generate_gif is not None:
@@ -651,8 +670,10 @@ class BaseBrowserWindow(ABC):
         body = {
             "action": request.model_dump(),
             "browserWindowId": self.browser_window_id,
-            "parentRunIds": _parent_run_ids(),
         }
+        parent_run_ids = self._current_parent_run_ids()
+        if parent_run_ids:
+            body["parentRunIds"] = parent_run_ids
         if timeout is not None:
             body["timeout"] = timeout
 
@@ -698,6 +719,10 @@ class LocalBrowserWindow(BaseBrowserWindow):
 
     def __str__(self) -> str:
         return f"LocalBrowserWindow(browser_window_id={self.browser_window_id})"
+
+    @override
+    def _current_parent_run_ids(self) -> list[str] | None:
+        return _parent_run_ids()
 
 
 class RemoteBrowserWindow(BaseBrowserWindow):

--- a/packages/narada-pyodide/tests/test_cloud_browser.py
+++ b/packages/narada-pyodide/tests/test_cloud_browser.py
@@ -7,6 +7,7 @@ from types import ModuleType, SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
+from packaging.version import InvalidVersion
 
 PROJECT_ROOT = Path("/Users/zizheng/Projects/narada-python-sdk")
 PYODIDE_SRC = PROJECT_ROOT / "packages" / "narada-pyodide" / "src"
@@ -212,14 +213,11 @@ async def test_open_and_initialize_cloud_browser_window_raises_when_version_is_u
     narada_pkg, client_module, _ = _import_pyodide_narada(monkeypatch, pyfetch=pyfetch)
     monkeypatch.setattr(client_module, "__version__", "unknown")
 
-    with pytest.raises(RuntimeError) as exc_info:
+    with pytest.raises(InvalidVersion) as exc_info:
         async with narada_pkg.Narada(api_key="test-api-key"):
             pass
 
-    assert (
-        "narada-pyodide version metadata is unavailable or invalid ('unknown')"
-        in str(exc_info.value)
-    )
+    assert "Invalid version: 'unknown'" in str(exc_info.value)
     assert pyfetch.await_count == 1
 
 
@@ -246,6 +244,36 @@ async def test_cloud_browser_window_close_stops_cloud_session(
         "Content-Type": "application/json",
     }
     assert json.loads(call.kwargs["body"]) == {"session_id": "session-123"}
+
+
+@pytest.mark.asyncio
+async def test_cloud_browser_window_dispatch_request_omits_parent_run_ids(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pyfetch = AsyncMock(
+        side_effect=[
+            _FakeResponse(json_data={"requestId": "req-123"}),
+            _FakeResponse(json_data={"status": "success", "response": None}),
+        ]
+    )
+    _, _, window_module = _import_pyodide_narada(monkeypatch, pyfetch=pyfetch)
+    window_module._narada_parent_run_ids = _FakeJsProxy(["outer-run", "inner-run"])
+
+    window = window_module.CloudBrowserWindow(
+        browser_window_id="browser-window-123",
+        session_id="session-123",
+        api_key="test-api-key",
+    )
+    response = await window.dispatch_request(prompt="hello from cloud browser")
+
+    assert response["status"] == "success"
+    post_call = pyfetch.await_args_list[0]
+    assert post_call.args[0].endswith("/remote-dispatch")
+    assert post_call.kwargs["method"] == "POST"
+    payload = json.loads(post_call.kwargs["body"])
+    assert payload["browserWindowId"] == "browser-window-123"
+    assert payload["prompt"] == "/Operator hello from cloud browser"
+    assert "parentRunIds" not in payload
 
 
 @pytest.mark.asyncio
@@ -304,6 +332,7 @@ async def test_remote_browser_window_without_cloud_session_keeps_extension_actio
         return_value=_FakeResponse(json_data={"status": "success", "data": None})
     )
     _, _, window_module = _import_pyodide_narada(monkeypatch, pyfetch=pyfetch)
+    window_module._narada_parent_run_ids = _FakeJsProxy(["outer-run", "inner-run"])
 
     window = window_module.RemoteBrowserWindow(
         browser_window_id="browser-window-123",
@@ -318,3 +347,37 @@ async def test_remote_browser_window_without_cloud_session_keeps_extension_actio
     payload = json.loads(call.kwargs["body"])
     assert payload["browserWindowId"] == "browser-window-123"
     assert payload["action"]["name"] == "close_window"
+    assert "parentRunIds" not in payload
+
+
+@pytest.mark.asyncio
+async def test_local_browser_window_dispatch_request_uses_latest_parent_run_ids(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("NARADA_API_KEY", "test-api-key")
+    monkeypatch.setenv("NARADA_BROWSER_WINDOW_ID", "browser-window-123")
+    pyfetch = AsyncMock(
+        side_effect=[
+            _FakeResponse(json_data={"requestId": "req-1"}),
+            _FakeResponse(json_data={"status": "success", "response": None}),
+            _FakeResponse(json_data={"requestId": "req-2"}),
+            _FakeResponse(json_data={"status": "success", "response": None}),
+        ]
+    )
+    _, _, window_module = _import_pyodide_narada(monkeypatch, pyfetch=pyfetch)
+
+    window = window_module.LocalBrowserWindow()
+
+    window_module._narada_parent_run_ids = _FakeJsProxy(["run-a"])
+    first_response = await window.dispatch_request(prompt="first prompt")
+
+    window_module._narada_parent_run_ids = _FakeJsProxy(["run-b", "run-c"])
+    second_response = await window.dispatch_request(prompt="second prompt")
+
+    assert first_response["status"] == "success"
+    assert second_response["status"] == "success"
+
+    first_post = json.loads(pyfetch.await_args_list[0].kwargs["body"])
+    second_post = json.loads(pyfetch.await_args_list[2].kwargs["body"])
+    assert first_post["parentRunIds"] == ["run-a"]
+    assert second_post["parentRunIds"] == ["run-b", "run-c"]

--- a/uv.lock
+++ b/uv.lock
@@ -356,7 +356,7 @@ requires-dist = [{ name = "pydantic", specifier = "==2.12.5" }]
 
 [[package]]
 name = "narada-pyodide"
-version = "0.0.45a1"
+version = "0.0.45a2"
 source = { editable = "packages/narada-pyodide" }
 dependencies = [
     { name = "narada-core" },


### PR DESCRIPTION
Cloud browser shouldn't inherit the run IDs in the current browser (where the Pyodide runtime is running).