### PR TITLE
Add Excel sheet SDK actions

### DIFF
--- a/examples/excel_sheets.py
+++ b/examples/excel_sheets.py
@@ -1,0 +1,31 @@
+import asyncio
+
+from narada import Narada
+
+
+async def main() -> None:
+    async with Narada() as narada:
+        window = await narada.open_and_initialize_browser_window()
+
+        # To read from an Excel workbook, connect the Microsoft account that has access
+        # to the workbook and use the workbook URL from Excel Online.
+        resp = await window.read_excel_sheet(
+            workbook_url="https://contoso.sharepoint.com/:x:/r/sites/Team/Shared%20Documents/Workbook.xlsx",
+            range="Sheet1!A1:D10",
+            microsoft_account_email="person@example.com",
+        )
+        print(resp.values)
+
+        # To write to an Excel workbook, you need to have write permission to the workbook.
+        # You can copy the workbook URL from Excel Online.
+        #
+        # await window.write_excel_sheet(
+        #     workbook_url="WORKBOOK_URL",
+        #     range="Sheet1!A11:D12",
+        #     microsoft_account_email="person@example.com",
+        #     values=[["hello", "world", "foo", "bar"], ["1", "2", "3", "4"]],
+        # )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/packages/narada-core/src/narada_core/actions/models.py
+++ b/packages/narada-core/src/narada_core/actions/models.py
@@ -104,8 +104,20 @@ class ReadGoogleSheetTrace(BaseModel):
     description: str
 
 
+class ReadExcelSheetTrace(BaseModel):
+    step_type: Literal["readExcelSheet"]
+    url: str
+    description: str
+
+
 class WriteGoogleSheetTrace(BaseModel):
     step_type: Literal["writeGoogleSheet"]
+    url: str
+    description: str
+
+
+class WriteExcelSheetTrace(BaseModel):
+    step_type: Literal["writeExcelSheet"]
     url: str
     description: str
 
