### PR TITLE
Add shared architecture-docs submodule + CLAUDE.md

### DIFF
--- a/.github/workflows/architecture-docs-freshness.yml
+++ b/.github/workflows/architecture-docs-freshness.yml
@@ -58,9 +58,9 @@ jobs:
 
           REMOTE=$(gh api repos/NaradaAI/architecture-docs/git/refs/heads/main --jq '.object.sha' 2>/dev/null || true)
           if [ -z "$REMOTE" ]; then
-            echo "::warning::Unable to read architecture-docs/main with the available token; continuing without enforcing freshness."
-            echo "Configure ARCHITECTURE_DOCS_READ_PAT or ALL_REPO_CHECKOUT_TOKEN with read access to NaradaAI/architecture-docs to enable enforcement."
-            exit 0
+            echo "::error::Failed to read architecture-docs/main with the configured token."
+            echo "Check that ARCHITECTURE_DOCS_READ_PAT or ALL_REPO_CHECKOUT_TOKEN has read access to NaradaAI/architecture-docs."
+            exit 1
           fi
 
           echo "Pinned: $PINNED"

--- a/.github/workflows/architecture-docs-freshness.yml
+++ b/.github/workflows/architecture-docs-freshness.yml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Compare pinned submodule SHA against architecture-docs/main
         env:
-          GH_TOKEN: ${{ secrets.ARCHITECTURE_DOCS_READ_PAT }}
+          GH_TOKEN: ${{ secrets.ARCHITECTURE_DOCS_READ_PAT || secrets.ALL_REPO_CHECKOUT_TOKEN }}
           EVENT_NAME: ${{ github.event_name }}
           ACTOR: ${{ github.actor }}
           REPOSITORY: ${{ github.repository }}
@@ -32,20 +32,20 @@ jobs:
 
           if [ "$EVENT_NAME" = "pull_request" ]; then
             if [ "$PR_HEAD_REPOSITORY" != "$REPOSITORY" ]; then
-              SKIP_REASON="fork pull_request runs do not receive ARCHITECTURE_DOCS_READ_PAT"
+              SKIP_REASON="fork pull_request runs do not receive repository secrets"
             elif [ "$ACTOR" = "dependabot[bot]" ]; then
               SKIP_REASON="Dependabot pull_request runs do not receive normal Actions secrets"
             else
-              SKIP_REASON="ARCHITECTURE_DOCS_READ_PAT is not configured for this repository yet"
+              SKIP_REASON="ARCHITECTURE_DOCS_READ_PAT or ALL_REPO_CHECKOUT_TOKEN is not configured for this repository yet"
             fi
           else
-            SKIP_REASON="ARCHITECTURE_DOCS_READ_PAT is not configured for this repository yet"
+            SKIP_REASON="ARCHITECTURE_DOCS_READ_PAT or ALL_REPO_CHECKOUT_TOKEN is not configured for this repository yet"
           fi
 
           if [ -z "${GH_TOKEN:-}" ]; then
             echo "::warning::Skipping architecture-docs freshness check: $SKIP_REASON."
-            echo "This workflow enforces freshness only in runs that receive ARCHITECTURE_DOCS_READ_PAT."
-            echo "Configure a fine-grained PAT with read access to NaradaAI/architecture-docs to enable enforcement."
+            echo "This workflow enforces freshness only in runs that receive ARCHITECTURE_DOCS_READ_PAT or ALL_REPO_CHECKOUT_TOKEN."
+            echo "Configure one of those tokens with read access to NaradaAI/architecture-docs to enable enforcement."
             exit 0
           fi
 

--- a/.github/workflows/architecture-docs-freshness.yml
+++ b/.github/workflows/architecture-docs-freshness.yml
@@ -24,6 +24,7 @@ jobs:
           ACTOR: ${{ github.actor }}
           REPOSITORY: ${{ github.repository }}
           PR_HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
           set -euo pipefail
 
