### PR TITLE
Pass cloud browser session ID through subagents

### DIFF
--- a/packages/narada-pyodide/src/narada/window.py
+++ b/packages/narada-pyodide/src/narada/window.py
@@ -176,6 +176,17 @@ class BaseBrowserWindow(ABC):
     def browser_window_id(self) -> str:
         return self._browser_window_id
 
+    @property
+    def cloud_browser_session_id(self) -> str | None:
+        """Cloud browser session backing this window, if any.
+
+        `dispatch_request` includes this value in remote-dispatch requests so backend
+        observability can link a client-mode run to an existing SDK-owned cloud browser. Plain
+        local windows are not cloud-backed and return `None`; cloud-backed subclasses override this
+        property with their session ID.
+        """
+        return None
+
     def _current_parent_run_ids(self) -> list[str] | None:
         """Returns the runnable stack to forward with SDK requests.
 
@@ -358,6 +369,9 @@ class BaseBrowserWindow(ABC):
         parent_run_ids = self._current_parent_run_ids()
         if parent_run_ids:
             body["parentRunIds"] = parent_run_ids
+        cloud_browser_session_id = self.cloud_browser_session_id
+        if cloud_browser_session_id is not None:
+            body["cloudBrowserSessionId"] = cloud_browser_session_id
         if clear_chat is not None:
             body["clearChat"] = clear_chat
         if generate_gif is not None:

--- a/packages/narada-pyodide/tests/test_cloud_browser.py
+++ b/packages/narada-pyodide/tests/test_cloud_browser.py
@@ -272,6 +272,7 @@ async def test_cloud_browser_window_dispatch_request_omits_parent_run_ids(
     assert post_call.kwargs["method"] == "POST"
     payload = json.loads(post_call.kwargs["body"])
     assert payload["browserWindowId"] == "browser-window-123"
+    assert payload["cloudBrowserSessionId"] == "session-123"
     assert payload["prompt"] == "/Operator hello from cloud browser"
     assert "parentRunIds" not in payload
 

--- a/packages/narada/src/narada/window.py
+++ b/packages/narada/src/narada/window.py
@@ -148,6 +148,17 @@ class BaseBrowserWindow(ABC):
     def browser_window_id(self) -> str:
         return self._browser_window_id
 
+    @property
+    def cloud_browser_session_id(self) -> str | None:
+        """Cloud browser session backing this window, if any.
+
+        `dispatch_request` includes this value in remote-dispatch requests so backend
+        observability can link a client-mode run to an existing SDK-owned cloud browser. Plain
+        local windows are not cloud-backed and return `None`; cloud-backed subclasses override this
+        property with their session ID.
+        """
+        return None
+
     async def upload_file(self, *, file: IO) -> File:
         """Uploads a file that can be used as an attachment in a subsequent `agent` request.
 
@@ -389,6 +400,9 @@ class BaseBrowserWindow(ABC):
             "browserWindowId": self.browser_window_id,
             "timeZone": time_zone,
         }
+        cloud_browser_session_id = self.cloud_browser_session_id
+        if cloud_browser_session_id is not None:
+            body["cloudBrowserSessionId"] = cloud_browser_session_id
         if clear_chat is not None:
             body["clearChat"] = clear_chat
         if generate_gif is not None:

--- a/packages/narada/tests/test_input_variables.py
+++ b/packages/narada/tests/test_input_variables.py
@@ -1,7 +1,7 @@
 from io import BytesIO
 
 import pytest
-from narada.window import BaseBrowserWindow
+from narada.window import BaseBrowserWindow, CloudBrowserWindow, RemoteBrowserWindow
 
 
 @pytest.mark.asyncio
@@ -37,3 +37,19 @@ async def test_input_variable_files_normalize_to_current_file_variable_shape(
             "mimeType": "text/plain",
         }
     }
+
+
+def test_cloud_browser_windows_expose_session_id_for_remote_dispatch() -> None:
+    cloud_window = CloudBrowserWindow(
+        auth_headers={},
+        browser_window_id="browser-window-123",
+        session_id="session-123",
+    )
+    remote_window = RemoteBrowserWindow(
+        auth_headers={},
+        browser_window_id="browser-window-456",
+        cloud_browser_session_id="session-456",
+    )
+
+    assert cloud_window.cloud_browser_session_id == "session-123"
+    assert remote_window.cloud_browser_session_id == "session-456"


### PR DESCRIPTION
Previously this wasn't being threaded through for observability.