### PR TITLE
[codex] add agentic selector precondition parameter

### DIFF
--- a/packages/narada-core/src/narada_core/actions/models.py
+++ b/packages/narada-core/src/narada_core/actions/models.py
@@ -187,15 +187,19 @@ class AgenticSelectorRequest(BaseModel):
     action: AgenticSelectorAction
     selectors: AgenticSelectors
     fallback_operator_query: str
+    pre_cond: str | None = None
 
     @override
     def model_dump(self) -> dict[str, Any]:
-        return {
+        result = {
             "name": self.name,
             "action": _dump_agentic_selector_action(self.action),
             "selectors": _dump_agentic_selectors(self.selectors),
             "fallback_operator_query": self.fallback_operator_query,
         }
+        if self.pre_cond is not None:
+            result["pre_cond"] = self.pre_cond
+        return result
 
 
 class AgenticSelectorResponse(BaseModel):

--- a/packages/narada-pyodide/src/narada/window.py
+++ b/packages/narada-pyodide/src/narada/window.py
@@ -795,11 +795,15 @@ class BaseBrowserWindow(ABC):
         action: AgenticSelectorAction,
         selectors: AgenticSelectors,
         fallback_operator_query: str,
+        pre_cond: str | None = None,
         # Larger default timeout because Operator can take a bit to run.
         timeout: int | None = 300,
     ) -> AgenticSelectorResponse:
         """Performs an action on an element specified by the given selectors, falling back to using
         the Operator agent if the selectors fail to match a unique element.
+
+        If ``pre_cond`` is provided, it is checked only after selector failure and before the
+        Operator fallback runs. A failed precondition raises ``NaradaError`` and prevents fallback.
 
         Returns AgenticSelectorResponse with the value for 'get_text' and 'get_property' actions,
         otherwise returns None.
@@ -815,6 +819,7 @@ class BaseBrowserWindow(ABC):
                 action=action,
                 selectors=selectors,
                 fallback_operator_query=fallback_operator_query,
+                pre_cond=pre_cond,
             ),
             response_model,
             timeout=timeout,

--- a/packages/narada/src/narada/window.py
+++ b/packages/narada/src/narada/window.py
@@ -730,11 +730,15 @@ class BaseBrowserWindow(ABC):
         action: AgenticSelectorAction,
         selectors: AgenticSelectors,
         fallback_operator_query: str,
+        pre_cond: str | None = None,
         # Larger default timeout because Operator can take a bit to run.
         timeout: int | None = 300,
     ) -> AgenticSelectorResponse:
         """Performs an action on an element specified by the given selectors, falling back to using
         the Operator agent if the selectors fail to match a unique element.
+
+        If ``pre_cond`` is provided, it is checked only after selector failure and before the
+        Operator fallback runs. A failed precondition raises ``NaradaError`` and prevents fallback.
         """
         response_model = (
             AgenticSelectorResponse
@@ -746,6 +750,7 @@ class BaseBrowserWindow(ABC):
                 action=action,
                 selectors=selectors,
                 fallback_operator_query=fallback_operator_query,
+                pre_cond=pre_cond,
             ),
             response_model=response_model,
             timeout=timeout,


### PR DESCRIPTION
## Summary
- Add optional `pre_cond` support to `AgenticSelectorRequest` serialization.
- Expose `pre_cond` on both Python and Pyodide `agentic_selector` methods.
- Keep the field omitted from dispatch payloads when it is not provided.

## Scope note
This PR was created from a clean `origin/main` worktree and intentionally excludes an unrelated local Pyodide workflow-trace compatibility fix that was present in the original dirty checkout.

## Validation
- `uv run ruff check packages/narada-core/src/narada_core/actions/models.py packages/narada-pyodide/src/narada/window.py packages/narada/src/narada/window.py`
- `uv run python -c 'from narada_core.actions.models import AgenticSelectorRequest; req=AgenticSelectorRequest(action={"type":"click"}, selectors={"tag_name":"BUTTON"}, fallback_operator_query="Click Submit", pre_cond="check Submit exists"); dumped=req.model_dump(); assert dumped["pre_cond"] == "check Submit exists"; req2=AgenticSelectorRequest(action={"type":"click"}, selectors={"tag_name":"BUTTON"}, fallback_operator_query="Click Submit"); assert "pre_cond" not in req2.model_dump(); print("pre_cond serialization ok")'`
- `git diff --check origin/main...HEAD`