### PR TITLE
Add matching selectors finder SDK primitive

### DIFF
--- a/packages/narada-core/pyproject.toml
+++ b/packages/narada-core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "narada-core"
-version = "0.0.25"
+version = "0.0.26"
 description = "Code shared by the `narada` and `narada-pyodide` packages."
 license = "Apache-2.0"
 readme = "README.md"

--- a/packages/narada-core/src/narada_core/actions/models.py
+++ b/packages/narada-core/src/narada_core/actions/models.py
@@ -200,14 +200,14 @@ class AgenticSelectorResponse(BaseModel):
     value: str | None
 
 
-class AgenticMatchingElementFinderRequest(BaseModel):
-    name: Literal["agentic_matching_element_finder"] = (
-        "agentic_matching_element_finder"
+class AgenticMatchingSelectorsFinderRequest(BaseModel):
+    name: Literal["agentic_matching_selectors_finder"] = (
+        "agentic_matching_selectors_finder"
     )
     prompt: str
 
 
-class AgenticMatchingElementFinderResponse(BaseModel):
+class AgenticMatchingSelectorsFinderResponse(BaseModel):
     selectors: list[AgenticSelectors]
 
 
@@ -433,7 +433,7 @@ class UserApprovalResponse(BaseModel):
 
 type ExtensionActionRequest = (
     AgenticSelectorRequest
-    | AgenticMatchingElementFinderRequest
+    | AgenticMatchingSelectorsFinderRequest
     | AgenticMouseActionRequest
     | CloseWindowRequest
     | GoToUrlRequest

--- a/packages/narada-core/src/narada_core/actions/models.py
+++ b/packages/narada-core/src/narada_core/actions/models.py
@@ -200,6 +200,15 @@ class AgenticSelectorResponse(BaseModel):
     value: str | None
 
 
+class AgenticXPathFinderRequest(BaseModel):
+    name: Literal["agentic_xpath_finder"] = "agentic_xpath_finder"
+    prompt: str
+
+
+class AgenticXPathFinderResponse(BaseModel):
+    xpaths: list[str]
+
+
 class WaitForElementRequest(BaseModel):
     name: Literal["wait_for_element"] = "wait_for_element"
     selectors: AgenticSelectors
@@ -422,6 +431,7 @@ class UserApprovalResponse(BaseModel):
 
 type ExtensionActionRequest = (
     AgenticSelectorRequest
+    | AgenticXPathFinderRequest
     | AgenticMouseActionRequest
     | CloseWindowRequest
     | GoToUrlRequest

--- a/packages/narada-core/src/narada_core/actions/models.py
+++ b/packages/narada-core/src/narada_core/actions/models.py
@@ -200,13 +200,15 @@ class AgenticSelectorResponse(BaseModel):
     value: str | None
 
 
-class AgenticXPathFinderRequest(BaseModel):
-    name: Literal["agentic_xpath_finder"] = "agentic_xpath_finder"
+class AgenticMatchingElementFinderRequest(BaseModel):
+    name: Literal["agentic_matching_element_finder"] = (
+        "agentic_matching_element_finder"
+    )
     prompt: str
 
 
-class AgenticXPathFinderResponse(BaseModel):
-    xpaths: list[str]
+class AgenticMatchingElementFinderResponse(BaseModel):
+    selectors: list[AgenticSelectors]
 
 
 class WaitForElementRequest(BaseModel):
@@ -431,7 +433,7 @@ class UserApprovalResponse(BaseModel):
 
 type ExtensionActionRequest = (
     AgenticSelectorRequest
-    | AgenticXPathFinderRequest
+    | AgenticMatchingElementFinderRequest
     | AgenticMouseActionRequest
     | CloseWindowRequest
     | GoToUrlRequest

--- a/packages/narada-pyodide/pyproject.toml
+++ b/packages/narada-pyodide/pyproject.toml
@@ -1,14 +1,14 @@
 
 [project]
 name = "narada-pyodide"
-version = "0.0.56"
+version = "0.0.57"
 description = "Pyodide-compatible Python client SDK for Narada"
 license = "Apache-2.0"
 readme = "README.md"
 authors = [{ name = "Narada", email = "support@narada.ai" }]
 requires-python = ">=3.12"
 dependencies = [
-    "narada-core==0.0.25",
+    "narada-core==0.0.26",
     # Must be a supported version in https://pyodide.org/en/stable/usage/packages-in-pyodide.html
     "packaging==24.2",
 ]

--- a/packages/narada-pyodide/src/narada/window.py
+++ b/packages/narada-pyodide/src/narada/window.py
@@ -762,24 +762,6 @@ class BaseBrowserWindow(ABC):
         )
         return result.selectors
 
-    async def agentic_xpath_finder(
-        self,
-        *,
-        prompt: str,
-        timeout: int | None = 300,
-    ) -> list[str]:
-        """Finds matching page elements and returns their XPath selectors."""
-        selectors = await self.agentic_matching_element_finder(
-            prompt=prompt,
-            timeout=timeout,
-        )
-        xpaths: list[str] = []
-        for selector in selectors:
-            xpath = selector.get("xpath")
-            if isinstance(xpath, str):
-                xpaths.append(xpath)
-        return xpaths
-
     async def agentic_mouse_action(
         self,
         *,

--- a/packages/narada-pyodide/src/narada/window.py
+++ b/packages/narada-pyodide/src/narada/window.py
@@ -28,6 +28,8 @@ from narada_core.actions.models import (
     AgenticSelectorRequest,
     AgenticSelectorResponse,
     AgenticSelectors,
+    AgenticXPathFinderRequest,
+    AgenticXPathFinderResponse,
     AgentResponse,
     AgentUsage,
     CloseWindowRequest,
@@ -745,6 +747,20 @@ class BaseBrowserWindow(ABC):
             return AgenticSelectorResponse(value=None)
 
         return result
+
+    async def agentic_xpath_finder(
+        self,
+        *,
+        prompt: str,
+        timeout: int | None = 300,
+    ) -> list[str]:
+        """Finds all visible page elements matching a prompt and returns XPath selectors."""
+        result = await self._run_extension_action(
+            AgenticXPathFinderRequest(prompt=prompt),
+            AgenticXPathFinderResponse,
+            timeout=timeout,
+        )
+        return result.xpaths
 
     async def agentic_mouse_action(
         self,

--- a/packages/narada-pyodide/src/narada/window.py
+++ b/packages/narada-pyodide/src/narada/window.py
@@ -24,12 +24,12 @@ from narada_core.actions.critic import run_critic
 from narada_core.actions.models import (
     AgenticMouseAction,
     AgenticMouseActionRequest,
+    AgenticMatchingElementFinderRequest,
+    AgenticMatchingElementFinderResponse,
     AgenticSelectorAction,
     AgenticSelectorRequest,
     AgenticSelectorResponse,
     AgenticSelectors,
-    AgenticXPathFinderRequest,
-    AgenticXPathFinderResponse,
     AgentResponse,
     AgentUsage,
     CloseWindowRequest,
@@ -748,19 +748,37 @@ class BaseBrowserWindow(ABC):
 
         return result
 
+    async def agentic_matching_element_finder(
+        self,
+        *,
+        prompt: str,
+        timeout: int | None = 300,
+    ) -> list[AgenticSelectors]:
+        """Finds all visible page elements matching a prompt and returns selectors."""
+        result = await self._run_extension_action(
+            AgenticMatchingElementFinderRequest(prompt=prompt),
+            AgenticMatchingElementFinderResponse,
+            timeout=timeout,
+        )
+        return result.selectors
+
     async def agentic_xpath_finder(
         self,
         *,
         prompt: str,
         timeout: int | None = 300,
     ) -> list[str]:
-        """Finds all visible page elements matching a prompt and returns XPath selectors."""
-        result = await self._run_extension_action(
-            AgenticXPathFinderRequest(prompt=prompt),
-            AgenticXPathFinderResponse,
+        """Finds matching page elements and returns their XPath selectors."""
+        selectors = await self.agentic_matching_element_finder(
+            prompt=prompt,
             timeout=timeout,
         )
-        return result.xpaths
+        xpaths: list[str] = []
+        for selector in selectors:
+            xpath = selector.get("xpath")
+            if isinstance(xpath, str):
+                xpaths.append(xpath)
+        return xpaths
 
     async def agentic_mouse_action(
         self,

--- a/packages/narada-pyodide/src/narada/window.py
+++ b/packages/narada-pyodide/src/narada/window.py
@@ -24,8 +24,8 @@ from narada_core.actions.critic import run_critic
 from narada_core.actions.models import (
     AgenticMouseAction,
     AgenticMouseActionRequest,
-    AgenticMatchingElementFinderRequest,
-    AgenticMatchingElementFinderResponse,
+    AgenticMatchingSelectorsFinderRequest,
+    AgenticMatchingSelectorsFinderResponse,
     AgenticSelectorAction,
     AgenticSelectorRequest,
     AgenticSelectorResponse,
@@ -748,16 +748,16 @@ class BaseBrowserWindow(ABC):
 
         return result
 
-    async def agentic_matching_element_finder(
+    async def agentic_matching_selectors_finder(
         self,
         *,
         prompt: str,
         timeout: int | None = 300,
     ) -> list[AgenticSelectors]:
-        """Finds all visible page elements matching a prompt and returns selectors."""
+        """Finds all visible targets matching a prompt and returns selectors."""
         result = await self._run_extension_action(
-            AgenticMatchingElementFinderRequest(prompt=prompt),
-            AgenticMatchingElementFinderResponse,
+            AgenticMatchingSelectorsFinderRequest(prompt=prompt),
+            AgenticMatchingSelectorsFinderResponse,
             timeout=timeout,
         )
         return result.selectors

--- a/packages/narada/pyproject.toml
+++ b/packages/narada/pyproject.toml
@@ -1,13 +1,13 @@
 [project]
 name = "narada"
-version = "0.1.53a5"
+version = "0.1.53a6"
 description = "Python client SDK for Narada"
 license = "Apache-2.0"
 readme = "README.md"
 authors = [{ name = "Narada", email = "support@narada.ai" }]
 requires-python = ">=3.12"
 dependencies = [
-    "narada-core==0.0.25",
+    "narada-core==0.0.26",
     "aiohttp>=3.12.13",
     "playwright>=1.53.0",
     "rich>=14.0.0",

--- a/packages/narada/src/narada/window.py
+++ b/packages/narada/src/narada/window.py
@@ -29,6 +29,8 @@ from narada_core.actions.models import (
     AgenticSelectorRequest,
     AgenticSelectorResponse,
     AgenticSelectors,
+    AgenticXPathFinderRequest,
+    AgenticXPathFinderResponse,
     AgentResponse,
     AgentUsage,
     CloseWindowRequest,
@@ -695,6 +697,20 @@ class BaseBrowserWindow(ABC):
             return AgenticSelectorResponse(value=None)
 
         return result
+
+    async def agentic_xpath_finder(
+        self,
+        *,
+        prompt: str,
+        timeout: int | None = 300,
+    ) -> list[str]:
+        """Finds all visible page elements matching a prompt and returns XPath selectors."""
+        result = await self._run_extension_action(
+            AgenticXPathFinderRequest(prompt=prompt),
+            AgenticXPathFinderResponse,
+            timeout=timeout,
+        )
+        return result.xpaths
 
     async def agentic_mouse_action(
         self,

--- a/packages/narada/src/narada/window.py
+++ b/packages/narada/src/narada/window.py
@@ -25,12 +25,12 @@ from narada_core.actions.critic import run_critic
 from narada_core.actions.models import (
     AgenticMouseAction,
     AgenticMouseActionRequest,
+    AgenticMatchingElementFinderRequest,
+    AgenticMatchingElementFinderResponse,
     AgenticSelectorAction,
     AgenticSelectorRequest,
     AgenticSelectorResponse,
     AgenticSelectors,
-    AgenticXPathFinderRequest,
-    AgenticXPathFinderResponse,
     AgentResponse,
     AgentUsage,
     CloseWindowRequest,
@@ -698,19 +698,37 @@ class BaseBrowserWindow(ABC):
 
         return result
 
+    async def agentic_matching_element_finder(
+        self,
+        *,
+        prompt: str,
+        timeout: int | None = 300,
+    ) -> list[AgenticSelectors]:
+        """Finds all visible page elements matching a prompt and returns selectors."""
+        result = await self._run_extension_action(
+            AgenticMatchingElementFinderRequest(prompt=prompt),
+            AgenticMatchingElementFinderResponse,
+            timeout=timeout,
+        )
+        return result.selectors
+
     async def agentic_xpath_finder(
         self,
         *,
         prompt: str,
         timeout: int | None = 300,
     ) -> list[str]:
-        """Finds all visible page elements matching a prompt and returns XPath selectors."""
-        result = await self._run_extension_action(
-            AgenticXPathFinderRequest(prompt=prompt),
-            AgenticXPathFinderResponse,
+        """Finds matching page elements and returns their XPath selectors."""
+        selectors = await self.agentic_matching_element_finder(
+            prompt=prompt,
             timeout=timeout,
         )
-        return result.xpaths
+        xpaths: list[str] = []
+        for selector in selectors:
+            xpath = selector.get("xpath")
+            if isinstance(xpath, str):
+                xpaths.append(xpath)
+        return xpaths
 
     async def agentic_mouse_action(
         self,

--- a/packages/narada/src/narada/window.py
+++ b/packages/narada/src/narada/window.py
@@ -25,8 +25,8 @@ from narada_core.actions.critic import run_critic
 from narada_core.actions.models import (
     AgenticMouseAction,
     AgenticMouseActionRequest,
-    AgenticMatchingElementFinderRequest,
-    AgenticMatchingElementFinderResponse,
+    AgenticMatchingSelectorsFinderRequest,
+    AgenticMatchingSelectorsFinderResponse,
     AgenticSelectorAction,
     AgenticSelectorRequest,
     AgenticSelectorResponse,
@@ -698,16 +698,16 @@ class BaseBrowserWindow(ABC):
 
         return result
 
-    async def agentic_matching_element_finder(
+    async def agentic_matching_selectors_finder(
         self,
         *,
         prompt: str,
         timeout: int | None = 300,
     ) -> list[AgenticSelectors]:
-        """Finds all visible page elements matching a prompt and returns selectors."""
+        """Finds all visible targets matching a prompt and returns selectors."""
         result = await self._run_extension_action(
-            AgenticMatchingElementFinderRequest(prompt=prompt),
-            AgenticMatchingElementFinderResponse,
+            AgenticMatchingSelectorsFinderRequest(prompt=prompt),
+            AgenticMatchingSelectorsFinderResponse,
             timeout=timeout,
         )
         return result.selectors

--- a/packages/narada/src/narada/window.py
+++ b/packages/narada/src/narada/window.py
@@ -712,24 +712,6 @@ class BaseBrowserWindow(ABC):
         )
         return result.selectors
 
-    async def agentic_xpath_finder(
-        self,
-        *,
-        prompt: str,
-        timeout: int | None = 300,
-    ) -> list[str]:
-        """Finds matching page elements and returns their XPath selectors."""
-        selectors = await self.agentic_matching_element_finder(
-            prompt=prompt,
-            timeout=timeout,
-        )
-        xpaths: list[str] = []
-        for selector in selectors:
-            xpath = selector.get("xpath")
-            if isinstance(xpath, str):
-                xpaths.append(xpath)
-        return xpaths
-
     async def agentic_mouse_action(
         self,
         *,

--- a/uv.lock
+++ b/uv.lock
@@ -312,7 +312,7 @@ wheels = [
 
 [[package]]
 name = "narada"
-version = "0.1.53a5"
+version = "0.1.53a6"
 source = { editable = "packages/narada" }
 dependencies = [
     { name = "aiohttp" },
@@ -345,7 +345,7 @@ dev = [
 
 [[package]]
 name = "narada-core"
-version = "0.0.25"
+version = "0.0.26"
 source = { editable = "packages/narada-core" }
 dependencies = [
     { name = "pydantic" },
@@ -356,7 +356,7 @@ requires-dist = [{ name = "pydantic", specifier = "==2.12.5" }]
 
 [[package]]
 name = "narada-pyodide"
-version = "0.0.56"
+version = "0.0.57"
 source = { editable = "packages/narada-pyodide" }
 dependencies = [
     { name = "narada-core" },


### PR DESCRIPTION
## Summary

Adds the SDK-side public primitive for selector collection:

- adds `AgenticMatchingSelectorsFinderRequest/Response`
- exposes `BaseBrowserWindow.agentic_matching_selectors_finder(...)`
- returns `list[AgenticSelectors]` so scripts can loop and pass each selector object into `agentic_selector`
- bumps `narada-core`, `narada`, and `narada-pyodide` package versions and repins downstream `narada-core` dependencies for release

## Testing

- `python3 -m py_compile packages/narada-core/src/narada_core/actions/models.py packages/narada/src/narada/window.py packages/narada-pyodide/src/narada/window.py`
- `git diff --check`

## Codex sibling refs

- caddie: https://github.com/NaradaAI/caddie/pull/6533
- frontend: https://github.com/NaradaAI/frontend/pull/1773
- architecture-docs: https://github.com/NaradaAI/architecture-docs/pull/15