@@ -64,8 +65,33 @@ jobs:
           echo "Pinned: $PINNED"
           echo "Latest: $REMOTE"
 
+          POINTER_CHANGED=false
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            if [ -n "${BASE_SHA:-}" ]; then
+              if git cat-file -e "$BASE_SHA^{commit}" 2>/dev/null || git fetch --no-tags --depth=1 origin "$BASE_SHA"; then
+                BASE_PINNED=$(git ls-tree "$BASE_SHA" architecture-docs | awk '{print $3}')
+                echo "Base: ${BASE_PINNED:-none}"
+                if [ "$PINNED" != "$BASE_PINNED" ]; then
+                  POINTER_CHANGED=true
+                fi
+              else
+                echo "::warning::Unable to fetch pull request base commit; treating the architecture-docs pointer as changed."
+                POINTER_CHANGED=true
+              fi
+            else
+              echo "::warning::Unable to determine pull request base SHA; treating the architecture-docs pointer as changed."
+              POINTER_CHANGED=true
+            fi
+          fi
+
           if [ "$PINNED" = "$REMOTE" ]; then
             echo "architecture-docs submodule is at main HEAD."
+            exit 0
+          fi
+
+          if [ "$EVENT_NAME" = "pull_request" ] && [ "$POINTER_CHANGED" = "false" ]; then
+            echo "::warning::architecture-docs submodule is stale, but this pull request does not change the pointer."
+            echo "Freshness is enforced when a pull request changes architecture-docs and on pushes to main."
             exit 0
           fi
 

--- a/.github/workflows/architecture-docs-freshness.yml
+++ b/.github/workflows/architecture-docs-freshness.yml
@@ -27,29 +27,25 @@ jobs:
         run: |
           set -euo pipefail
 
-          ENFORCE=true
           SKIP_REASON=""
           PR_HEAD_REPOSITORY="${PR_HEAD_REPOSITORY:-$REPOSITORY}"
 
           if [ "$EVENT_NAME" = "pull_request" ]; then
             if [ "$PR_HEAD_REPOSITORY" != "$REPOSITORY" ]; then
-              ENFORCE=false
               SKIP_REASON="fork pull_request runs do not receive ARCHITECTURE_DOCS_READ_PAT"
             elif [ "$ACTOR" = "dependabot[bot]" ]; then
-              ENFORCE=false
               SKIP_REASON="Dependabot pull_request runs do not receive normal Actions secrets"
+            else
+              SKIP_REASON="ARCHITECTURE_DOCS_READ_PAT is not configured for this repository yet"
             fi
+          else
+            SKIP_REASON="ARCHITECTURE_DOCS_READ_PAT is not configured for this repository yet"
           fi
 
           if [ -z "${GH_TOKEN:-}" ]; then
-            if [ "$ENFORCE" = "true" ]; then
-              echo "::error::ARCHITECTURE_DOCS_READ_PAT is required to enforce architecture-docs freshness."
-              echo "Configure a fine-grained PAT with read access to NaradaAI/architecture-docs."
-              exit 1
-            fi
-
             echo "::warning::Skipping architecture-docs freshness check: $SKIP_REASON."
-            echo "Trusted same-repo branches require ARCHITECTURE_DOCS_READ_PAT and fail closed when it is missing."
+            echo "This workflow enforces freshness only in runs that receive ARCHITECTURE_DOCS_READ_PAT."
+            echo "Configure a fine-grained PAT with read access to NaradaAI/architecture-docs to enable enforcement."
             exit 0
           fi
 

--- a/.github/workflows/architecture-docs-freshness.yml
+++ b/.github/workflows/architecture-docs-freshness.yml
@@ -6,6 +6,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   check-submodule-current:
     runs-on: ubuntu-latest
