### PR TITLE
Add Codex sibling refs to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,12 +6,12 @@
 
 ## Codex sibling refs
 
-<!-- Optional: declare sibling PRs/SHAs that Codex should use instead of sibling repo main.
-Supported values: PR URL, NaradaAI/<repo>#123, <repo>#123, pr:123, sha:<40hex>, branch:<name>, main, or skip.
-Prefer PR URLs or PR numbers over branch names. Leave blank to use the default main snapshot when this repo's Codex reviewer loads that sibling repo. -->
+<!-- Optional: declare sibling PRs that Codex should use instead of sibling repo main.
+Supported values: PR URL, NaradaAI/<repo>#123, <repo>#123, pr:123, main, or skip.
+If related work is still only on a branch, open a draft PR in that repo and paste the PR URL here.
+Leave blank to use the default main snapshot when this repo's Codex reviewer loads that sibling repo. -->
 
 - caddie:
 - frontend:
-- narada-python-sdk:
 - desktop-automation-app:
 - api-docs:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,10 +6,9 @@
 
 ## Codex sibling refs
 
-<!-- Optional: declare sibling PRs that Codex should use instead of sibling repo main.
-Supported values: PR URL, NaradaAI/<repo>#123, <repo>#123, pr:123, main, or skip.
-If related work is still only on a branch, open a draft PR in that repo and paste the PR URL here.
-Leave blank to use the default main snapshot when this repo's Codex reviewer loads that sibling repo. -->
+<!-- Optional: declare sibling refs that Codex should use instead of sibling repo main.
+Supported values: PR URL, NaradaAI/<repo>#123, <repo>#123, pr:123, sha:<40hex>, branch:<name>, main, or skip.
+Prefer PR URLs when possible. Leave blank to use the default main snapshot when this repo's Codex reviewer loads that sibling repo. -->
 
 - caddie:
 - frontend:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,17 @@
+## Summary
+
+
+## Testing
+
+
+## Codex sibling refs
+
+<!-- Optional: declare sibling PRs/SHAs that Codex should use instead of sibling repo main.
+Supported values: PR URL, NaradaAI/<repo>#123, <repo>#123, pr:123, sha:<40hex>, branch:<name>, main, or skip.
+Prefer PR URLs or PR numbers over branch names. Leave blank to use the default main snapshot when this repo's Codex reviewer loads that sibling repo. -->
+
+- caddie:
+- frontend:
+- narada-python-sdk:
+- desktop-automation-app:
+- api-docs:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,8 +1,6 @@
 ## Summary
 
-
 ## Testing
-
 
 ## Codex sibling refs
 


### PR DESCRIPTION
## Summary

- add the Codex sibling refs block to the PR template

## Testing

- git diff --check

## Codex sibling refs

- caddie: NaradaAI/caddie#6454
- frontend: NaradaAI/frontend#1713
- narada-python-sdk:
- desktop-automation-app: NaradaAI/desktop-automation-app#13
- api-docs: