### PR TITLE
Experiment with longer timeout in VM

### DIFF
--- a/packages/narada/pyproject.toml
+++ b/packages/narada/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "narada"
-version = "0.1.52"
+version = "0.1.53a1"
 description = "Python client SDK for Narada"
 license = "Apache-2.0"
 readme = "README.md"

--- a/packages/narada/src/narada/client.py
+++ b/packages/narada/src/narada/client.py
@@ -279,7 +279,7 @@ class Narada:
         # Navigate to login URL (provided by backend with custom token)
         context = browser.contexts[0]
         initialization_page = context.pages[0]
-        await initialization_page.goto(login_url, timeout=20_000)
+        await initialization_page.goto(login_url, timeout=15_000)
 
         # Wait for browser window ID. The extension can take a bit to be installed, so we retry a
         # few times.
@@ -289,7 +289,7 @@ class Narada:
                 browser_window_id = await self._wait_for_browser_window_id(
                     initialization_page,
                     config,
-                    timeout=10_000,
+                    timeout=30_000,
                 )
                 break
             except NaradaExtensionMissingError:
@@ -302,7 +302,7 @@ class Narada:
                     raise
                 # If browser window ID is not found, reload the page and try again
                 # try to go to the login URL again (with customToken query param)
-                await initialization_page.goto(login_url, timeout=20_000)
+                await initialization_page.goto(login_url, timeout=15_000)
 
         cloud_window = CloudBrowserWindow(
             browser_window_id=browser_window_id,

--- a/uv.lock
+++ b/uv.lock
@@ -312,7 +312,7 @@ wheels = [
 
 [[package]]
 name = "narada"
-version = "0.1.52"
+version = "0.1.53a1"
 source = { editable = "packages/narada" }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
It seems that in the cloud, even 10 seconds isn't enough for the frontend/extension authentication sync to complete.