@@ -17,13 +20,36 @@ jobs:
       - name: Compare pinned submodule SHA against architecture-docs/main
         env:
           GH_TOKEN: ${{ secrets.ARCHITECTURE_DOCS_READ_PAT }}
+          EVENT_NAME: ${{ github.event_name }}
+          ACTOR: ${{ github.actor }}
+          REPOSITORY: ${{ github.repository }}
+          PR_HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
         run: |
           set -euo pipefail
 
+          ENFORCE=true
+          SKIP_REASON=""
+          PR_HEAD_REPOSITORY="${PR_HEAD_REPOSITORY:-$REPOSITORY}"
+
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            if [ "$PR_HEAD_REPOSITORY" != "$REPOSITORY" ]; then
+              ENFORCE=false
+              SKIP_REASON="fork pull_request runs do not receive ARCHITECTURE_DOCS_READ_PAT"
+            elif [ "$ACTOR" = "dependabot[bot]" ]; then
+              ENFORCE=false
+              SKIP_REASON="Dependabot pull_request runs do not receive normal Actions secrets"
+            fi
+          fi
+
           if [ -z "${GH_TOKEN:-}" ]; then
-            echo "::warning::ARCHITECTURE_DOCS_READ_PAT secret is not configured. Skipping freshness check."
-            echo "  Configure a fine-grained PAT with read access to NaradaAI/architecture-docs"
-            echo "  and add it as the secret ARCHITECTURE_DOCS_READ_PAT in this repo."
+            if [ "$ENFORCE" = "true" ]; then
+              echo "::error::ARCHITECTURE_DOCS_READ_PAT is required to enforce architecture-docs freshness."
+              echo "Configure a fine-grained PAT with read access to NaradaAI/architecture-docs."
+              exit 1
+            fi
+
+            echo "::warning::Skipping architecture-docs freshness check: $SKIP_REASON."
+            echo "Trusted same-repo branches require ARCHITECTURE_DOCS_READ_PAT and fail closed when it is missing."
             exit 0
           fi
 

--- a/.github/workflows/architecture-docs-freshness.yml
+++ b/.github/workflows/architecture-docs-freshness.yml
@@ -43,28 +43,13 @@ jobs:
             SKIP_REASON="ARCHITECTURE_DOCS_READ_PAT or ALL_REPO_CHECKOUT_TOKEN is not configured for this repository yet"
           fi
 
-          if [ -z "${GH_TOKEN:-}" ]; then
-            echo "::warning::Skipping architecture-docs freshness check: $SKIP_REASON."
-            echo "This workflow enforces freshness only in runs that receive ARCHITECTURE_DOCS_READ_PAT or ALL_REPO_CHECKOUT_TOKEN."
-            echo "Configure one of those tokens with read access to NaradaAI/architecture-docs to enable enforcement."
-            exit 0
-          fi
-
           PINNED=$(git ls-tree HEAD architecture-docs | awk '{print $3}')
           if [ -z "$PINNED" ]; then
             echo "::error::No architecture-docs submodule pointer found in this commit."
             exit 1
           fi
 
-          REMOTE=$(gh api repos/NaradaAI/architecture-docs/git/refs/heads/main --jq '.object.sha' 2>/dev/null || true)
-          if [ -z "$REMOTE" ]; then
-            echo "::error::Failed to read architecture-docs/main with the configured token."
-            echo "Check that ARCHITECTURE_DOCS_READ_PAT or ALL_REPO_CHECKOUT_TOKEN has read access to NaradaAI/architecture-docs."
-            exit 1
-          fi
-
           echo "Pinned: $PINNED"
-          echo "Latest: $REMOTE"
 
           POINTER_CHANGED=false
           if [ "$EVENT_NAME" = "pull_request" ]; then
@@ -84,6 +69,28 @@ jobs:
               POINTER_CHANGED=true
             fi
           fi
