### PR TITLE
Add SDK browser auto-login fallback

### DIFF
--- a/packages/narada/src/narada/environment.py
+++ b/packages/narada/src/narada/environment.py
@@ -28,6 +28,7 @@ from typing import (
     overload,
     override,
 )
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 from uuid import uuid4
 
 import aiohttp
@@ -150,6 +151,10 @@ class _PresignedPost(BaseModel):
     fields: dict[str, Any]
 
 
+class _CustomTokenResponse(BaseModel):
+    token: str
+
+
 @dataclass
 class SessionDownloadItem:
     """A file downloaded during a cloud browser session (file name, size, presigned GET URL)."""
@@ -164,6 +169,23 @@ class _LaunchBrowserResult:
     browser_process_id: int
     browser_window_id: str
     side_panel_page: Page
+
+
+def _with_query_params(url: str, params: Mapping[str, str]) -> str:
+    parsed_url = urlsplit(url)
+    query_params = [
+        *parse_qsl(parsed_url.query, keep_blank_values=True),
+        *params.items(),
+    ]
+    return urlunsplit(
+        (
+            parsed_url.scheme,
+            parsed_url.netloc,
+            parsed_url.path,
+            urlencode(query_params),
+            parsed_url.fragment,
+        )
+    )
 
 
 class ApiErrorPayload(BaseModel):
@@ -290,8 +312,8 @@ class _BrowserInitializationHelper:
                     )
                 except NaradaExtensionUnauthenticatedError:
                     self._console.input(
-                        "\n[bold]>[/bold] [bold blue]Please sign in to the Narada extension first, "
-                        "then press Enter to continue.[/bold blue]",
+                        "\n[bold]>[/bold] [bold blue]Narada is signing in automatically with your "
+                        "SDK credentials. Press Enter to retry if this does not continue.[/bold blue]",
                     )
 
                 # Bring the page to the front and wait a little bit before refreshing it, as this
@@ -1007,8 +1029,10 @@ class BrowserEnvironment(BaseBrowserEnvironment):
         initialization_page = await context.new_page()
         await initialization_page.goto(tagged_initialization_url)
 
-        browser_window_id = await self._wait_for_browser_window_id(
-            initialization_page, self._config
+        browser_window_id = await self._wait_for_browser_window_id_with_lazy_login(
+            initialization_page,
+            self._config,
+            tagged_initialization_url,
         )
 
         # Playwright seems unable to pick up the side panel page that is automatically opened by the
@@ -1139,8 +1163,12 @@ class BrowserEnvironment(BaseBrowserEnvironment):
                 (p for p in context.pages if p.url == tagged_initialization_url), None
             )
             if initialization_page is not None:
-                browser_window_id = await self._wait_for_browser_window_id(
-                    initialization_page, config
+                browser_window_id = (
+                    await self._wait_for_browser_window_id_with_lazy_login(
+                        initialization_page,
+                        config,
+                        tagged_initialization_url,
+                    )
                 )
 
                 side_panel_url = create_side_panel_url(config, browser_window_id)
@@ -1202,6 +1230,82 @@ class BrowserEnvironment(BaseBrowserEnvironment):
         return await self._browser_initialization.wait_for_browser_window_id(
             initialization_page, config, timeout=timeout
         )
+
+    async def _fetch_browser_login_token(self) -> str:
+        async with aiohttp.ClientSession() as session:
+            async with session.get(
+                f"{self._base_url}/auth/custom-token",
+                headers=self._auth_headers,
+                timeout=aiohttp.ClientTimeout(total=30),
+            ) as resp:
+                if not resp.ok:
+                    error_text = await resp.text()
+                    raise NaradaInitializationError(
+                        "Failed to sign in the Narada browser with SDK credentials: "
+                        f"{resp.status} {error_text}"
+                    )
+
+                return _CustomTokenResponse.model_validate(await resp.json()).token
+
+    async def _wait_for_browser_window_id_with_lazy_login(
+        self,
+        initialization_page: Page,
+        config: BrowserConfig,
+        initialization_url: str,
+        *,
+        timeout: int = 30_000,
+    ) -> str:
+        login_attempts = 0
+        max_login_attempts = 2
+
+        try:
+            while True:
+                try:
+                    return await _BrowserInitializationHelper.wait_for_browser_window_id_silently(
+                        initialization_page,
+                        timeout=timeout,
+                    )
+                except NaradaExtensionMissingError:
+                    if not config.interactive:
+                        raise
+
+                    self._console.input(
+                        "\n[bold]>[/bold] [bold blue]The Narada Enterprise extension is not "
+                        "installed. Please follow the instructions in the browser window to "
+                        "install it first, then press Enter to continue.[/bold blue]\n",
+                    )
+                    await initialization_page.bring_to_front()
+                    await asyncio.sleep(0.1)
+                    await initialization_page.reload()
+                except NaradaExtensionUnauthenticatedError as error:
+                    if login_attempts >= max_login_attempts:
+                        raise NaradaExtensionUnauthenticatedError(
+                            "Automatic sign-in with SDK credentials did not complete"
+                        ) from error
+
+                    login_attempts += 1
+                    if config.interactive:
+                        self._console.print(
+                            "\n[bold]>[/bold] [bold blue]Signing in to Narada with your SDK "
+                            "credentials...[/bold blue]\n",
+                        )
+
+                    custom_token = await self._fetch_browser_login_token()
+                    await initialization_page.goto(
+                        _with_query_params(
+                            initialization_url,
+                            {"customToken": custom_token},
+                        ),
+                        timeout=15_000,
+                        wait_until="domcontentloaded",
+                    )
+
+        except PlaywrightError:
+            self._console.print(
+                "\n[bold]>[/bold] [bold red]It seems the Narada automation page was closed. Please "
+                "retry the action and keep the Narada web page open.[/bold red]",
+            )
+            sys.exit(1)
 
     async def _setup_proxy_authentication_browser_level(
         self, browser: Browser, proxy_config: ProxyConfig

--- a/packages/narada/src/narada/environment.py
+++ b/packages/narada/src/narada/environment.py
@@ -1198,39 +1198,6 @@ class BrowserEnvironment(BaseBrowserEnvironment):
             side_panel_page=side_panel_page,
         )
 
-    @staticmethod
-    async def _wait_for_selector_attached(
-        page: Page, selector: str, *, timeout: int
-    ) -> ElementHandle | None:
-        return await _BrowserInitializationHelper.wait_for_selector_attached(
-            page, selector, timeout=timeout
-        )
-
-    @staticmethod
-    async def _wait_for_browser_window_id_silently(page: Page, *, timeout: int) -> str:
-        return await _BrowserInitializationHelper.wait_for_browser_window_id_silently(
-            page, timeout=timeout
-        )
-
-    async def _wait_for_browser_window_id_interactively(
-        self, page: Page, *, per_attempt_timeout: int
-    ) -> str:
-        return (
-            await self._browser_initialization.wait_for_browser_window_id_interactively(
-                page, per_attempt_timeout=per_attempt_timeout
-            )
-        )
-
-    async def _wait_for_browser_window_id(
-        self,
-        initialization_page: Page,
-        config: BrowserConfig,
-        timeout: int = 30_000,
-    ) -> str:
-        return await self._browser_initialization.wait_for_browser_window_id(
-            initialization_page, config, timeout=timeout
-        )
-
     async def _fetch_browser_login_token(self) -> str:
         async with aiohttp.ClientSession() as session:
             async with session.get(
@@ -1595,7 +1562,7 @@ class CloudBrowserEnvironment(BaseBrowserEnvironment):
         # canceled.
         await side_panel_page.reload()
 
-    async def _wait_for_browser_window_id(
+    async def _wait_for_cloud_browser_window_id(
         self,
         initialization_page: Page,
         config: BrowserConfig,
@@ -1635,7 +1602,7 @@ class CloudBrowserEnvironment(BaseBrowserEnvironment):
         max_attempts = 10
         for attempt in range(max_attempts):
             try:
-                browser_window_id = await self._wait_for_browser_window_id(
+                browser_window_id = await self._wait_for_cloud_browser_window_id(
                     initialization_page,
                     self._config,
                     timeout=30_000,

--- a/packages/narada/tests/test_browser_environment_login.py
+++ b/packages/narada/tests/test_browser_environment_login.py
@@ -1,0 +1,81 @@
+from unittest.mock import AsyncMock
+
+import pytest
+from narada import BrowserEnvironment
+from narada.config import BrowserConfig
+from narada_core.errors import NaradaExtensionUnauthenticatedError
+
+
+@pytest.mark.asyncio
+async def test_browser_environment_does_not_fetch_login_token_when_already_authenticated(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import narada.environment as environment_module
+
+    wait_for_browser_window_id = AsyncMock(return_value="browser-window-123")
+    monkeypatch.setattr(
+        environment_module._BrowserInitializationHelper,
+        "wait_for_browser_window_id_silently",
+        wait_for_browser_window_id,
+    )
+
+    page = AsyncMock()
+    env = BrowserEnvironment(
+        auth_headers={"x-api-key": "test-key"},
+        config=BrowserConfig(interactive=False),
+    )
+    fetch_browser_login_token = AsyncMock()
+    monkeypatch.setattr(env, "_fetch_browser_login_token", fetch_browser_login_token)
+
+    browser_window_id = await env._wait_for_browser_window_id_with_lazy_login(
+        page,
+        BrowserConfig(interactive=False),
+        "https://app.narada.ai/initialize?t=window-tag",
+    )
+
+    assert browser_window_id == "browser-window-123"
+    fetch_browser_login_token.assert_not_awaited()
+    page.goto.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_browser_environment_fetches_login_token_after_unauthenticated_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import narada.environment as environment_module
+
+    wait_for_browser_window_id = AsyncMock(
+        side_effect=[
+            NaradaExtensionUnauthenticatedError(
+                "Sign in to the Narada extension first"
+            ),
+            "browser-window-123",
+        ]
+    )
+    monkeypatch.setattr(
+        environment_module._BrowserInitializationHelper,
+        "wait_for_browser_window_id_silently",
+        wait_for_browser_window_id,
+    )
+
+    page = AsyncMock()
+    env = BrowserEnvironment(
+        auth_headers={"x-api-key": "test-key"},
+        config=BrowserConfig(interactive=False),
+    )
+    fetch_browser_login_token = AsyncMock(return_value="custom token")
+    monkeypatch.setattr(env, "_fetch_browser_login_token", fetch_browser_login_token)
+
+    browser_window_id = await env._wait_for_browser_window_id_with_lazy_login(
+        page,
+        BrowserConfig(interactive=False),
+        "https://app.narada.ai/initialize?t=window-tag",
+    )
+
+    assert browser_window_id == "browser-window-123"
+    fetch_browser_login_token.assert_awaited_once()
+    page.goto.assert_awaited_once_with(
+        "https://app.narada.ai/initialize?t=window-tag&customToken=custom+token",
+        timeout=15_000,
+        wait_until="domcontentloaded",
+    )

--- a/packages/narada/tests/test_cloud_browser.py
+++ b/packages/narada/tests/test_cloud_browser.py
@@ -257,7 +257,9 @@ async def test_cloud_browser_environment_uses_domcontentloaded_for_login_navigat
     env = _build_cloud_environment_with_page(page)
 
     wait_for_browser_window_id = AsyncMock(return_value="browser-window-123")
-    monkeypatch.setattr(env, "_wait_for_browser_window_id", wait_for_browser_window_id)
+    monkeypatch.setattr(
+        env, "_wait_for_cloud_browser_window_id", wait_for_browser_window_id
+    )
 
     await env._initialize_cloud_browser_window(
         cdp_websocket_url="wss://agentcore.example.test/session-123",
@@ -293,7 +295,9 @@ async def test_cloud_browser_environment_uses_domcontentloaded_for_retry_navigat
             "browser-window-123",
         ]
     )
-    monkeypatch.setattr(env, "_wait_for_browser_window_id", wait_for_browser_window_id)
+    monkeypatch.setattr(
+        env, "_wait_for_cloud_browser_window_id", wait_for_browser_window_id
+    )
 
     await env._initialize_cloud_browser_window(
         cdp_websocket_url="wss://agentcore.example.test/session-123",


### PR DESCRIPTION
## Summary
- lazily fetch `/auth/custom-token` when local BrowserEnvironment initialization detects an unauthenticated extension
- retry `/initialize` with `customToken` so the browser signs in with SDK credentials
- add focused tests for authenticated and unauthenticated initialization paths

## Companion branches
- frontend: `codex/sdk-browser-auto-login` (not opened as PR)
- caddie: `codex/sdk-browser-auto-login` (not opened as PR)
- architecture-docs: `codex/sdk-browser-auto-login-docs` (not opened as PR)

## Tests
- `uv run pytest packages/narada/tests`
- `uv run ruff format --check packages/narada/src/narada/environment.py packages/narada/tests/test_browser_environment_login.py`