### PR TITLE
Gracefully handle initial Playwright goto timeout

### DIFF
--- a/packages/narada/pyproject.toml
+++ b/packages/narada/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "narada"
-version = "0.1.48"
+version = "0.1.49"
 description = "Python client SDK for Narada"
 license = "Apache-2.0"
 readme = "README.md"

--- a/packages/narada/src/narada/client.py
+++ b/packages/narada/src/narada/client.py
@@ -269,17 +269,35 @@ class Narada:
         login_url: str,
         cdp_auth_headers: dict[str, str],
     ) -> CloudBrowserWindow:
-        assert self._playwright is not None
+        # Use a local variable for type narrowing.
+        pw = self._playwright
+        assert pw is not None
+
+        async def connect_over_cdp() -> Browser:
+            return await pw.chromium.connect_over_cdp(
+                cdp_websocket_url, headers=cdp_auth_headers
+            )
 
         # Connect to browser via CDP with authentication headers
-        browser = await self._playwright.chromium.connect_over_cdp(
-            cdp_websocket_url, headers=cdp_auth_headers
-        )
+        browser = await connect_over_cdp()
 
         # Navigate to login URL (provided by backend with custom token)
         context = browser.contexts[0]
         initialization_page = context.pages[0]
-        await initialization_page.goto(login_url)
+
+        # This `goto` action can occasionally timeout for unknown reasons. To mitigate this, we
+        # wrap it in a retry loop.
+        max_attempts = 3
+        for attempt in range(max_attempts):
+            try:
+                await initialization_page.goto(login_url, timeout=15_000)
+                break
+            except PlaywrightTimeoutError:
+                if attempt == max_attempts - 1:
+                    raise
+                logging.info("Retrying navigation to login URL...")
+                await browser.close()
+                browser = await connect_over_cdp()
 
         # Wait for browser window ID. The extension can take a bit to be installed, so we retry a
         # few times.

--- a/uv.lock
+++ b/uv.lock
@@ -312,7 +312,7 @@ wheels = [
 
 [[package]]
 name = "narada"
-version = "0.1.48"
+version = "0.1.49"
 source = { editable = "packages/narada" }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
This Playwright `.goto()` call sometimes just times out for no apparent reason.