@@ -227,7 +239,9 @@ ApaStepTrace = Annotated[
     | PressKeysTrace
     | ReadCsvTrace
     | ReadGoogleSheetTrace
+    | ReadExcelSheetTrace
     | WriteGoogleSheetTrace
+    | WriteExcelSheetTrace
     | DataTableExportAsCsvTrace
     | ObjectExportAsJsonTrace
     | PythonTrace
@@ -536,10 +550,29 @@ class ReadGoogleSheetResponse(BaseModel):
     values: list[list[str]]
 
 
+class ReadExcelSheetRequest(BaseModel):
+    name: Literal["read_excel_sheet"] = "read_excel_sheet"
+    workbook_url: str
+    range: str
+    microsoft_account_email: str
+
+
+class ReadExcelSheetResponse(BaseModel):
+    values: list[list[str]]
+
+
 class WriteGoogleSheetRequest(BaseModel):
     name: Literal["write_google_sheet"] = "write_google_sheet"
     spreadsheet_id: str
     range: str
+    values: list[list[str]]
+
+
+class WriteExcelSheetRequest(BaseModel):
+    name: Literal["write_excel_sheet"] = "write_excel_sheet"
+    workbook_url: str
+    range: str
+    microsoft_account_email: str
     values: list[list[str]]
 
 
@@ -614,7 +647,9 @@ type ExtensionActionRequest = (
     | GoToUrlRequest
     | PrintMessageRequest
     | ReadGoogleSheetRequest
+    | ReadExcelSheetRequest
     | WriteGoogleSheetRequest
+    | WriteExcelSheetRequest
     | GetFullHtmlRequest
     | GetSimplifiedHtmlRequest
     | GetScreenshotRequest

--- a/packages/narada-core/src/narada_core/models.py
+++ b/packages/narada-core/src/narada_core/models.py
@@ -152,8 +152,20 @@ class ReadGoogleSheetTrace(TypedDict):
     description: str
 
 
+class ReadExcelSheetTrace(TypedDict):
+    step_type: Literal["readExcelSheet"]
+    url: str
+    description: str
+
+
 class WriteGoogleSheetTrace(TypedDict):
     step_type: Literal["writeGoogleSheet"]
+    url: str
+    description: str
+
+
+class WriteExcelSheetTrace(TypedDict):
+    step_type: Literal["writeExcelSheet"]
     url: str
     description: str
 
@@ -275,7 +287,9 @@ ApaStepTrace = (
     | PressKeysTrace
     | ReadCsvTrace
     | ReadGoogleSheetTrace
+    | ReadExcelSheetTrace
     | WriteGoogleSheetTrace
+    | WriteExcelSheetTrace
     | DataTableExportAsCsvTrace
     | ObjectExportAsJsonTrace
     | PythonTrace

--- a/packages/narada-pyodide/src/narada/window.py
+++ b/packages/narada-pyodide/src/narada/window.py
@@ -45,11 +45,14 @@ from narada_core.actions.models import (
     PromptForUserInputRequest,
     PromptForUserInputResponse,
     PromptForUserInputVariable,
+    ReadExcelSheetRequest,
+    ReadExcelSheetResponse,
     ReadGoogleSheetRequest,
     ReadGoogleSheetResponse,
     RecordedClick,
     UserApprovalRequest,
     UserApprovalResponse,
+    WriteExcelSheetRequest,
     WriteGoogleSheetRequest,
     parse_action_trace,
 )
@@ -596,6 +599,25 @@ class BaseBrowserWindow(ABC):
             timeout=timeout,
         )
 
+    async def read_excel_sheet(
+        self,
+        *,
+        workbook_url: str,
+        range: str,
+        microsoft_account_email: str,
+        timeout: int | None = None,
+    ) -> ReadExcelSheetResponse:
+        """Reads a range of cells from a Microsoft Excel workbook."""
+        return await self._run_extension_action(
+            ReadExcelSheetRequest(
+                workbook_url=workbook_url,
+                range=range,
+                microsoft_account_email=microsoft_account_email,
+            ),
+            ReadExcelSheetResponse,
+            timeout=timeout,
+        )
+
     async def write_google_sheet(
         self,
         *,
@@ -608,6 +630,26 @@ class BaseBrowserWindow(ABC):
         return await self._run_extension_action(
             WriteGoogleSheetRequest(
                 spreadsheet_id=spreadsheet_id, range=range, values=values
+            ),
+            timeout=timeout,
+        )
+
+    async def write_excel_sheet(
+        self,
+        *,
+        workbook_url: str,
+        range: str,
+        microsoft_account_email: str,
+        values: list[list[str]],
+        timeout: int | None = None,
+    ) -> None:
+        """Writes a range of cells to a Microsoft Excel workbook."""
+        return await self._run_extension_action(
+            WriteExcelSheetRequest(
+                workbook_url=workbook_url,
+                range=range,
+                microsoft_account_email=microsoft_account_email,
+                values=values,
             ),
             timeout=timeout,
         )

--- a/packages/narada/src/narada/window.py
+++ b/packages/narada/src/narada/window.py
@@ -35,11 +35,14 @@ from narada_core.actions.models import (
     PromptForUserInputRequest,
     PromptForUserInputResponse,
     PromptForUserInputVariable,
+    ReadExcelSheetRequest,
+    ReadExcelSheetResponse,
     ReadGoogleSheetRequest,
     ReadGoogleSheetResponse,
     RecordedClick,
     UserApprovalRequest,
     UserApprovalResponse,
+    WriteExcelSheetRequest,
     WriteGoogleSheetRequest,
     parse_action_trace,
 )
@@ -597,6 +600,25 @@ class BaseBrowserWindow(ABC):
             timeout=timeout,
         )
 
+    async def read_excel_sheet(
+        self,
+        *,
+        workbook_url: str,
+        range: str,
+        microsoft_account_email: str,
+        timeout: int | None = None,
+    ) -> ReadExcelSheetResponse:
+        """Reads a range of cells from a Microsoft Excel workbook."""
+        return await self._run_extension_action(
+            ReadExcelSheetRequest(
+                workbook_url=workbook_url,
+                range=range,
+                microsoft_account_email=microsoft_account_email,
+            ),
+            ReadExcelSheetResponse,
+            timeout=timeout,
+        )
+
     async def write_google_sheet(
         self,
         *,
@@ -609,6 +631,26 @@ class BaseBrowserWindow(ABC):
         return await self._run_extension_action(
             WriteGoogleSheetRequest(
                 spreadsheet_id=spreadsheet_id, range=range, values=values
+            ),
+            timeout=timeout,
+        )
+
+    async def write_excel_sheet(
+        self,
+        *,
+        workbook_url: str,
+        range: str,
+        microsoft_account_email: str,
+        values: list[list[str]],
+        timeout: int | None = None,
+    ) -> None:
+        """Writes a range of cells to a Microsoft Excel workbook."""
+        return await self._run_extension_action(
+            WriteExcelSheetRequest(
+                workbook_url=workbook_url,
+                range=range,
+                microsoft_account_email=microsoft_account_email,
+                values=values,
             ),
             timeout=timeout,
         )


### PR DESCRIPTION
## Summary
- add Excel sheet extension action models and traces to narada-core
- add read_excel_sheet and write_excel_sheet helpers to narada and narada-pyodide windows
- add an Excel sheets example mirroring the Google Sheets example

## Tests
- .venv/bin/ruff check packages/narada-core/src/narada_core/actions/models.py packages/narada-core/src/narada_core/models.py packages/narada/src/narada/window.py packages/narada-pyodide/src/narada/window.py examples/excel_sheets.py
- .venv/bin/ruff format --check packages/narada-core/src/narada_core/actions/models.py packages/narada-core/src/narada_core/models.py packages/narada/src/narada/window.py packages/narada-pyodide/src/narada/window.py examples/excel_sheets.py
- .venv/bin/python -m py_compile packages/narada-core/src/narada_core/actions/models.py packages/narada-core/src/narada_core/models.py packages/narada/src/narada/window.py packages/narada-pyodide/src/narada/window.py examples/excel_sheets.py
- PYTHONPATH=packages/narada-core/src:packages/narada/src .venv/bin/python - <<'PY'
from narada_core.actions.models import ReadExcelSheetRequest, WriteExcelSheetRequest
read = ReadExcelSheetRequest(workbook_url='u', range='Sheet1!A1', microsoft_account_email='person@example.com')
write = WriteExcelSheetRequest(workbook_url='u', range='Sheet1!A1', microsoft_account_email='person@example.com', values=[['a']])
assert read.model_dump()['name'] == 'read_excel_sheet'
assert write.model_dump()['name'] == 'write_excel_sheet'
print('ok')
PY