### PR TITLE
Volodymyr/speed up extensioneless lambdas v2

### DIFF
--- a/packages/narada/src/narada/client.py
+++ b/packages/narada/src/narada/client.py
@@ -177,11 +177,18 @@ class Narada:
         session_timeout: int | None = None,
         require_extension: bool = True,
     ) -> CloudBrowserWindow:
-        """Creates a cloud browser by calling the backend.
+        """Create a cloud browser session and return a ``CloudBrowserWindow``.
 
-        The backend creates a cloud browser session and returns
-        a CDP WebSocket URL. This method connects to it, initializes the extension,
-        and returns a CloudBrowserWindow instance.
+        With ``require_extension=True`` (default), calls
+        ``POST /cloud-browser/create-cloud-browser-session``, then connects local Playwright
+        over CDP, opens ``login_url``, and waits for ``#narada-browser-window-id`` (extension
+        install retries apply). ``config`` controls interactive prompts and related behavior.
+
+        With ``require_extension=False``, calls
+        ``POST /cloud-browser/create-and-initialize-cloud-browser-session`` instead: the API
+        provisions the browser and runs the same CDP initialization on the server, returning
+        ``session_id`` and ``browser_window_id`` in the JSON body. Local Playwright is not used
+        for that path, and ``config`` is ignored.
         """
         config = config or BrowserConfig()
         base_url = os.getenv("NARADA_API_BASE_URL", "https://api.narada.ai/fast/v2")

--- a/packages/narada/tests/test_cloud_browser.py
+++ b/packages/narada/tests/test_cloud_browser.py
@@ -85,3 +85,56 @@ async def test_extensionless_cloud_browser_uses_backend_initialization(
         "session_name": "fast-session",
         "session_timeout": 300,
     }
+
+
+class _ForbiddenResponse:
+    ok = False
+    status = 403
+
+    async def __aenter__(self) -> "_ForbiddenResponse":
+        return self
+
+    async def __aexit__(self, *args: Any) -> None:
+        pass
+
+    async def json(self) -> dict[str, Any]:
+        return {}
+
+    async def text(self) -> str:
+        return '{"detail": {"reason": "forbidden"}}'
+
+
+class _ForbiddenClientSession:
+    def __init__(self) -> None:
+        self.posts: list[str] = []
+
+    async def __aenter__(self) -> "_ForbiddenClientSession":
+        return self
+
+    async def __aexit__(self, *args: Any) -> None:
+        pass
+
+    def post(self, url: str, **kwargs: Any) -> _ForbiddenResponse:
+        self.posts.append(url)
+        return _ForbiddenResponse()
+
+
+@pytest.mark.asyncio
+async def test_extensionless_cloud_browser_forbidden_sets_error_attributes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_session = _ForbiddenClientSession()
+    monkeypatch.setattr(client_module.aiohttp, "ClientSession", lambda: fake_session)
+
+    narada = Narada(auth_headers={"x-api-key": "test-key"})
+
+    with pytest.raises(RuntimeError) as excinfo:
+        await narada.open_and_initialize_cloud_browser_window(require_extension=False)
+
+    err = excinfo.value
+    assert getattr(err, "status_code", None) == 403
+    assert getattr(err, "detail", None) == {"reason": "forbidden"}
+    assert len(fake_session.posts) == 1
+    assert fake_session.posts[0].endswith(
+        "/cloud-browser/create-and-initialize-cloud-browser-session"
+    )


### PR DESCRIPTION

This PR speeds up extensionless cloud browser startup by routing require_extension=False SDK sessions through the backend’s create-and-initialize endpoint, avoiding the old local Playwright CDP initialization path. On the backend, extensionless cloud sessions now initialize via /initialize?requireExtension=false instead of the full /chat app, and timing logs were added around AgentCore startup, CDP signing, session creation, and Narada initialization so future latency can be isolated more clearly. The SDK docstring and tests were updated to reflect the split behavior between extension-required and extensionless sessions.

