### PR TITLE
Support prompt messages in prompt input API

### DIFF
--- a/examples/human_in_the_loop.py
+++ b/examples/human_in_the_loop.py
@@ -1,7 +1,8 @@
 import asyncio
 
-from narada import Agent, Narada, UserAbortedError
 from narada_core.actions.models import PromptForUserInputVariable
+
+from narada import Agent, Narada, UserAbortedError
 
 
 async def main() -> None:
@@ -27,6 +28,7 @@ async def main() -> None:
                         enum_values=["pricing", "customers", "recent news"],
                     ),
                 ],
+                prompt_message="Tell us which company to research and what to focus on.",
             )
 
             company = values["company"]

--- a/packages/narada-core/src/narada_core/actions/models.py
+++ b/packages/narada-core/src/narada_core/actions/models.py
@@ -401,6 +401,7 @@ class PromptForUserInputRequest(BaseModel):
     name: Literal["prompt_for_user_input"] = "prompt_for_user_input"
     step_id: str
     variables: list[PromptForUserInputVariable]
+    prompt_message: str | None = None
 
 
 class PromptForUserInputResponse(BaseModel):

--- a/packages/narada-pyodide/src/narada/window.py
+++ b/packages/narada-pyodide/src/narada/window.py
@@ -799,11 +799,14 @@ class BaseBrowserWindow(ABC):
         *,
         step_id: str,
         variables: list[PromptForUserInputVariable],
+        prompt_message: str | None = None,
         timeout: int | None = None,
     ) -> dict[str, Any]:
         """Prompts the user for one or more input values in the extension UI."""
         result = await self._run_extension_action(
-            PromptForUserInputRequest(step_id=step_id, variables=variables),
+            PromptForUserInputRequest(
+                step_id=step_id, prompt_message=prompt_message, variables=variables
+            ),
             PromptForUserInputResponse,
             timeout=timeout,
         )

--- a/packages/narada/src/narada/window.py
+++ b/packages/narada/src/narada/window.py
@@ -769,11 +769,14 @@ class BaseBrowserWindow(ABC):
         *,
         step_id: str,
         variables: list[PromptForUserInputVariable],
+        prompt_message: str | None = None,
         timeout: int | None = None,
     ) -> dict[str, Any]:
         """Prompts the user for one or more input values in the extension UI."""
         result = await self._run_extension_action(
-            PromptForUserInputRequest(step_id=step_id, variables=variables),
+            PromptForUserInputRequest(
+                step_id=step_id, prompt_message=prompt_message, variables=variables
+            ),
             PromptForUserInputResponse,
             timeout=timeout,
         )


### PR DESCRIPTION
## Summary
- Add optional `prompt_message` to the prompt_for_user_input action request model.
- Expose `prompt_message` on both the Python and Pyodide browser window APIs.
- Update the human-in-the-loop example to show plain-language helper text.