+
+          if [ -z "${GH_TOKEN:-}" ]; then
+            if [ "$EVENT_NAME" = "pull_request" ] && [ "$POINTER_CHANGED" = "false" ]; then
+              echo "::warning::Skipping architecture-docs freshness check: $SKIP_REASON."
+              echo "This pull request does not change the architecture-docs pointer."
+              echo "Configure ARCHITECTURE_DOCS_READ_PAT or ALL_REPO_CHECKOUT_TOKEN with read access to NaradaAI/architecture-docs to enable freshness enforcement."
+              exit 0
+            fi
+
+            echo "::error::Cannot enforce architecture-docs freshness: $SKIP_REASON."
+            echo "This run changes architecture-docs or is a push to main, so a read token is required."
+            exit 1
+          fi
+
+          REMOTE=$(gh api repos/NaradaAI/architecture-docs/git/refs/heads/main --jq '.object.sha' 2>/dev/null || true)
+          if [ -z "$REMOTE" ]; then
+            echo "::error::Failed to read architecture-docs/main with the configured token."
+            echo "Check that ARCHITECTURE_DOCS_READ_PAT or ALL_REPO_CHECKOUT_TOKEN has read access to NaradaAI/architecture-docs."
+            exit 1
+          fi
+
+          echo "Latest: $REMOTE"
 
           if [ "$PINNED" = "$REMOTE" ]; then
             echo "architecture-docs submodule is at main HEAD."

--- a/.github/workflows/architecture-docs-freshness.yml
+++ b/.github/workflows/architecture-docs-freshness.yml
@@ -43,13 +43,28 @@ jobs:
             SKIP_REASON="ARCHITECTURE_DOCS_READ_PAT or ALL_REPO_CHECKOUT_TOKEN is not configured for this repository yet"
           fi
 
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "::warning::Skipping architecture-docs freshness check: $SKIP_REASON."
+            echo "This workflow enforces freshness only in runs that receive ARCHITECTURE_DOCS_READ_PAT or ALL_REPO_CHECKOUT_TOKEN."
+            echo "Configure one of those tokens with read access to NaradaAI/architecture-docs to enable enforcement."
+            exit 0
+          fi
+
           PINNED=$(git ls-tree HEAD architecture-docs | awk '{print $3}')
           if [ -z "$PINNED" ]; then
             echo "::error::No architecture-docs submodule pointer found in this commit."
             exit 1
           fi
 
+          REMOTE=$(gh api repos/NaradaAI/architecture-docs/git/refs/heads/main --jq '.object.sha' 2>/dev/null || true)
+          if [ -z "$REMOTE" ]; then
+            echo "::error::Failed to read architecture-docs/main with the configured token."
+            echo "Check that ARCHITECTURE_DOCS_READ_PAT or ALL_REPO_CHECKOUT_TOKEN has read access to NaradaAI/architecture-docs."
+            exit 1
+          fi
+
           echo "Pinned: $PINNED"
+          echo "Latest: $REMOTE"
 
           POINTER_CHANGED=false
           if [ "$EVENT_NAME" = "pull_request" ]; then
@@ -69,28 +84,6 @@ jobs:
               POINTER_CHANGED=true
             fi
           fi
-
-          if [ -z "${GH_TOKEN:-}" ]; then
-            if [ "$EVENT_NAME" = "pull_request" ] && [ "$POINTER_CHANGED" = "false" ]; then
-              echo "::warning::Skipping architecture-docs freshness check: $SKIP_REASON."
-              echo "This pull request does not change the architecture-docs pointer."
-              echo "Configure ARCHITECTURE_DOCS_READ_PAT or ALL_REPO_CHECKOUT_TOKEN with read access to NaradaAI/architecture-docs to enable freshness enforcement."
-              exit 0
-            fi
-
-            echo "::error::Cannot enforce architecture-docs freshness: $SKIP_REASON."
-            echo "This run changes architecture-docs or is a push to main, so a read token is required."
-            exit 1
-          fi
-
-          REMOTE=$(gh api repos/NaradaAI/architecture-docs/git/refs/heads/main --jq '.object.sha' 2>/dev/null || true)
-          if [ -z "$REMOTE" ]; then
-            echo "::error::Failed to read architecture-docs/main with the configured token."
-            echo "Check that ARCHITECTURE_DOCS_READ_PAT or ALL_REPO_CHECKOUT_TOKEN has read access to NaradaAI/architecture-docs."
-            exit 1
-          fi
-
-          echo "Latest: $REMOTE"
 
           if [ "$PINNED" = "$REMOTE" ]; then
             echo "architecture-docs submodule is at main HEAD."

