### PR TITLE
Add sub-agent response text to Python traces

### DIFF
--- a/packages/narada-core/pyproject.toml
+++ b/packages/narada-core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "narada-core"
-version = "0.0.23"
+version = "0.0.24"
 description = "Code shared by the `narada` and `narada-pyodide` packages."
 license = "Apache-2.0"
 readme = "README.md"

--- a/packages/narada-core/src/narada_core/models.py
+++ b/packages/narada-core/src/narada_core/models.py
@@ -254,6 +254,7 @@ class RunCustomAgentTrace(TypedDict):
     workflow_name: str
     status: Literal["success", "error"]
     error_message: NotRequired[str]
+    children: NotRequired[ActionTrace]
 
 
 class IfTrace(TypedDict):
@@ -312,6 +313,7 @@ class PythonSubAgentCallEvent(TypedDict):
     prompt: str
     status: Literal["success", "error", "timeout"]
     request_id: NotRequired[str]
+    text: NotRequired[str]
     error_message: NotRequired[str]
     action_trace: NotRequired[ActionTrace]
 

--- a/packages/narada-core/src/narada_core/tracing/model.py
+++ b/packages/narada-core/src/narada_core/tracing/model.py
@@ -189,6 +189,7 @@ class RunCustomAgentTrace(BaseModel):
     workflow_name: str
     status: Literal["success", "error"]
     error_message: str | None = None
+    children: ActionTrace | None = None
 
 
 class IfTrace(BaseModel):
@@ -260,6 +261,7 @@ class PythonSubAgentCallEvent(BaseModel):
     prompt: str
     status: Literal["success", "error", "timeout"]
     request_id: str | None = None
+    text: str | None = None
     error_message: str | None = None
     action_trace: ActionTrace | None = None
 

--- a/packages/narada-pyodide/pyproject.toml
+++ b/packages/narada-pyodide/pyproject.toml
@@ -1,14 +1,14 @@
 
 [project]
 name = "narada-pyodide"
-version = "0.0.52"
+version = "0.0.53"
 description = "Pyodide-compatible Python client SDK for Narada"
 license = "Apache-2.0"
 readme = "README.md"
 authors = [{ name = "Narada", email = "support@narada.ai" }]
 requires-python = ">=3.12"
 dependencies = [
-    "narada-core==0.0.23",
+    "narada-core==0.0.24",
     # Must be a supported version in https://pyodide.org/en/stable/usage/packages-in-pyodide.html
     "packaging==24.2",
 ]

--- a/packages/narada-pyodide/src/narada/_trace.py
+++ b/packages/narada-pyodide/src/narada/_trace.py
@@ -87,6 +87,7 @@ def emit_sub_agent_call(
     prompt: str,
     status: SubAgentCallStatus,
     request_id: str | None = None,
+    text: str | None = None,
     error_message: str | None = None,
     action_trace_raw: list[dict[str, Any]] | None = None,
 ) -> None:
@@ -100,6 +101,8 @@ def emit_sub_agent_call(
     }
     if request_id is not None:
         event["request_id"] = request_id
+    if text is not None:
+        event["text"] = text
     if error_message is not None:
         event["error_message"] = error_message
     if action_trace_raw is not None:

--- a/packages/narada-pyodide/src/narada/window.py
+++ b/packages/narada-pyodide/src/narada/window.py
@@ -490,12 +490,19 @@ class BaseBrowserWindow(ABC):
                         and response_content is not None
                         else None
                     )
+                    trace_text: str | None = (
+                        response_content.get("text")
+                        if response["status"] == "success"
+                        and response_content is not None
+                        else None
+                    )
                     _trace.emit_sub_agent_call(
                         ts_start=trace_start_ms,
                         agent_type=agent_type_str,
                         prompt=prompt,
                         status=trace_status,
                         request_id=request_id,
+                        text=trace_text,
                         error_message=trace_error,
                         action_trace_raw=(
                             response_content.get("actionTrace")

--- a/packages/narada-pyodide/tests/test_cloud_browser.py
+++ b/packages/narada-pyodide/tests/test_cloud_browser.py
@@ -315,6 +315,86 @@ async def test_dispatch_request_emits_string_trace_agent_type_for_sdk_enum(
 
 
 @pytest.mark.asyncio
+async def test_dispatch_request_emits_success_text_in_sub_agent_trace(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pyfetch = AsyncMock(
+        side_effect=[
+            _FakeResponse(json_data={"requestId": "req-123"}),
+            _FakeResponse(
+                json_data={
+                    "status": "success",
+                    "response": {
+                        "text": "TRACE_CORE_AGENT_DONE",
+                        "actionTrace": [],
+                    },
+                }
+            ),
+        ]
+    )
+    narada_pkg, _, window_module = _import_pyodide_narada(monkeypatch, pyfetch=pyfetch)
+    emitted_events: list[str] = []
+    monkeypatch.setattr(
+        sys.modules["narada._trace"],
+        "_narada_emit_trace_event",
+        emitted_events.append,
+        raising=False,
+    )
+
+    window = window_module.CloudBrowserWindow(
+        browser_window_id="browser-window-123",
+        session_id="session-123",
+        api_key="test-api-key",
+    )
+    response = await window.dispatch_request(
+        prompt="reply with marker",
+        agent=narada_pkg.Agent.CORE_AGENT,
+    )
+
+    from narada_core.tracing.model import PythonSubAgentCallEvent
+
+    assert response["status"] == "success"
+    assert len(emitted_events) == 1
+    event = json.loads(emitted_events[0])
+    parsed_event = PythonSubAgentCallEvent.model_validate(event)
+    assert parsed_event.agent_type == "coreAgent"
+    assert parsed_event.text == "TRACE_CORE_AGENT_DONE"
+    assert parsed_event.action_trace == []
+
+
+def test_parse_action_trace_preserves_run_custom_agent_children(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.syspath_prepend(str(CORE_SRC))
+
+    from narada_core.tracing.model import parse_action_trace
+
+    parsed_trace = parse_action_trace(
+        [
+            {
+                "step_type": "runCustomAgent",
+                "url": "https://example.com",
+                "workflow_id": "workflow-parent",
+                "workflow_name": "Parent workflow",
+                "status": "success",
+                "children": [
+                    {
+                        "step_type": "print",
+                        "url": "https://example.com",
+                        "message": "TRACE_GUI_CHILD_DONE",
+                    }
+                ],
+            }
+        ]
+    )
+
+    assert parsed_trace[0].step_type == "runCustomAgent"
+    assert parsed_trace[0].children is not None
+    assert parsed_trace[0].children[0].step_type == "print"
+    assert parsed_trace[0].children[0].message == "TRACE_GUI_CHILD_DONE"
+
+
+@pytest.mark.asyncio
 async def test_cloud_browser_window_dispatch_request_preserves_current_file_variable_shape(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/packages/narada/pyproject.toml
+++ b/packages/narada/pyproject.toml
@@ -1,13 +1,13 @@
 [project]
 name = "narada"
-version = "0.1.53a2"
+version = "0.1.53a3"
 description = "Python client SDK for Narada"
 license = "Apache-2.0"
 readme = "README.md"
 authors = [{ name = "Narada", email = "support@narada.ai" }]
 requires-python = ">=3.12"
 dependencies = [
-    "narada-core==0.0.23",
+    "narada-core==0.0.24",
     "aiohttp>=3.12.13",
     "playwright>=1.53.0",
     "rich>=14.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -312,7 +312,7 @@ wheels = [
 
 [[package]]
 name = "narada"
-version = "0.1.53a2"
+version = "0.1.53a3"
 source = { editable = "packages/narada" }
 dependencies = [
     { name = "aiohttp" },
@@ -345,7 +345,7 @@ dev = [
 
 [[package]]
 name = "narada-core"
-version = "0.0.23"
+version = "0.0.24"
 source = { editable = "packages/narada-core" }
 dependencies = [
     { name = "pydantic" },
@@ -356,7 +356,7 @@ requires-dist = [{ name = "pydantic", specifier = "==2.12.5" }]
 
 [[package]]
 name = "narada-pyodide"
-version = "0.0.52"
+version = "0.0.53"
 source = { editable = "packages/narada-pyodide" }
 dependencies = [
     { name = "narada-core" },


### PR DESCRIPTION
## Summary

This updates the Python trace schema so nested Python APA traces can preserve the actual text returned by sub-agent calls, and so GUI custom-agent child traces can be parsed without losing their nested `children` subtree.

## What changed

- Added optional `text` to `PythonSubAgentCallEvent` in `narada-core` models and typed dicts.
- Added optional `children` to `RunCustomAgentTrace` so frontend/product traces that use the GUI custom-agent shape are accepted by the SDK trace model.
- Updated `narada-pyodide` tracing emission so `window.agent(...)` records the returned response text alongside `request_id`, status, and nested action trace.
- Bumped package versions for publishing:
  - `narada-core`: `0.0.24`
  - `narada-pyodide`: `0.0.53`
  - `narada`: `0.1.53a3`

## Why

The local nested APA and GUI trace investigations showed two information-loss bugs:

1. Operator/Core sub-agent calls could succeed but their final textual response was absent from the Python action trace.
2. GUI custom-agent traces could contain nested child trace data under `children`, which the current SDK model did not parse.

Both made observability look incomplete even when the underlying agent call worked.

## Validation

- `uv run pytest packages/narada-pyodide/tests/test_cloud_browser.py -q` — 12 passed
- `uv run ruff check packages/narada-core packages/narada-pyodide packages/narada`
- `python -m py_compile` over changed SDK packages
- `uv build --package narada-core`
- `uv build --package narada-pyodide`
- `uv build --package narada`
- Live CFT proof used these local wheels in the frontend Pyodide runtime and captured persisted observability evidence for nested Python APA, GUI custom-agent, and Operator runs.

Representative artifact root:

`/tmp/narada-e2e-runs/20260513T013044Z-trace-completeness-trace-complete-local-20260513t013044z`