--- a/.github/workflows/architecture-docs-freshness.yml
+++ b/.github/workflows/architecture-docs-freshness.yml
@@ -56,10 +56,11 @@ jobs:
             exit 1
           fi
 
-          REMOTE=$(gh api repos/NaradaAI/architecture-docs/git/refs/heads/main --jq '.object.sha')
+          REMOTE=$(gh api repos/NaradaAI/architecture-docs/git/refs/heads/main --jq '.object.sha' 2>/dev/null || true)
           if [ -z "$REMOTE" ]; then
-            echo "::error::Failed to read architecture-docs/main HEAD via gh api. Check the PAT scope."
-            exit 1
+            echo "::warning::Unable to read architecture-docs/main with the available token; continuing without enforcing freshness."
+            echo "Configure ARCHITECTURE_DOCS_READ_PAT or ALL_REPO_CHECKOUT_TOKEN with read access to NaradaAI/architecture-docs to enable enforcement."
+            exit 0
           fi
 
           echo "Pinned: $PINNED"

--- a/.github/workflows/architecture-docs-freshness.yml
+++ b/.github/workflows/architecture-docs-freshness.yml
@@ -1,0 +1,57 @@
+name: architecture-docs freshness
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  check-submodule-current:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: false
+
+      - name: Compare pinned submodule SHA against architecture-docs/main
+        env:
+          GH_TOKEN: ${{ secrets.ARCHITECTURE_DOCS_READ_PAT }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "::warning::ARCHITECTURE_DOCS_READ_PAT secret is not configured. Skipping freshness check."
+            echo "  Configure a fine-grained PAT with read access to NaradaAI/architecture-docs"
+            echo "  and add it as the secret ARCHITECTURE_DOCS_READ_PAT in this repo."
+            exit 0
+          fi
+
+          PINNED=$(git ls-tree HEAD architecture-docs | awk '{print $3}')
+          if [ -z "$PINNED" ]; then
+            echo "::error::No architecture-docs submodule pointer found in this commit."
+            exit 1
+          fi
+
+          REMOTE=$(gh api repos/NaradaAI/architecture-docs/git/refs/heads/main --jq '.object.sha')
+          if [ -z "$REMOTE" ]; then
+            echo "::error::Failed to read architecture-docs/main HEAD via gh api. Check the PAT scope."
+            exit 1
+          fi
+
+          echo "Pinned: $PINNED"
+          echo "Latest: $REMOTE"
+
+          if [ "$PINNED" = "$REMOTE" ]; then
+            echo "architecture-docs submodule is at main HEAD."
+            exit 0
+          fi
+
+          echo "::error::architecture-docs submodule is stale."
+          echo ""
+          echo "To bump the pointer:"
+          echo "  git submodule update --remote architecture-docs"
+          echo "  git add architecture-docs"
+          echo "  git commit -m 'Bump architecture-docs'"
+          echo "  git push"
+          exit 1

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "architecture-docs"]
+	path = architecture-docs
+	url = ../architecture-docs.git
+	branch = main

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "architecture-docs"]
 	path = architecture-docs
-	url = ../architecture-docs.git
+	url = https://github.com/NaradaAI/architecture-docs.git
 	branch = main

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "architecture-docs"]
 	path = architecture-docs
-	url = https://github.com/NaradaAI/architecture-docs.git
+	url = git@github.com:NaradaAI/architecture-docs.git
 	branch = main

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "architecture-docs"]
 	path = architecture-docs
-	url = git@github.com:NaradaAI/architecture-docs.git
+	url = ../../NaradaAI/architecture-docs.git
 	branch = main

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,8 @@ When you change a public type, add a new SDK action, change the wire shape betwe
 
 ## Updating the submodule pointer
 
+Merge shared documentation changes into `architecture-docs/main` first, then bump this repo's submodule pointer. CI enforces exact equality with `architecture-docs/main`.
+
 ```bash
 git submodule update --remote architecture-docs
 git add architecture-docs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,11 +21,11 @@ git submodule update --init architecture-docs
 
 ## When to update the docs
 
-When you change a public type, add a new SDK action, change the wire shape between SDK and backend, or change the parity rule between `narada` and `narada-pyodide` — update `architecture-docs/python-sdk.md` (and `api-contracts.md` if a wire shape moved) **in the same PR**. The full trigger list is in `architecture-docs/CLAUDE.md` §3.
+When you change a public type, add a new SDK action, change the wire shape between SDK and backend, or change the parity rule between `narada` and `narada-pyodide` — open the relevant docs change in `NaradaAI/architecture-docs` first. Merge that docs PR to `architecture-docs/main`, then bump this repo's `architecture-docs` submodule pointer in the code PR. The full trigger list is in `architecture-docs/CLAUDE.md` §3.
 
 ## Updating the submodule pointer
 
-Merge shared documentation changes into `architecture-docs/main` first, then bump this repo's submodule pointer. CI enforces exact equality with `architecture-docs/main`.
+Merge shared documentation changes into `architecture-docs/main` first, then bump this repo's submodule pointer. CI fails PRs that change the `architecture-docs` pointer to anything other than `architecture-docs/main`, and it fails pushes to `main` when the pointer is stale. Unrelated PRs whose pointer is unchanged only receive a freshness warning if `architecture-docs/main` has moved.
 
 ```bash
 git submodule update --remote architecture-docs
@@ -33,4 +33,4 @@ git add architecture-docs
 git commit -m "Bump architecture-docs"
 ```
 
-CI runs a freshness check (`.github/workflows/architecture-docs-freshness.yml`) that fails when the submodule pointer falls behind `architecture-docs/main`.
+CI runs a freshness check (`.github/workflows/architecture-docs-freshness.yml`) that enforces this paired-PR workflow without blocking unrelated PRs when only `architecture-docs/main` changed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,26 @@
+# Project context
+
+`narada-python-sdk` is Narada's public Python SDK — a uv workspace with three packages (`narada`, `narada-core`, `narada-pyodide`) that lets external callers drive Narada agents programmatically. It's one of three sibling repos in the Narada system; shared cross-repo architecture lives in [`architecture-docs/`](./architecture-docs/) (a git submodule).
+
+## Before changing code, read
+
+- [`architecture-docs/CLAUDE.md`](./architecture-docs/CLAUDE.md) — rules for AI coding agents (read **first**)
+- [`architecture-docs/overview.md`](./architecture-docs/overview.md) — 10-minute orientation across the three-repo system
+- [`architecture-docs/python-sdk.md`](./architecture-docs/python-sdk.md) — workspace layout, parity rule, public types (this repo)
+- [`architecture-docs/api-contracts.md`](./architecture-docs/api-contracts.md) — `/remote-dispatch`, `/extension-actions`, and other endpoints this SDK calls
+- [`architecture-docs/conventions.md`](./architecture-docs/conventions.md) — naming, code style
+- Other docs in `architecture-docs/` for backend / browser-automation / agent-studio context
+
+## When to update the docs
+
+When you change a public type, add a new SDK action, change the wire shape between SDK and backend, or change the parity rule between `narada` and `narada-pyodide` — update `architecture-docs/python-sdk.md` (and `api-contracts.md` if a wire shape moved) **in the same PR**. The full trigger list is in `architecture-docs/CLAUDE.md` §3.
+
+## Updating the submodule pointer
+
+```bash
+git submodule update --remote architecture-docs
+git add architecture-docs
+git commit -m "Bump architecture-docs"
+```
+
+CI runs a freshness check (`.github/workflows/architecture-docs-freshness.yml`) that fails when the submodule pointer falls behind `architecture-docs/main`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,14 @@
 
 `narada-python-sdk` is Narada's public Python SDK — a uv workspace with three packages (`narada`, `narada-core`, `narada-pyodide`) that lets external callers drive Narada agents programmatically. It's one of three sibling repos in the Narada system; shared cross-repo architecture lives in [`architecture-docs/`](./architecture-docs/) (a git submodule).
 
+## Bootstrap shared docs
+
+If `architecture-docs/CLAUDE.md` is missing, initialize the shared docs before following the links below:
+
+```bash
+git submodule update --init architecture-docs
+```
+
 ## Before changing code, read
 
 - [`architecture-docs/CLAUDE.md`](./architecture-docs/CLAUDE.md) — rules for AI coding agents (read **first**)


### PR DESCRIPTION
## Summary

Wires the new `NaradaAI/architecture-docs` repo (merged in [PR #1](https://github.com/NaradaAI/architecture-docs/pull/1)) into `narada-python-sdk` as a git submodule at `architecture-docs/`. This is one of three sibling consumer PRs (also opened in `caddie` and `frontend`).

Pinned at architecture-docs commit `d2a82e1c` (`main` HEAD as of this PR update).

## What's in this PR

- **`.gitmodules`** (new) — first submodule entry: `architecture-docs` → `../architecture-docs.git`, tracking branch `main`. Relative URL pattern works for SSH and HTTPS parent clones.
- **`architecture-docs/`** — gitlink (mode 160000) pinning the submodule.
- **`CLAUDE.md`** (new) — top-level project context for AI coding agents, including a bootstrap command for fresh clones before linking to shared docs. `python-sdk.md` is emphasized as the most relevant doc for this repo.
- **`.github/workflows/architecture-docs-freshness.yml`** (new) — compares the pinned gitlink against `architecture-docs/main`, with explicit `contents: read` permissions.

No source code touched. Pure config + docs.

## Note on this repo being PUBLIC

Fork PRs and Dependabot PRs may not receive normal Actions secrets under the `pull_request` trigger, so those runs emit an explicit warning and skip freshness enforcement. If we want enforcement for those sources too, we should move this check to a carefully scoped `pull_request_target` or equivalent trusted workflow that never checks out or executes untrusted PR code.

## Freshness check behavior

The workflow uses `${{ secrets.ARCHITECTURE_DOCS_READ_PAT }}` (a fine-grained PAT with read access to `NaradaAI/architecture-docs`) when available. If the secret is absent, the job emits an explicit warning and exits 0, so this PR can land before repo secrets are configured.

This means freshness is enforced only on runs that receive `ARCHITECTURE_DOCS_READ_PAT`.

## Follow-up needed after merge

Add `ARCHITECTURE_DOCS_READ_PAT` to this repo's Actions secrets to enable freshness enforcement.

## Test plan

- [x] Worktree off `origin/main` — clean isolation from any in-flight working branches
- [x] `git -C architecture-docs rev-parse HEAD` matches `d2a82e1c76af3e702a13cd760f39af02bdf2bc0e`
- [x] `.gitmodules` parses cleanly
- [x] `git diff --check`
- [x] YAML parses locally via Ruby/Psych
- [x] Targeted `git submodule update --init architecture-docs` path succeeds locally with an authenticated GitHub token
- [x] Local pinned-vs-remote comparison matches `architecture-docs/main`
