### PR TITLE
[Narada Code 1] Add workbench trace materialization verifier spine

### DIFF
--- a/packages/narada-core/pyproject.toml
+++ b/packages/narada-core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "narada-core"
-version = "0.1.0"
+version = "0.1.1"
 description = "Code shared by the `narada` and `narada-pyodide` packages."
 license = "Apache-2.0"
 readme = "README.md"

--- a/packages/narada-core/src/narada_core/actions/models.py
+++ b/packages/narada-core/src/narada_core/actions/models.py
@@ -67,6 +67,7 @@ class AgentResponse(BaseModel, Generic[_StructuredOutputT]):
     execution_trace_context: dict[str, Any] | None = Field(
         default=None, alias="executionTraceContext"
     )
+    execution_trace_path: str | None = None
 
 
 class AgenticSelectorClickAction(TypedDict):

--- a/packages/narada-core/src/narada_core/execution_trace.py
+++ b/packages/narada-core/src/narada_core/execution_trace.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict
+
+
+class ExecutionTraceContext(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    type: Literal["executionTraceContext"] = "executionTraceContext"
+    schemaVersion: int = 1
+    label: str
+    traceId: str
+    segmentId: str | None = None
+    segmentKind: str | None = None
+    executionTraceS3Key: str
+    executionTraceSegmentS3Key: str | None = None
+    rootExecutionTraceS3Key: str | None = None
+    status: str | None = None
+    summary: dict[str, Any] | None = None

--- a/packages/narada-pyodide/pyproject.toml
+++ b/packages/narada-pyodide/pyproject.toml
@@ -1,14 +1,14 @@
 
 [project]
 name = "narada-pyodide"
-version = "0.1.0"
+version = "0.1.1"
 description = "Pyodide-compatible Python client SDK for Narada"
 license = "Apache-2.0"
 readme = "README.md"
 authors = [{ name = "Narada", email = "support@narada.ai" }]
 requires-python = ">=3.12"
 dependencies = [
-    "narada-core==0.1.0",
+    "narada-core==0.1.1",
     # Must be a supported version in https://pyodide.org/en/stable/usage/packages-in-pyodide.html
     "packaging==24.2",
 ]

--- a/packages/narada-pyodide/src/narada/agent.py
+++ b/packages/narada-pyodide/src/narada/agent.py
@@ -188,6 +188,7 @@ class Agent(Generic[_StructuredOutput]):
             else None
         )
         workflow_trace = response_content.get("workflowTrace")
+        execution_trace_context = response_content.get("executionTraceContext")
         parent_request_id = self.environment._current_parent_request_id()
         # Preserve the response contract for direct callers, but avoid adding a second
         # child node when the backend will stitch the child request into the parent row.
@@ -216,6 +217,7 @@ class Agent(Generic[_StructuredOutput]):
             action_trace=action_trace,
             workflow_trace=workflow_trace,
             critic_result=critic_result,
+            execution_trace_context=execution_trace_context,
         )
 
     async def _dispatch_request(

--- a/packages/narada-pyodide/src/narada/environment.py
+++ b/packages/narada-pyodide/src/narada/environment.py
@@ -87,6 +87,14 @@ def _parent_request_id() -> str | None:
     return parent_request_id if isinstance(parent_request_id, str) else None
 
 
+def _remote_dispatch_request_id() -> str | None:
+    request_id = os.environ.get(_REMOTE_DISPATCH_REQUEST_ID_ENV_VAR)
+    if request_id is None:
+        return None
+    request_id = request_id.strip()
+    return request_id or None
+
+
 def _load_execution_trace_context_from_env() -> dict[str, Any] | None:
     raw = os.environ.get("NARADA_EXECUTION_TRACE_CONTEXT")
     if not raw:
@@ -581,7 +589,12 @@ class Environment(ABC):
         parent_run_ids = self._current_parent_run_ids()
         if parent_run_ids:
             body["parentRunIds"] = parent_run_ids
-        parent_request_id = self._current_parent_request_id()
+        # Backend parentRequestId has a stricter contract than the worker's
+        # `_narada_request_id`: it must identify a live remote-dispatch request
+        # owned by the caller. The frontend injects that value explicitly when a
+        # Python APA is running under remote dispatch; otherwise omit it and
+        # rely on parentRunIds/executionTraceContext for local runnable linkage.
+        parent_request_id = _remote_dispatch_request_id()
         if parent_request_id is not None:
             body["parentRequestId"] = parent_request_id
         execution_trace_context = _load_execution_trace_context_from_env()

--- a/packages/narada-pyodide/tests/test_cloud_browser.py
+++ b/packages/narada-pyodide/tests/test_cloud_browser.py
@@ -402,7 +402,7 @@ async def test_dispatch_request_waits_through_active_input_required(
 
 
 @pytest.mark.asyncio
-async def test_agent_run_keeps_parent_request_id_from_injected_builtins(
+async def test_agent_run_does_not_forward_python_worker_request_as_parent_request_id(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     pyfetch = AsyncMock(
@@ -439,7 +439,7 @@ async def test_agent_run_keeps_parent_request_id_from_injected_builtins(
 
     assert response.status == "success"
     payload = json.loads(pyfetch.await_args_list[0].kwargs["body"])
-    assert payload["parentRequestId"] == "parent-request-123"
+    assert "parentRequestId" not in payload
 
 
 @pytest.mark.asyncio
@@ -481,6 +481,12 @@ async def test_agent_run_exposes_workflow_trace_alias(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     workflow_trace = {"step_type": "workflow", "children": []}
+    execution_trace_context = {
+        "type": "executionTraceContext",
+        "label": "Trace",
+        "traceId": "trace-1",
+        "executionTraceS3Key": "user-test/recording-trace-1/execution-trace/index.json",
+    }
     pyfetch = AsyncMock(
         side_effect=[
             _FakeResponse(json_data={"requestId": "child-request-123"}),
@@ -491,6 +497,7 @@ async def test_agent_run_exposes_workflow_trace_alias(
                         "text": "done",
                         "output": {"type": "text", "content": "done"},
                         "workflowTrace": workflow_trace,
+                        "executionTraceContext": execution_trace_context,
                     },
                     "completedAt": "2026-05-08T00:00:00+00:00",
                     "usage": {"actions": 0, "credits": 0},
@@ -516,7 +523,9 @@ async def test_agent_run_exposes_workflow_trace_alias(
     response = await narada_pkg.Agent(environment=env).run("return a trace")
 
     assert response.workflow_trace == workflow_trace
+    assert response.execution_trace_context == execution_trace_context
     assert response.model_dump(by_alias=True)["workflowTrace"] == workflow_trace
+    assert response.model_dump(by_alias=True)["executionTraceContext"] == execution_trace_context
     sub_workflow_events = [
         json.loads(event)
         for event in emitted_events
@@ -1014,6 +1023,94 @@ async def test_extension_action_includes_remote_dispatch_context(
     assert payload["requestId"] == "request-123"
     assert payload["apiKeyId"] == "api-key-123"
     assert payload["actionExecutionId"].startswith("action_")
+
+
+@pytest.mark.asyncio
+async def test_agent_run_uses_remote_dispatch_request_as_parent_request_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("NARADA_BROWSER_WINDOW_ID", "browser-window-123")
+    monkeypatch.setenv("NARADA_USER_ID", "user-123")
+    monkeypatch.setenv("NARADA_ENV", "dev")
+    monkeypatch.setenv("NARADA_REMOTE_DISPATCH_REQUEST_ID", "remote-parent-123")
+    pyfetch = AsyncMock(
+        side_effect=[
+            _sdk_config_response(),
+            _FakeResponse(json_data={"requestId": "child-request-123"}),
+            _FakeResponse(
+                json_data={
+                    "status": "success",
+                    "completedAt": "2026-06-08T00:00:00Z",
+                    "response": {
+                        "text": "done",
+                        "output": {"type": "text", "content": "done"},
+                    },
+                    "usage": {"actions": 0, "credits": 0},
+                    "activeInputRequest": None,
+                }
+            ),
+        ]
+    )
+    narada_pkg, env_module = _import_pyodide_narada(monkeypatch, pyfetch=pyfetch)
+    env_module._narada_parent_run_ids = _FakeJsProxy(["run-parent"])
+    env_module._narada_request_id = "python-worker-request"
+    monkeypatch.setattr(
+        builtins, "_narada_request_id", "python-worker-request", raising=False
+    )
+
+    response = await narada_pkg.Agent(
+        environment=narada_pkg.BrowserEnvironment()
+    ).run("child task")
+
+    assert response.text == "done"
+    dispatch_call = pyfetch.await_args_list[1]
+    payload = json.loads(dispatch_call.kwargs["body"])
+    assert payload["parentRequestId"] == "remote-parent-123"
+    assert payload["parentRunIds"] == ["run-parent"]
+
+
+@pytest.mark.asyncio
+async def test_agent_run_does_not_use_python_worker_request_as_parent_request_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("NARADA_BROWSER_WINDOW_ID", "browser-window-123")
+    monkeypatch.setenv("NARADA_USER_ID", "user-123")
+    monkeypatch.setenv("NARADA_ENV", "dev")
+    monkeypatch.delenv("NARADA_REMOTE_DISPATCH_REQUEST_ID", raising=False)
+    pyfetch = AsyncMock(
+        side_effect=[
+            _sdk_config_response(),
+            _FakeResponse(json_data={"requestId": "child-request-123"}),
+            _FakeResponse(
+                json_data={
+                    "status": "success",
+                    "completedAt": "2026-06-08T00:00:00Z",
+                    "response": {
+                        "text": "done",
+                        "output": {"type": "text", "content": "done"},
+                    },
+                    "usage": {"actions": 0, "credits": 0},
+                    "activeInputRequest": None,
+                }
+            ),
+        ]
+    )
+    narada_pkg, env_module = _import_pyodide_narada(monkeypatch, pyfetch=pyfetch)
+    env_module._narada_parent_run_ids = _FakeJsProxy(["run-parent"])
+    env_module._narada_request_id = "python-worker-request"
+    monkeypatch.setattr(
+        builtins, "_narada_request_id", "python-worker-request", raising=False
+    )
+
+    response = await narada_pkg.Agent(
+        environment=narada_pkg.BrowserEnvironment()
+    ).run("child task")
+
+    assert response.text == "done"
+    dispatch_call = pyfetch.await_args_list[1]
+    payload = json.loads(dispatch_call.kwargs["body"])
+    assert "parentRequestId" not in payload
+    assert payload["parentRunIds"] == ["run-parent"]
 
 
 @pytest.mark.asyncio

--- a/packages/narada-pyodide/tests/test_cloud_browser.py
+++ b/packages/narada-pyodide/tests/test_cloud_browser.py
@@ -525,7 +525,10 @@ async def test_agent_run_exposes_workflow_trace_alias(
     assert response.workflow_trace == workflow_trace
     assert response.execution_trace_context == execution_trace_context
     assert response.model_dump(by_alias=True)["workflowTrace"] == workflow_trace
-    assert response.model_dump(by_alias=True)["executionTraceContext"] == execution_trace_context
+    assert (
+        response.model_dump(by_alias=True)["executionTraceContext"]
+        == execution_trace_context
+    )
     sub_workflow_events = [
         json.loads(event)
         for event in emitted_events
@@ -1058,9 +1061,9 @@ async def test_agent_run_uses_remote_dispatch_request_as_parent_request_id(
         builtins, "_narada_request_id", "python-worker-request", raising=False
     )
 
-    response = await narada_pkg.Agent(
-        environment=narada_pkg.BrowserEnvironment()
-    ).run("child task")
+    response = await narada_pkg.Agent(environment=narada_pkg.BrowserEnvironment()).run(
+        "child task"
+    )
 
     assert response.text == "done"
     dispatch_call = pyfetch.await_args_list[1]
@@ -1102,9 +1105,9 @@ async def test_agent_run_does_not_use_python_worker_request_as_parent_request_id
         builtins, "_narada_request_id", "python-worker-request", raising=False
     )
 
-    response = await narada_pkg.Agent(
-        environment=narada_pkg.BrowserEnvironment()
-    ).run("child task")
+    response = await narada_pkg.Agent(environment=narada_pkg.BrowserEnvironment()).run(
+        "child task"
+    )
 
     assert response.text == "done"
     dispatch_call = pyfetch.await_args_list[1]

--- a/packages/narada/README.md
+++ b/packages/narada/README.md
@@ -92,7 +92,53 @@ This version introduces a non-backward-compatible, agent-centered API:
 - **Parallel Execution**: Run multiple browser tasks simultaneously across different windows
 - **Error Handling**: Built-in timeout handling and retry mechanisms
 - **Action Recording**: Generate GIFs of agent actions for debugging and documentation
+- **Trace Materialization**: Materialize returned execution traces into local proof roots for
+  debugging and validation
 - **Async Support**: Full async/await support for efficient operations
+
+## Workbench Trace Materialization
+
+When a Narada run returns an `executionTraceContext`, the SDK can materialize the trace into a local
+filesystem proof root:
+
+```python
+import asyncio
+
+from narada import Agent, BrowserEnvironment, trace
+
+
+async def main() -> None:
+    env = BrowserEnvironment()
+    try:
+        async with trace("workflow-v3", out="./narada-runs/workflow-v3") as tr:
+            response = await Agent(environment=env).run("/me/workflow-v3")
+            print(response.execution_trace_context)
+        print("Trace proof root:", tr.path)
+        print("Response trace path:", response.execution_trace_path)
+    finally:
+        await env.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
+```
+
+The CLI exposes the same materializer and verifier:
+
+```bash
+narada workbench trace materialize --request-id req_123 --out ./narada-runs/run-1
+narada workbench trace materialize --context-file context.json --source-status success --out ./narada-runs/run-1
+narada workbench score ./narada-runs/run-1 --json
+narada workbench verify ./narada-runs/run-1 --json
+```
+
+The materializer uses Narada's backend ownership checks and short-lived artifact URLs. It writes
+hash-linked local artifacts and redacted reports; it does not require local AWS credentials.
+`--request-id` is the preferred proof path because it binds the trace to the authoritative
+remote-dispatch run status. A raw context file can materialize trace artifacts, but it is not a
+clean run-success proof unless the caller provides explicit source-run status.
+For a one-off run, `await agent.run("/me/workflow-v3", trace=True)` materializes the returned
+trace immediately and sets `response.execution_trace_path` to the local proof root.
 
 ## Key Capabilities
 

--- a/packages/narada/pyproject.toml
+++ b/packages/narada/pyproject.toml
@@ -1,13 +1,13 @@
 [project]
 name = "narada"
-version = "0.2.0"
+version = "0.2.1"
 description = "Python client SDK for Narada"
 license = "Apache-2.0"
 readme = "README.md"
 authors = [{ name = "Narada", email = "support@narada.ai" }]
 requires-python = ">=3.12"
 dependencies = [
-    "narada-core==0.1.0",
+    "narada-core==0.1.1",
     "aiohttp>=3.12.13",
     "playwright>=1.53.0",
     "rich>=14.0.0",
@@ -18,6 +18,9 @@ dependencies = [
 Homepage = "https://github.com/NaradaAI/narada-python-sdk/narada"
 Repository = "https://github.com/NaradaAI/narada-python-sdk"
 Issues = "https://github.com/NaradaAI/narada-python-sdk/issues"
+
+[project.scripts]
+narada = "narada.cli:main"
 
 [build-system]
 requires = ["hatchling"]

--- a/packages/narada/src/narada/__init__.py
+++ b/packages/narada/src/narada/__init__.py
@@ -28,6 +28,7 @@ from narada.environment import (
     RemoteBrowserEnvironment,
     SessionDownloadItem,
 )
+from narada.tracing import TraceSession, trace
 from narada.utils import download_file, render_html
 from narada.version import __version__
 
@@ -59,5 +60,7 @@ __all__ = [
     "Response",
     "ResponseContent",
     "SessionDownloadItem",
+    "trace",
+    "TraceSession",
     "UserAbortedError",
 ]

--- a/packages/narada/src/narada/agent.py
+++ b/packages/narada/src/narada/agent.py
@@ -62,6 +62,8 @@ from narada.environment import (
     Environment,
     InputRequiredCallback,
 )
+from narada.tracing import get_active_trace_session
+from narada.workbench import materialize_execution_trace_context
 
 _StructuredOutput = TypeVar("_StructuredOutput", bound=BaseModel)
 
@@ -101,6 +103,7 @@ class Agent(Generic[_StructuredOutput]):
         callback_headers: Mapping[str, Any] | None = None,
         on_input_required: InputRequiredCallback | None = None,
         critic: CriticConfig | None = None,
+        trace: bool = False,
         timeout: int = 1000,
     ) -> AgentResponse[dict[str, Any]]: ...
 
@@ -127,6 +130,7 @@ class Agent(Generic[_StructuredOutput]):
         callback_headers: Mapping[str, Any] | None = None,
         on_input_required: InputRequiredCallback | None = None,
         critic: CriticConfig | None = None,
+        trace: bool = False,
         timeout: int = 1000,
     ) -> AgentResponse[_StructuredOutput]: ...
 
@@ -152,6 +156,7 @@ class Agent(Generic[_StructuredOutput]):
         callback_headers: Mapping[str, Any] | None = None,
         on_input_required: InputRequiredCallback | None = None,
         critic: CriticConfig | None = None,
+        trace: bool = False,
         timeout: int = 1000,
     ) -> AgentResponse:
         """Invokes an agent in the bound Narada environment."""
@@ -186,6 +191,7 @@ class Agent(Generic[_StructuredOutput]):
             else None
         )
         workflow_trace = response_content.get("workflowTrace")
+        execution_trace_context = response_content.get("executionTraceContext")
 
         critic_result: CriticResult | None = None
         if critic is not None:
@@ -199,7 +205,7 @@ class Agent(Generic[_StructuredOutput]):
                 timeout=timeout,
             )
 
-        return AgentResponse(
+        response = AgentResponse(
             request_id=remote_dispatch_response["requestId"],
             status=remote_dispatch_response["status"],
             text=response_content["text"],
@@ -209,7 +215,30 @@ class Agent(Generic[_StructuredOutput]):
             action_trace=action_trace,
             workflow_trace=workflow_trace,
             critic_result=critic_result,
+            execution_trace_context=execution_trace_context,
         )
+        active_trace_session = get_active_trace_session()
+        if trace and response.execution_trace_context is not None:
+            materialized = await materialize_execution_trace_context(
+                response.execution_trace_context,
+                label=f"agent-run-{response.request_id}",
+                source_run={
+                    "type": "remote-dispatch",
+                    "authority": "agent-run-response",
+                    "requestId": response.request_id,
+                    "status": response.status,
+                },
+                auth_headers=self.environment._auth_headers,
+                base_url=self.environment._base_url,
+            )
+            response.execution_trace_path = str(materialized.path)
+        elif active_trace_session is not None:
+            active_trace_session.register_response(
+                response,
+                auth_headers=self.environment._auth_headers,
+                base_url=self.environment._base_url,
+            )
+        return response
 
     async def _dispatch_request(
         self,

--- a/packages/narada/src/narada/cli.py
+++ b/packages/narada/src/narada/cli.py
@@ -34,7 +34,9 @@ def _load_context_file(path: Path) -> dict[str, Any]:
         raise ValueError("Context file must contain a JSON object")
     context = payload.get("executionTraceContext") or payload.get("context") or payload
     if not isinstance(context, dict):
-        raise ValueError("Context file must contain executionTraceContext or context object")
+        raise ValueError(
+            "Context file must contain executionTraceContext or context object"
+        )
     return context
 
 

--- a/packages/narada/src/narada/cli.py
+++ b/packages/narada/src/narada/cli.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from narada.workbench import (
+    default_api_base_url,
+    default_auth_headers,
+    materialize_execution_trace_context,
+    materialize_execution_trace_from_request_id,
+    score_proof_root,
+    verify_proof_root,
+)
+
+
+def _print(value: dict[str, Any], *, as_json: bool) -> None:
+    if as_json:
+        print(json.dumps(value, indent=2, sort_keys=True))
+        return
+    status = value.get("status", "unknown")
+    proof_root = value.get("proofRoot") or value.get("path")
+    print(f"status: {status}")
+    if proof_root:
+        print(f"proofRoot: {proof_root}")
+
+
+def _load_context_file(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("Context file must contain a JSON object")
+    context = payload.get("executionTraceContext") or payload.get("context") or payload
+    if not isinstance(context, dict):
+        raise ValueError("Context file must contain executionTraceContext or context object")
+    return context
+
+
+async def _trace_materialize(args: argparse.Namespace) -> int:
+    auth_headers = default_auth_headers()
+    base_url = args.base_url or default_api_base_url()
+    if args.context_file:
+        source_run = None
+        if args.source_status or args.source_request_id:
+            source_run = {
+                "type": args.source_type,
+                "authority": "caller-attested",
+                "status": args.source_status or "unknown",
+                "requestId": args.source_request_id,
+            }
+        result = await materialize_execution_trace_context(
+            _load_context_file(Path(args.context_file)),
+            out=args.out,
+            source_run=source_run,
+            auth_headers=auth_headers,
+            base_url=base_url,
+        )
+    else:
+        result = await materialize_execution_trace_from_request_id(
+            args.request_id,
+            out=args.out,
+            auth_headers=auth_headers,
+            base_url=base_url,
+        )
+    payload = {
+        "schemaVersion": 1,
+        "status": result.report["status"],
+        "path": str(result.path),
+        "proofRoot": str(result.path),
+        "artifactCount": result.report["artifactCount"],
+        "warnings": result.report["warnings"],
+    }
+    _print(payload, as_json=args.json)
+    return 0 if result.report["status"] in {"passed", "needs_review"} else 1
+
+
+def _score(args: argparse.Namespace) -> int:
+    result = score_proof_root(args.proof_root)
+    _print(result, as_json=args.json)
+    return 0 if result["status"] == "passed" else 1
+
+
+def _verify(args: argparse.Namespace) -> int:
+    result = verify_proof_root(args.proof_root)
+    _print(result, as_json=args.json)
+    return 0 if result["verified"] else 1
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="narada")
+    subparsers = parser.add_subparsers(dest="command")
+    workbench = subparsers.add_parser("workbench")
+    workbench_subparsers = workbench.add_subparsers(dest="workbench_command")
+
+    trace_parser = workbench_subparsers.add_parser("trace")
+    trace_subparsers = trace_parser.add_subparsers(dest="trace_command")
+    materialize = trace_subparsers.add_parser("materialize")
+    materialize_source = materialize.add_mutually_exclusive_group(required=True)
+    materialize_source.add_argument("--context-file")
+    materialize_source.add_argument("--request-id")
+    materialize.add_argument("--out")
+    materialize.add_argument("--base-url")
+    materialize.add_argument("--source-status")
+    materialize.add_argument("--source-request-id")
+    materialize.add_argument("--source-type", default="external")
+    materialize.add_argument("--json", action="store_true")
+    materialize.set_defaults(handler=lambda args: asyncio.run(_trace_materialize(args)))
+
+    score = workbench_subparsers.add_parser("score")
+    score.add_argument("proof_root")
+    score.add_argument("--json", action="store_true")
+    score.set_defaults(handler=_score)
+
+    verify = workbench_subparsers.add_parser("verify")
+    verify.add_argument("proof_root")
+    verify.add_argument("--json", action="store_true")
+    verify.set_defaults(handler=_verify)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    handler = getattr(args, "handler", None)
+    if handler is None:
+        parser.print_help()
+        return 2
+    try:
+        return int(handler(args))
+    except Exception as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packages/narada/src/narada/tracing.py
+++ b/packages/narada/src/narada/tracing.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from contextvars import ContextVar, Token
+from pathlib import Path
+from types import TracebackType
+from typing import Any
+
+from narada_core.actions.models import AgentResponse
+
+from narada.workbench import MaterializedTrace, materialize_execution_trace_context
+
+_ACTIVE_TRACE_SESSION: ContextVar[TraceSession | None] = ContextVar(
+    "narada_active_trace_session",
+    default=None,
+)
+
+
+class TraceSession:
+    def __init__(self, label: str, *, out: str | Path | None = None) -> None:
+        self.label = label
+        self.out = Path(out) if out is not None else None
+        self.paths: list[Path] = []
+        self.path: Path | None = None
+        self._responses: list[tuple[AgentResponse[Any], dict[str, str], str]] = []
+        self._token: Token[TraceSession | None] | None = None
+
+    async def __aenter__(self) -> TraceSession:
+        self._token = _ACTIVE_TRACE_SESSION.set(self)
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        del exc, tb
+        try:
+            try:
+                await self.materialize()
+            except Exception:
+                if exc_type is None:
+                    raise
+        finally:
+            if self._token is not None:
+                _ACTIVE_TRACE_SESSION.reset(self._token)
+                self._token = None
+
+    def register_response(
+        self,
+        response: AgentResponse[Any],
+        *,
+        auth_headers: dict[str, str],
+        base_url: str,
+    ) -> None:
+        if response.execution_trace_context is None:
+            return
+        self._responses.append((response, dict(auth_headers), base_url))
+
+    async def materialize(self) -> list[MaterializedTrace]:
+        results: list[MaterializedTrace] = []
+        for index, (response, auth_headers, base_url) in enumerate(
+            self._responses,
+            start=1,
+        ):
+            if response.execution_trace_context is None:
+                continue
+            if self.out is None:
+                out = None
+            elif len(self._responses) == 1:
+                out = self.out
+            else:
+                out = self.out / f"run-{index}-{response.request_id}"
+            result = await materialize_execution_trace_context(
+                response.execution_trace_context,
+                out=out,
+                label=f"{self.label}-{response.request_id}",
+                source_run={
+                    "type": "remote-dispatch",
+                    "authority": "agent-run-response",
+                    "requestId": response.request_id,
+                    "status": response.status,
+                },
+                auth_headers=auth_headers,
+                base_url=base_url,
+            )
+            response.execution_trace_path = str(result.path)
+            results.append(result)
+            self.paths.append(result.path)
+        self.path = results[-1].path if results else None
+        return results
+
+
+def trace(label: str, *, out: str | Path | None = None) -> TraceSession:
+    return TraceSession(label, out=out)
+
+
+def get_active_trace_session() -> TraceSession | None:
+    return _ACTIVE_TRACE_SESSION.get()

--- a/packages/narada/src/narada/workbench.py
+++ b/packages/narada/src/narada/workbench.py
@@ -1,0 +1,922 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import uuid
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Callable, Iterable
+from urllib.parse import urlsplit, urlunsplit
+
+import aiohttp
+from narada_core.execution_trace import ExecutionTraceContext
+
+DEFAULT_API_BASE_URL = "https://api.narada.ai/fast/v2"
+
+_SIGNED_URL_PATTERNS = (
+    "x-amz-signature",
+    "x-amz-credential",
+    "x-amz-security-token",
+    "awsaccesskeyid",
+)
+_SECRET_PATTERNS = (
+    re.compile(r"Authorization:\s*Bearer\s+\S+", re.IGNORECASE),
+    re.compile(r'"authorization"\s*:\s*"Bearer\s+[^"]+"', re.IGNORECASE),
+    re.compile(r"x-api-key\s*[:=]\s*['\"]?[^'\"\s,}]+", re.IGNORECASE),
+    re.compile(r"NARADA_API_KEY\s*=\s*['\"]?[^'\"\s,}]+", re.IGNORECASE),
+    re.compile(r"callbackSecret\s*[:=]\s*['\"]?[^'\"\s,}]+", re.IGNORECASE),
+    re.compile(r"secretVariables\s*[:=]", re.IGNORECASE),
+    re.compile(r"NARADA_TEST_SECRET_SHOULD_FAIL"),
+    re.compile(r"\bsk-[A-Za-z0-9_-]{16,}\b"),
+    re.compile(r"\bAKIA[0-9A-Z]{16}\b"),
+)
+_SELF_REVIEW_PATTERNS = (
+    re.compile(r"workflowSelfApproved", re.IGNORECASE),
+    re.compile(r"manual_review_accepted_by_workflow", re.IGNORECASE),
+    re.compile(r"self_review_accepted", re.IGNORECASE),
+    re.compile(r"approvedBy[\"'\s:=]+workflow", re.IGNORECASE),
+    re.compile(r"reviewStatus[\"'\s:=]+accepted", re.IGNORECASE),
+    re.compile(r"manualReview[\"'\s:=]+pass", re.IGNORECASE),
+)
+_STATIC_ANSWER_PATTERNS = (
+    re.compile(r"\bVALUE_RULES\b"),
+    re.compile(r"\bSTATUS_FACTS\b"),
+    re.compile(r"\bPRICE_FACTS\b"),
+    re.compile(r"\bANSWER_MAP\b"),
+    re.compile(r"source-facts\.json"),
+    re.compile(r"source-inventory\.json"),
+)
+_FAILED_STATUSES = (
+    "failed",
+    "failure",
+    "error",
+    "errored",
+    "aborted",
+    "cancelled",
+    "canceled",
+    "timeout",
+    "timed_out",
+)
+_SUCCESS_STATUSES = (
+    "success",
+    "succeeded",
+    "completed",
+    "complete",
+    "passed",
+)
+_NON_TERMINAL_STATUSES = (
+    "input-required",
+    "input_required",
+    "pending",
+    "queued",
+    "running",
+    "in-progress",
+    "in_progress",
+)
+_CLEAN_SOURCE_AUTHORITIES = (
+    "remote-dispatch-response-api",
+    "agent-run-response",
+)
+_CLEAN_COMMAND_STATUSES = (
+    "passed",
+    "materialized",
+    "not_applicable",
+)
+
+
+@dataclass(frozen=True)
+class MaterializedTrace:
+    path: Path
+    manifest: dict[str, Any]
+    report: dict[str, Any]
+
+
+def default_auth_headers() -> dict[str, str]:
+    api_key = os.getenv("NARADA_API_KEY")
+    return {"x-api-key": api_key} if api_key else {}
+
+
+def default_api_base_url() -> str:
+    return os.getenv("NARADA_API_BASE_URL", DEFAULT_API_BASE_URL)
+
+
+def _now_iso() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _safe_slug(value: str) -> str:
+    cleaned = re.sub(r"[^A-Za-z0-9._-]+", "-", value).strip("-._")
+    return cleaned[:80] or "trace"
+
+
+def _default_out_dir(label: str) -> Path:
+    timestamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+    return Path(".narada") / "workbench-runs" / f"{timestamp}-{_safe_slug(label)}"
+
+
+def _write_json(path: Path, value: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _write_jsonl(path: Path, rows: Iterable[Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "".join(json.dumps(row, sort_keys=True) + "\n" for row in rows),
+        encoding="utf-8",
+    )
+
+
+def _sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _sha256_file(path: Path) -> str:
+    return _sha256_bytes(path.read_bytes())
+
+
+def _sha256_json(value: Any) -> str:
+    encoded = json.dumps(value, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return _sha256_bytes(encoded)
+
+
+def _relative(path: Path, root: Path) -> str:
+    return path.relative_to(root).as_posix()
+
+
+def _redact_url(value: str) -> str:
+    split = urlsplit(value)
+    if not split.query:
+        return value
+    return urlunsplit((split.scheme, split.netloc, split.path, "", ""))
+
+
+def _frame_dir(root: Path, frame: dict[str, Any], index: int) -> Path:
+    frame_id = str(frame.get("frameId") or f"frame_{index}")
+    return root / "trace" / "frames" / _safe_slug(frame_id)
+
+
+def _is_failed_status(value: Any) -> bool:
+    return isinstance(value, str) and value.lower() in _FAILED_STATUSES
+
+
+def _is_unknown_status(value: Any) -> bool:
+    return not isinstance(value, str) or not value or value.lower() == "unknown"
+
+
+def _is_success_status(value: Any) -> bool:
+    return isinstance(value, str) and value.lower() in _SUCCESS_STATUSES
+
+
+def _is_non_terminal_status(value: Any) -> bool:
+    return isinstance(value, str) and value.lower() in _NON_TERMINAL_STATUSES
+
+
+def _is_clean_source_authority(value: Any) -> bool:
+    return isinstance(value, str) and value in _CLEAN_SOURCE_AUTHORITIES
+
+
+def _source_run_problems(source_run: dict[str, Any]) -> tuple[list[str], list[str]]:
+    failures: list[str] = []
+    taints: list[str] = []
+    source_status = source_run.get("status")
+    if _is_unknown_status(source_status):
+        taints.append("source_run_status_unknown")
+    elif _is_failed_status(source_status):
+        failures.append("source_run_failed")
+    elif _is_non_terminal_status(source_status):
+        failures.append("source_run_not_terminal")
+    elif not _is_success_status(source_status):
+        taints.append("source_run_status_unrecognized")
+
+    authority = source_run.get("authority")
+    if not _is_clean_source_authority(authority):
+        taints.append("source_run_authority_unverified")
+    return failures, taints
+
+
+def _collect_artifact_keys_from_artifacts(artifacts: dict[str, Any]) -> set[str]:
+    keys: set[str] = set()
+    for name, value in artifacts.items():
+        if name.endswith("S3Key") and isinstance(value, str) and value:
+            keys.add(value)
+        elif name.endswith("S3Keys") and isinstance(value, list):
+            keys.update(item for item in value if isinstance(item, str) and item)
+    return keys
+
+
+def _collect_resolved_trace_artifact_keys(
+    context: dict[str, Any],
+    resolved_trace: dict[str, Any],
+) -> set[str]:
+    keys = {
+        value
+        for key in (
+            "executionTraceS3Key",
+            "executionTraceSegmentS3Key",
+            "rootExecutionTraceS3Key",
+        )
+        if isinstance((value := context.get(key)), str) and value
+    }
+    manifest = resolved_trace.get("manifest")
+    if isinstance(manifest, dict):
+        artifacts = manifest.get("artifacts")
+        if isinstance(artifacts, dict):
+            keys.update(_collect_artifact_keys_from_artifacts(artifacts))
+        for segment in manifest.get("segments") or []:
+            if isinstance(segment, dict) and isinstance(segment.get("indexS3Key"), str):
+                keys.add(segment["indexS3Key"])
+    for segment_manifest in resolved_trace.get("segments") or []:
+        if not isinstance(segment_manifest, dict):
+            continue
+        artifacts = segment_manifest.get("artifacts")
+        if isinstance(artifacts, dict):
+            keys.update(_collect_artifact_keys_from_artifacts(artifacts))
+        for segment in segment_manifest.get("segments") or []:
+            if isinstance(segment, dict) and isinstance(segment.get("indexS3Key"), str):
+                keys.add(segment["indexS3Key"])
+    for frame in resolved_trace.get("frames") or []:
+        if not isinstance(frame, dict):
+            continue
+        for key in ("frameS3Key", "htmlS3Key", "screenshotS3Key"):
+            value = frame.get(key)
+            if isinstance(value, str) and value:
+                keys.add(value)
+    return keys
+
+
+async def _fetch_json(
+    url: str,
+    *,
+    method: str = "GET",
+    auth_headers: dict[str, str] | None = None,
+    json_body: dict[str, Any] | None = None,
+    session_factory: Callable[[], Any] = aiohttp.ClientSession,
+) -> dict[str, Any]:
+    async with session_factory() as session:
+        request = session.post if method.upper() == "POST" else session.get
+        kwargs: dict[str, Any] = {"headers": auth_headers or {}}
+        if json_body is not None:
+            kwargs["json"] = json_body
+        async with request(url, **kwargs) as response:
+            response.raise_for_status()
+            payload = await response.json()
+    if not isinstance(payload, dict):
+        raise ValueError(f"Expected JSON object from {url}")
+    return payload
+
+
+async def _download_bytes(
+    url: str,
+    *,
+    session_factory: Callable[[], Any] = aiohttp.ClientSession,
+) -> bytes:
+    async with session_factory() as session:
+        async with session.get(url) as response:
+            response.raise_for_status()
+            return await response.read()
+
+
+async def resolve_execution_trace(
+    context: dict[str, Any],
+    *,
+    auth_headers: dict[str, str] | None = None,
+    base_url: str | None = None,
+    session_factory: Callable[[], Any] = aiohttp.ClientSession,
+) -> dict[str, Any]:
+    validated = ExecutionTraceContext.model_validate(context)
+    return await _fetch_json(
+        f"{base_url or default_api_base_url()}/execution-trace/resolve",
+        method="POST",
+        auth_headers=auth_headers if auth_headers is not None else default_auth_headers(),
+        json_body={"executionTraceContext": validated.model_dump(mode="json")},
+        session_factory=session_factory,
+    )
+
+
+async def materialize_execution_trace_context(
+    context: dict[str, Any],
+    *,
+    out: str | Path | None = None,
+    label: str | None = None,
+    source_run: dict[str, Any] | None = None,
+    auth_headers: dict[str, str] | None = None,
+    base_url: str | None = None,
+    session_factory: Callable[[], Any] = aiohttp.ClientSession,
+) -> MaterializedTrace:
+    validated = ExecutionTraceContext.model_validate(context)
+    proof_root = Path(out) if out is not None else _default_out_dir(label or validated.label)
+    preexisting_root = proof_root.exists() and any(proof_root.iterdir())
+    proof_root.mkdir(parents=True, exist_ok=True)
+    (proof_root / "cleanup").mkdir(parents=True, exist_ok=True)
+    taints = ["proof_root_preexisting"] if preexisting_root else []
+    failures: list[str] = []
+    if source_run is None:
+        source_run = {"type": "unknown", "status": "unknown"}
+        taints.append("source_run_status_unknown")
+        taints.append("source_run_authority_unverified")
+    else:
+        source_failures, source_taints = _source_run_problems(source_run)
+        failures.extend(source_failures)
+        taints.extend(source_taints)
+
+    resolved_response = await resolve_execution_trace(
+        validated.model_dump(mode="json"),
+        auth_headers=auth_headers,
+        base_url=base_url,
+        session_factory=session_factory,
+    )
+    resolved_trace = resolved_response["resolvedTrace"]
+    artifacts = resolved_response.get("artifacts") or []
+    if not isinstance(artifacts, list):
+        raise ValueError("execution-trace resolve response artifacts must be a list")
+
+    trace_root = proof_root / "trace"
+    _write_json(trace_root / "context.json", validated.model_dump(mode="json"))
+    _write_json(trace_root / "resolved.json", resolved_trace)
+    _write_jsonl(trace_root / "events.jsonl", resolved_trace.get("events") or [])
+    _write_jsonl(trace_root / "scopes.jsonl", resolved_trace.get("scopes") or [])
+    _write_json(trace_root / "timeline.json", resolved_trace.get("timeline_index") or {})
+
+    frames = resolved_trace.get("frames") or []
+    if isinstance(frames, list):
+        for index, frame in enumerate(frames, start=1):
+            if isinstance(frame, dict):
+                _write_json(_frame_dir(proof_root, frame, index) / "frame.json", frame)
+
+    artifact_rows: list[dict[str, Any]] = []
+    warnings: list[str] = []
+    role_counts: dict[str, int] = {}
+    frames_by_id = {
+        str(frame.get("frameId")): frame
+        for frame in frames
+        if isinstance(frame, dict) and frame.get("frameId")
+    }
+
+    for artifact in artifacts:
+        if not isinstance(artifact, dict):
+            warnings.append("Skipping non-object artifact ref")
+            continue
+        role = str(artifact.get("role") or "artifact")
+        source_key = str(artifact.get("s3Key") or "")
+        download_url = str(artifact.get("downloadUrl") or "")
+        if not source_key or not download_url:
+            warnings.append(f"Skipping incomplete artifact ref for role {role}")
+            continue
+        role_counts[role] = role_counts.get(role, 0) + 1
+        frame_id = artifact.get("frameId")
+        frame = frames_by_id.get(str(frame_id)) if frame_id else None
+
+        if role in {"html", "screenshot", "frame"} and isinstance(frame, dict):
+            target_dir = _frame_dir(proof_root, frame, role_counts[role])
+            filename = {
+                "html": "page.html",
+                "screenshot": "screenshot.png",
+                "frame": "frame.json",
+            }[role]
+            local_path = target_dir / filename
+        else:
+            extension = {
+                "manifest": ".json",
+                "events": ".jsonl",
+                "scopes": ".jsonl",
+                "timeline": ".json",
+                "html": ".html",
+                "screenshot": ".png",
+                "frame": ".json",
+            }.get(role, ".bin")
+            local_path = trace_root / "artifacts" / f"{role}_{role_counts[role]}{extension}"
+
+        data = await _download_bytes(download_url, session_factory=session_factory)
+        local_path.parent.mkdir(parents=True, exist_ok=True)
+        local_path.write_bytes(data)
+        artifact_rows.append(
+            {
+                "role": role,
+                "sourceS3Key": source_key,
+                "localPath": _relative(local_path, proof_root),
+                "sha256": _sha256_bytes(data),
+                "bytes": len(data),
+                "contentType": artifact.get("contentType"),
+                "sensitive": bool(artifact.get("sensitive", True)),
+                "frameId": artifact.get("frameId"),
+                "label": artifact.get("label"),
+                "redactedDownloadUrl": _redact_url(download_url),
+            }
+        )
+
+    _write_jsonl(trace_root / "artifacts" / "index.jsonl", artifact_rows)
+
+    manifest = {
+        "schemaVersion": 1,
+        "runId": proof_root.name,
+        "label": label or validated.label,
+        "createdAt": _now_iso(),
+        "apiBaseUrl": base_url or default_api_base_url(),
+        "status": "tainted" if taints else "materialized",
+        "traceContext": validated.model_dump(mode="json"),
+        "traceId": validated.traceId,
+        "sourceRun": source_run,
+        "traceContextHash": _sha256_json(validated.model_dump(mode="json")),
+        "resolvedTraceHash": _sha256_json(resolved_trace),
+        "traceContextStatus": validated.status,
+        "traceManifestStatus": (resolved_trace.get("manifest") or {}).get("status")
+        if isinstance(resolved_trace.get("manifest"), dict)
+        else None,
+        "counts": {
+            "events": len(resolved_trace.get("events") or []),
+            "scopes": len(resolved_trace.get("scopes") or []),
+            "frames": len(frames) if isinstance(frames, list) else 0,
+            "artifacts": len(artifact_rows),
+        },
+        "sensitiveArtifacts": True,
+        "taints": taints,
+        "failures": failures,
+    }
+    _write_json(proof_root / "manifest.json", manifest)
+    _write_json(
+        proof_root / "cleanup" / "status.json",
+        {"status": "not_applicable", "reason": "trace materialization opened no environment"},
+    )
+    report = {
+        "schemaVersion": 1,
+        "status": "failed"
+        if failures
+        else ("tainted" if taints else ("passed" if not warnings else "needs_review")),
+        "proofRoot": str(proof_root),
+        "warnings": warnings,
+        "taints": taints,
+        "failures": failures,
+        "artifactCount": len(artifact_rows),
+    }
+    _write_json(proof_root / "reports" / "materialization-report.json", report)
+    (proof_root / "reports" / "materialization-report.md").write_text(
+        f"# Materialization Report\n\nStatus: {report['status']}\n\nArtifacts: {len(artifact_rows)}\n",
+        encoding="utf-8",
+    )
+    append_command(
+        proof_root,
+        command="trace.materialize",
+        status=report["status"],
+        artifacts=[
+            {"path": "trace/resolved.json", "role": "resolved-trace"},
+            {"path": "trace/artifacts/index.jsonl", "role": "artifact-index"},
+        ],
+        warnings=warnings,
+        taints=taints,
+        ids={
+            "traceId": validated.traceId,
+            "contextHash": manifest["traceContextHash"],
+            "resolvedTraceHash": manifest["resolvedTraceHash"],
+            "sourceRunStatus": source_run.get("status"),
+        },
+    )
+    return MaterializedTrace(path=proof_root, manifest=manifest, report=report)
+
+
+async def materialize_execution_trace_from_request_id(
+    request_id: str,
+    *,
+    out: str | Path | None = None,
+    auth_headers: dict[str, str] | None = None,
+    base_url: str | None = None,
+    session_factory: Callable[[], Any] = aiohttp.ClientSession,
+) -> MaterializedTrace:
+    resolved_base_url = base_url or default_api_base_url()
+    response = await _fetch_json(
+        f"{resolved_base_url}/remote-dispatch/responses/{request_id}",
+        auth_headers=auth_headers if auth_headers is not None else default_auth_headers(),
+        session_factory=session_factory,
+    )
+    response_content = response.get("response")
+    if not isinstance(response_content, dict):
+        raise ValueError(f"Remote dispatch response {request_id} has no response object")
+    context = response_content.get("executionTraceContext")
+    if not isinstance(context, dict):
+        raise ValueError(f"Remote dispatch response {request_id} has no executionTraceContext")
+    return await materialize_execution_trace_context(
+        context,
+        out=out,
+        label=f"request-{request_id}",
+        source_run={
+            "type": "remote-dispatch",
+            "authority": "remote-dispatch-response-api",
+            "requestId": request_id,
+            "status": response.get("status"),
+            "createdAt": response.get("createdAt"),
+            "completedAt": response.get("completedAt"),
+            "responseHash": _sha256_json(response),
+        },
+        auth_headers=auth_headers,
+        base_url=resolved_base_url,
+        session_factory=session_factory,
+    )
+
+
+def append_command(
+    proof_root: Path,
+    *,
+    command: str,
+    status: str,
+    artifacts: list[dict[str, Any]] | None = None,
+    warnings: list[str] | None = None,
+    taints: list[str] | None = None,
+    ids: dict[str, Any] | None = None,
+    inputs: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    now = _now_iso()
+    row = {
+        "schemaVersion": 1,
+        "commandId": f"cmd_{uuid.uuid4().hex}",
+        "runId": proof_root.name,
+        "command": command,
+        "status": status,
+        "startedAt": now,
+        "completedAt": now,
+        "ids": ids or {},
+        "inputs": inputs or {},
+        "artifacts": artifacts or [],
+        "warnings": warnings or [],
+        "taints": taints or [],
+    }
+    commands_path = proof_root / "commands.jsonl"
+    commands_path.parent.mkdir(parents=True, exist_ok=True)
+    with commands_path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(row, sort_keys=True) + "\n")
+    return row
+
+
+def _iter_text_files(root: Path) -> Iterable[Path]:
+    for path in root.rglob("*"):
+        if not path.is_file():
+            continue
+        if path.suffix.lower() in {".png", ".jpg", ".jpeg", ".gif", ".webp", ".pdf"}:
+            continue
+        yield path
+
+
+def _load_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _load_jsonl(path: Path) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if line.strip():
+            value = json.loads(line)
+            if isinstance(value, dict):
+                rows.append(value)
+    return rows
+
+
+def score_proof_root(proof_root: str | Path, *, write: bool = True) -> dict[str, Any]:
+    root = Path(proof_root)
+    failures: list[dict[str, Any]] = []
+    taints: list[dict[str, Any]] = []
+    warnings: list[dict[str, Any]] = []
+
+    required_files = [
+        "manifest.json",
+        "commands.jsonl",
+        "trace/context.json",
+        "trace/resolved.json",
+        "trace/events.jsonl",
+        "trace/scopes.jsonl",
+        "trace/timeline.json",
+        "trace/artifacts/index.jsonl",
+        "reports/materialization-report.json",
+        "cleanup/status.json",
+    ]
+    for relative_path in required_files:
+        if not (root / relative_path).exists():
+            failures.append({"code": "missing_required_file", "path": relative_path})
+
+    artifact_rows: list[dict[str, Any]] = []
+    manifest: dict[str, Any] | None = None
+    context: dict[str, Any] | None = None
+    resolved_trace: dict[str, Any] | None = None
+    expected_artifact_keys: set[str] = set()
+
+    manifest_path = root / "manifest.json"
+    context_path = root / "trace" / "context.json"
+    resolved_path = root / "trace" / "resolved.json"
+    if manifest_path.exists():
+        loaded = _load_json(manifest_path)
+        manifest = loaded if isinstance(loaded, dict) else None
+    if context_path.exists():
+        loaded = _load_json(context_path)
+        context = loaded if isinstance(loaded, dict) else None
+    if resolved_path.exists():
+        loaded = _load_json(resolved_path)
+        resolved_trace = loaded if isinstance(loaded, dict) else None
+
+    if manifest is None and manifest_path.exists():
+        failures.append({"code": "manifest_not_object"})
+    if context is None and context_path.exists():
+        failures.append({"code": "trace_context_not_object"})
+    if resolved_trace is None and resolved_path.exists():
+        failures.append({"code": "resolved_trace_not_object"})
+
+    if context is not None and resolved_trace is not None:
+        trace_id = context.get("traceId")
+        resolved_context = resolved_trace.get("context")
+        resolved_manifest = resolved_trace.get("manifest")
+        if isinstance(resolved_context, dict) and resolved_context.get("traceId") != trace_id:
+            failures.append({"code": "resolved_context_trace_id_mismatch"})
+        if isinstance(resolved_manifest, dict) and resolved_manifest.get("traceId") != trace_id:
+            failures.append({"code": "resolved_manifest_trace_id_mismatch"})
+        if not any(
+            isinstance(resolved_trace.get(name), list) and resolved_trace.get(name)
+            for name in ("events", "scopes", "frames")
+        ):
+            failures.append({"code": "empty_resolved_trace"})
+        for collection_name, id_name in (
+            ("events", "eventId"),
+            ("scopes", "scopeId"),
+            ("frames", "frameId"),
+        ):
+            rows = resolved_trace.get(collection_name)
+            if rows is None:
+                failures.append({"code": "resolved_collection_missing", "collection": collection_name})
+                continue
+            if not isinstance(rows, list):
+                failures.append({"code": "resolved_collection_not_list", "collection": collection_name})
+                continue
+            for row in rows:
+                if not isinstance(row, dict):
+                    failures.append({"code": "resolved_row_not_object", "collection": collection_name})
+                    continue
+                if row.get("traceId") != trace_id:
+                    failures.append(
+                        {
+                            "code": "resolved_row_trace_id_mismatch",
+                            "collection": collection_name,
+                            "rowId": row.get(id_name),
+                        }
+                    )
+        expected_artifact_keys = _collect_resolved_trace_artifact_keys(context, resolved_trace)
+
+    if manifest is not None:
+        manifest_context = manifest.get("traceContext")
+        source_run = manifest.get("sourceRun")
+        if not isinstance(source_run, dict):
+            failures.append({"code": "source_run_missing"})
+        else:
+            source_failures, source_taints = _source_run_problems(source_run)
+            for code in source_failures:
+                failures.append(
+                    {
+                        "code": code,
+                        "status": source_run.get("status"),
+                    }
+                )
+            for code in source_taints:
+                taints.append(
+                    {
+                        "code": code,
+                        "status": source_run.get("status"),
+                        "authority": source_run.get("authority"),
+                    }
+                )
+        if context is not None and manifest_context != context:
+            failures.append({"code": "manifest_context_mismatch"})
+        if context is not None and manifest.get("traceId") not in {None, context.get("traceId")}:
+            failures.append({"code": "manifest_trace_id_mismatch"})
+        if context is not None:
+            if not manifest.get("traceContextHash"):
+                failures.append({"code": "manifest_context_hash_missing"})
+            elif manifest.get("traceContextHash") != _sha256_json(context):
+                failures.append({"code": "manifest_context_hash_mismatch"})
+        if resolved_trace is not None:
+            if not manifest.get("resolvedTraceHash"):
+                failures.append({"code": "manifest_resolved_trace_hash_missing"})
+            elif manifest.get("resolvedTraceHash") != _sha256_json(resolved_trace):
+                failures.append({"code": "manifest_resolved_trace_hash_mismatch"})
+        for failure in manifest.get("failures") or []:
+            failures.append({"code": "manifest_failure", "failure": failure})
+        if manifest.get("status") == "tainted":
+            taints.append({"code": "manifest_tainted"})
+        for taint in manifest.get("taints") or []:
+            taints.append({"code": "manifest_taint", "taint": taint})
+        for status_field in ("traceContextStatus", "traceManifestStatus"):
+            if _is_failed_status(manifest.get(status_field)):
+                failures.append(
+                    {
+                        "code": "trace_status_failed",
+                        "field": status_field,
+                        "status": manifest.get(status_field),
+                    }
+                )
+    if context is not None and _is_failed_status(context.get("status")):
+        failures.append(
+            {
+                "code": "trace_status_failed",
+                "field": "context.status",
+                "status": context.get("status"),
+            }
+        )
+    if resolved_trace is not None:
+        resolved_manifest = resolved_trace.get("manifest")
+        if isinstance(resolved_manifest, dict) and _is_failed_status(
+            resolved_manifest.get("status")
+        ):
+            failures.append(
+                {
+                    "code": "trace_status_failed",
+                    "field": "resolved.manifest.status",
+                    "status": resolved_manifest.get("status"),
+                }
+            )
+
+    index_path = root / "trace" / "artifacts" / "index.jsonl"
+    if index_path.exists():
+        artifact_rows = _load_jsonl(index_path)
+        seen_artifact_keys: set[str] = set()
+        for row in artifact_rows:
+            local_path_value = row.get("localPath")
+            source_key = row.get("sourceS3Key")
+            if not isinstance(local_path_value, str) or not local_path_value:
+                failures.append({"code": "artifact_missing_local_path", "row": row})
+                continue
+            if not isinstance(source_key, str) or not source_key:
+                failures.append({"code": "artifact_missing_source_key", "path": local_path_value})
+            elif expected_artifact_keys and source_key not in expected_artifact_keys:
+                failures.append(
+                    {
+                        "code": "artifact_source_not_in_resolved_trace",
+                        "path": local_path_value,
+                        "sourceS3Key": source_key,
+                    }
+                )
+            elif source_key:
+                seen_artifact_keys.add(source_key)
+            if os.path.isabs(local_path_value):
+                failures.append({"code": "artifact_absolute_path", "path": local_path_value})
+            local_path = root / local_path_value
+            if not local_path.resolve().is_relative_to(root.resolve()):
+                failures.append({"code": "artifact_path_escape", "path": local_path_value})
+                continue
+            if not local_path.exists():
+                failures.append({"code": "artifact_file_missing", "path": local_path_value})
+                continue
+            expected_sha = row.get("sha256")
+            actual_sha = _sha256_file(local_path)
+            if expected_sha != actual_sha:
+                failures.append(
+                    {
+                        "code": "artifact_hash_mismatch",
+                        "path": local_path_value,
+                        "expected": expected_sha,
+                        "actual": actual_sha,
+                    }
+                )
+            if "downloadUrl" in row:
+                failures.append({"code": "signed_url_persisted", "path": local_path_value})
+        missing_artifact_keys = expected_artifact_keys - seen_artifact_keys
+        for source_key in sorted(missing_artifact_keys):
+            failures.append(
+                {
+                    "code": "resolved_artifact_not_downloaded",
+                    "sourceS3Key": source_key,
+                }
+            )
+
+    for text_path in _iter_text_files(root):
+        text = text_path.read_text(encoding="utf-8", errors="ignore")
+        text_lower = text.lower()
+        relative_path = _relative(text_path, root)
+        for marker in _SIGNED_URL_PATTERNS:
+            if marker in text_lower:
+                failures.append({"code": "signed_url_leak", "path": relative_path, "marker": marker})
+        for pattern in _SECRET_PATTERNS:
+            if pattern.search(text):
+                failures.append({"code": "secret_leak", "path": relative_path})
+        for pattern in _SELF_REVIEW_PATTERNS:
+            if pattern.search(text):
+                taints.append({"code": "workflow_self_review_marker", "path": relative_path})
+        for pattern in _STATIC_ANSWER_PATTERNS:
+            if pattern.search(text):
+                failures.append({"code": "static_answer_marker", "path": relative_path})
+
+    commands_path = root / "commands.jsonl"
+    if commands_path.exists():
+        command_rows = _load_jsonl(commands_path)
+        if not command_rows:
+            failures.append({"code": "empty_command_ledger"})
+        materialize_commands = [
+            row for row in command_rows if row.get("command") == "trace.materialize"
+        ]
+        if not materialize_commands:
+            failures.append({"code": "missing_materialize_command"})
+        for row in materialize_commands:
+            if row.get("status") not in _CLEAN_COMMAND_STATUSES:
+                continue
+            ids = row.get("ids")
+            if not isinstance(ids, dict):
+                failures.append({"code": "materialize_command_ids_missing"})
+                continue
+            if manifest is not None:
+                for field_name, manifest_field in (
+                    ("traceId", "traceId"),
+                    ("contextHash", "traceContextHash"),
+                    ("resolvedTraceHash", "resolvedTraceHash"),
+                ):
+                    if not ids.get(field_name):
+                        failures.append(
+                            {
+                                "code": "materialize_command_id_missing",
+                                "field": field_name,
+                            }
+                        )
+                    elif ids.get(field_name) != manifest.get(manifest_field):
+                        failures.append(
+                            {
+                                "code": "materialize_command_id_mismatch",
+                                "field": field_name,
+                            }
+                        )
+        for row in command_rows:
+            if not row.get("commandId"):
+                failures.append({"code": "command_missing_command_id", "command": row.get("command")})
+            if not row.get("runId"):
+                failures.append({"code": "command_missing_run_id", "command": row.get("command")})
+            row_status = row.get("status")
+            if row.get("command") == "trace.materialize" and row_status not in _CLEAN_COMMAND_STATUSES:
+                taints.append(
+                    {
+                        "code": "materialize_command_not_clean",
+                        "status": row_status,
+                    }
+                )
+            elif _is_failed_status(row_status):
+                taints.append({"code": "prior_command_failed", "status": row_status})
+            for taint in row.get("taints") or []:
+                taints.append({"code": "command_taint", "taint": taint})
+
+    cleanup_path = root / "cleanup" / "status.json"
+    if cleanup_path.exists():
+        cleanup = _load_json(cleanup_path)
+        if isinstance(cleanup, dict) and cleanup.get("status") == "failed":
+            taints.append({"code": "cleanup_failed"})
+    else:
+        taints.append({"code": "cleanup_status_missing"})
+
+    status = "failed" if failures else ("tainted" if taints else "passed")
+    score = {
+        "schemaVersion": 1,
+        "status": status,
+        "proofRoot": str(root),
+        "failures": failures,
+        "taints": taints,
+        "warnings": warnings,
+        "artifactCount": len(artifact_rows),
+    }
+    if write:
+        _write_json(root / "scorer" / "score.json", score)
+        (root / "scorer" / "score.md").write_text(
+            f"# Score\n\nStatus: {status}\n\nFailures: {len(failures)}\n\nTaints: {len(taints)}\n",
+            encoding="utf-8",
+        )
+        _write_json(root / "reports" / "proof-status.json", score)
+        (root / "reports" / "proof-status.md").write_text(
+            f"# Proof Status\n\nStatus: {status}\n",
+            encoding="utf-8",
+        )
+        append_command(
+            root,
+            command="score",
+            status=status,
+            artifacts=[{"path": "scorer/score.json", "role": "score"}],
+            warnings=[warning["code"] for warning in warnings],
+            taints=[taint["code"] for taint in taints],
+        )
+    return score
+
+
+def verify_proof_root(proof_root: str | Path, *, write: bool = True) -> dict[str, Any]:
+    score = score_proof_root(proof_root, write=write)
+    verified = {
+        **score,
+        "verified": score["status"] == "passed",
+    }
+    if write:
+        root = Path(proof_root)
+        _write_json(root / "reports" / "verification-report.json", verified)
+        (root / "reports" / "verification-report.md").write_text(
+            f"# Verification Report\n\nVerified: {str(verified['verified']).lower()}\n\nStatus: {score['status']}\n",
+            encoding="utf-8",
+        )
+        append_command(
+            root,
+            command="verify",
+            status=score["status"],
+            artifacts=[
+                {"path": "reports/proof-status.json", "role": "proof-status"},
+                {"path": "reports/verification-report.json", "role": "verification-report"},
+            ],
+            taints=[taint["code"] for taint in score["taints"]],
+        )
+    return verified

--- a/packages/narada/src/narada/workbench.py
+++ b/packages/narada/src/narada/workbench.py
@@ -119,7 +119,9 @@ def _default_out_dir(label: str) -> Path:
 
 def _write_json(path: Path, value: Any) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    path.write_text(
+        json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
 
 
 def _write_jsonl(path: Path, rows: Iterable[Any]) -> None:
@@ -291,7 +293,9 @@ async def resolve_execution_trace(
     return await _fetch_json(
         f"{base_url or default_api_base_url()}/execution-trace/resolve",
         method="POST",
-        auth_headers=auth_headers if auth_headers is not None else default_auth_headers(),
+        auth_headers=auth_headers
+        if auth_headers is not None
+        else default_auth_headers(),
         json_body={"executionTraceContext": validated.model_dump(mode="json")},
         session_factory=session_factory,
     )
@@ -308,7 +312,9 @@ async def materialize_execution_trace_context(
     session_factory: Callable[[], Any] = aiohttp.ClientSession,
 ) -> MaterializedTrace:
     validated = ExecutionTraceContext.model_validate(context)
-    proof_root = Path(out) if out is not None else _default_out_dir(label or validated.label)
+    proof_root = (
+        Path(out) if out is not None else _default_out_dir(label or validated.label)
+    )
     preexisting_root = proof_root.exists() and any(proof_root.iterdir())
     proof_root.mkdir(parents=True, exist_ok=True)
     (proof_root / "cleanup").mkdir(parents=True, exist_ok=True)
@@ -339,7 +345,9 @@ async def materialize_execution_trace_context(
     _write_json(trace_root / "resolved.json", resolved_trace)
     _write_jsonl(trace_root / "events.jsonl", resolved_trace.get("events") or [])
     _write_jsonl(trace_root / "scopes.jsonl", resolved_trace.get("scopes") or [])
-    _write_json(trace_root / "timeline.json", resolved_trace.get("timeline_index") or {})
+    _write_json(
+        trace_root / "timeline.json", resolved_trace.get("timeline_index") or {}
+    )
 
     frames = resolved_trace.get("frames") or []
     if isinstance(frames, list):
@@ -388,7 +396,9 @@ async def materialize_execution_trace_context(
                 "screenshot": ".png",
                 "frame": ".json",
             }.get(role, ".bin")
-            local_path = trace_root / "artifacts" / f"{role}_{role_counts[role]}{extension}"
+            local_path = (
+                trace_root / "artifacts" / f"{role}_{role_counts[role]}{extension}"
+            )
 
         data = await _download_bytes(download_url, session_factory=session_factory)
         local_path.parent.mkdir(parents=True, exist_ok=True)
@@ -439,7 +449,10 @@ async def materialize_execution_trace_context(
     _write_json(proof_root / "manifest.json", manifest)
     _write_json(
         proof_root / "cleanup" / "status.json",
-        {"status": "not_applicable", "reason": "trace materialization opened no environment"},
+        {
+            "status": "not_applicable",
+            "reason": "trace materialization opened no environment",
+        },
     )
     report = {
         "schemaVersion": 1,
@@ -488,15 +501,21 @@ async def materialize_execution_trace_from_request_id(
     resolved_base_url = base_url or default_api_base_url()
     response = await _fetch_json(
         f"{resolved_base_url}/remote-dispatch/responses/{request_id}",
-        auth_headers=auth_headers if auth_headers is not None else default_auth_headers(),
+        auth_headers=auth_headers
+        if auth_headers is not None
+        else default_auth_headers(),
         session_factory=session_factory,
     )
     response_content = response.get("response")
     if not isinstance(response_content, dict):
-        raise ValueError(f"Remote dispatch response {request_id} has no response object")
+        raise ValueError(
+            f"Remote dispatch response {request_id} has no response object"
+        )
     context = response_content.get("executionTraceContext")
     if not isinstance(context, dict):
-        raise ValueError(f"Remote dispatch response {request_id} has no executionTraceContext")
+        raise ValueError(
+            f"Remote dispatch response {request_id} has no executionTraceContext"
+        )
     return await materialize_execution_trace_context(
         context,
         out=out,
@@ -624,9 +643,15 @@ def score_proof_root(proof_root: str | Path, *, write: bool = True) -> dict[str,
         trace_id = context.get("traceId")
         resolved_context = resolved_trace.get("context")
         resolved_manifest = resolved_trace.get("manifest")
-        if isinstance(resolved_context, dict) and resolved_context.get("traceId") != trace_id:
+        if (
+            isinstance(resolved_context, dict)
+            and resolved_context.get("traceId") != trace_id
+        ):
             failures.append({"code": "resolved_context_trace_id_mismatch"})
-        if isinstance(resolved_manifest, dict) and resolved_manifest.get("traceId") != trace_id:
+        if (
+            isinstance(resolved_manifest, dict)
+            and resolved_manifest.get("traceId") != trace_id
+        ):
             failures.append({"code": "resolved_manifest_trace_id_mismatch"})
         if not any(
             isinstance(resolved_trace.get(name), list) and resolved_trace.get(name)
@@ -640,14 +665,29 @@ def score_proof_root(proof_root: str | Path, *, write: bool = True) -> dict[str,
         ):
             rows = resolved_trace.get(collection_name)
             if rows is None:
-                failures.append({"code": "resolved_collection_missing", "collection": collection_name})
+                failures.append(
+                    {
+                        "code": "resolved_collection_missing",
+                        "collection": collection_name,
+                    }
+                )
                 continue
             if not isinstance(rows, list):
-                failures.append({"code": "resolved_collection_not_list", "collection": collection_name})
+                failures.append(
+                    {
+                        "code": "resolved_collection_not_list",
+                        "collection": collection_name,
+                    }
+                )
                 continue
             for row in rows:
                 if not isinstance(row, dict):
-                    failures.append({"code": "resolved_row_not_object", "collection": collection_name})
+                    failures.append(
+                        {
+                            "code": "resolved_row_not_object",
+                            "collection": collection_name,
+                        }
+                    )
                     continue
                 if row.get("traceId") != trace_id:
                     failures.append(
@@ -657,7 +697,9 @@ def score_proof_root(proof_root: str | Path, *, write: bool = True) -> dict[str,
                             "rowId": row.get(id_name),
                         }
                     )
-        expected_artifact_keys = _collect_resolved_trace_artifact_keys(context, resolved_trace)
+        expected_artifact_keys = _collect_resolved_trace_artifact_keys(
+            context, resolved_trace
+        )
 
     if manifest is not None:
         manifest_context = manifest.get("traceContext")
@@ -683,7 +725,10 @@ def score_proof_root(proof_root: str | Path, *, write: bool = True) -> dict[str,
                 )
         if context is not None and manifest_context != context:
             failures.append({"code": "manifest_context_mismatch"})
-        if context is not None and manifest.get("traceId") not in {None, context.get("traceId")}:
+        if context is not None and manifest.get("traceId") not in {
+            None,
+            context.get("traceId"),
+        }:
             failures.append({"code": "manifest_trace_id_mismatch"})
         if context is not None:
             if not manifest.get("traceContextHash"):
@@ -742,7 +787,9 @@ def score_proof_root(proof_root: str | Path, *, write: bool = True) -> dict[str,
                 failures.append({"code": "artifact_missing_local_path", "row": row})
                 continue
             if not isinstance(source_key, str) or not source_key:
-                failures.append({"code": "artifact_missing_source_key", "path": local_path_value})
+                failures.append(
+                    {"code": "artifact_missing_source_key", "path": local_path_value}
+                )
             elif expected_artifact_keys and source_key not in expected_artifact_keys:
                 failures.append(
                     {
@@ -754,13 +801,19 @@ def score_proof_root(proof_root: str | Path, *, write: bool = True) -> dict[str,
             elif source_key:
                 seen_artifact_keys.add(source_key)
             if os.path.isabs(local_path_value):
-                failures.append({"code": "artifact_absolute_path", "path": local_path_value})
+                failures.append(
+                    {"code": "artifact_absolute_path", "path": local_path_value}
+                )
             local_path = root / local_path_value
             if not local_path.resolve().is_relative_to(root.resolve()):
-                failures.append({"code": "artifact_path_escape", "path": local_path_value})
+                failures.append(
+                    {"code": "artifact_path_escape", "path": local_path_value}
+                )
                 continue
             if not local_path.exists():
-                failures.append({"code": "artifact_file_missing", "path": local_path_value})
+                failures.append(
+                    {"code": "artifact_file_missing", "path": local_path_value}
+                )
                 continue
             expected_sha = row.get("sha256")
             actual_sha = _sha256_file(local_path)
@@ -774,7 +827,9 @@ def score_proof_root(proof_root: str | Path, *, write: bool = True) -> dict[str,
                     }
                 )
             if "downloadUrl" in row:
-                failures.append({"code": "signed_url_persisted", "path": local_path_value})
+                failures.append(
+                    {"code": "signed_url_persisted", "path": local_path_value}
+                )
         missing_artifact_keys = expected_artifact_keys - seen_artifact_keys
         for source_key in sorted(missing_artifact_keys):
             failures.append(
@@ -790,13 +845,17 @@ def score_proof_root(proof_root: str | Path, *, write: bool = True) -> dict[str,
         relative_path = _relative(text_path, root)
         for marker in _SIGNED_URL_PATTERNS:
             if marker in text_lower:
-                failures.append({"code": "signed_url_leak", "path": relative_path, "marker": marker})
+                failures.append(
+                    {"code": "signed_url_leak", "path": relative_path, "marker": marker}
+                )
         for pattern in _SECRET_PATTERNS:
             if pattern.search(text):
                 failures.append({"code": "secret_leak", "path": relative_path})
         for pattern in _SELF_REVIEW_PATTERNS:
             if pattern.search(text):
-                taints.append({"code": "workflow_self_review_marker", "path": relative_path})
+                taints.append(
+                    {"code": "workflow_self_review_marker", "path": relative_path}
+                )
         for pattern in _STATIC_ANSWER_PATTERNS:
             if pattern.search(text):
                 failures.append({"code": "static_answer_marker", "path": relative_path})
@@ -840,11 +899,21 @@ def score_proof_root(proof_root: str | Path, *, write: bool = True) -> dict[str,
                         )
         for row in command_rows:
             if not row.get("commandId"):
-                failures.append({"code": "command_missing_command_id", "command": row.get("command")})
+                failures.append(
+                    {
+                        "code": "command_missing_command_id",
+                        "command": row.get("command"),
+                    }
+                )
             if not row.get("runId"):
-                failures.append({"code": "command_missing_run_id", "command": row.get("command")})
+                failures.append(
+                    {"code": "command_missing_run_id", "command": row.get("command")}
+                )
             row_status = row.get("status")
-            if row.get("command") == "trace.materialize" and row_status not in _CLEAN_COMMAND_STATUSES:
+            if (
+                row.get("command") == "trace.materialize"
+                and row_status not in _CLEAN_COMMAND_STATUSES
+            ):
                 taints.append(
                     {
                         "code": "materialize_command_not_clean",
@@ -915,7 +984,10 @@ def verify_proof_root(proof_root: str | Path, *, write: bool = True) -> dict[str
             status=score["status"],
             artifacts=[
                 {"path": "reports/proof-status.json", "role": "proof-status"},
-                {"path": "reports/verification-report.json", "role": "verification-report"},
+                {
+                    "path": "reports/verification-report.json",
+                    "role": "verification-report",
+                },
             ],
             taints=[taint["code"] for taint in score["taints"]],
         )

--- a/packages/narada/tests/test_agent.py
+++ b/packages/narada/tests/test_agent.py
@@ -164,7 +164,10 @@ async def test_agent_run_exposes_execution_trace_context(
     response = await Agent(environment=_CountingEnvironment()).run("return trace")
 
     assert response.execution_trace_context == execution_trace_context
-    assert response.model_dump(by_alias=True)["executionTraceContext"] == execution_trace_context
+    assert (
+        response.model_dump(by_alias=True)["executionTraceContext"]
+        == execution_trace_context
+    )
 
 
 @pytest.mark.asyncio
@@ -217,7 +220,9 @@ async def test_trace_context_manager_materializes_registered_response(
     monkeypatch.setattr(
         environment_module.aiohttp, "ClientSession", lambda: fake_session
     )
-    monkeypatch.setattr(trace_module, "materialize_execution_trace_context", fake_materialize)
+    monkeypatch.setattr(
+        trace_module, "materialize_execution_trace_context", fake_materialize
+    )
 
     async with trace("unit-trace", out=tmp_path / "proof") as tr:
         response = await Agent(environment=_CountingEnvironment()).run("return trace")
@@ -277,9 +282,13 @@ async def test_agent_run_trace_true_materializes_single_response(
     monkeypatch.setattr(
         environment_module.aiohttp, "ClientSession", lambda: fake_session
     )
-    monkeypatch.setattr(agent_module, "materialize_execution_trace_context", fake_materialize)
+    monkeypatch.setattr(
+        agent_module, "materialize_execution_trace_context", fake_materialize
+    )
 
-    response = await Agent(environment=_CountingEnvironment()).run("return trace", trace=True)
+    response = await Agent(environment=_CountingEnvironment()).run(
+        "return trace", trace=True
+    )
 
     assert response.execution_trace_path == str(tmp_path / "proof")
     assert calls[0]["context"] == execution_trace_context
@@ -345,8 +354,12 @@ async def test_agent_run_trace_true_inside_trace_context_materializes_once(
     monkeypatch.setattr(
         environment_module.aiohttp, "ClientSession", lambda: fake_session
     )
-    monkeypatch.setattr(agent_module, "materialize_execution_trace_context", fake_agent_materialize)
-    monkeypatch.setattr(trace_module, "materialize_execution_trace_context", fake_context_materialize)
+    monkeypatch.setattr(
+        agent_module, "materialize_execution_trace_context", fake_agent_materialize
+    )
+    monkeypatch.setattr(
+        trace_module, "materialize_execution_trace_context", fake_context_materialize
+    )
 
     async with trace("unit-trace", out=tmp_path / "context-proof") as tr:
         response = await Agent(environment=_CountingEnvironment()).run(

--- a/packages/narada/tests/test_agent.py
+++ b/packages/narada/tests/test_agent.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+import importlib
+from pathlib import Path
 from typing import Any
 
 import pytest
-from narada import Agent, Environment
+from narada import Agent, Environment, trace
 
 
 class _FakeResponse:
@@ -119,3 +121,240 @@ async def test_agent_run_forwards_clear_chat(
     await agent.run("fresh task", clear_chat=True)
 
     assert fake_session.dispatched_bodies[0]["clearChat"] is True
+
+
+@pytest.mark.asyncio
+async def test_agent_run_exposes_execution_trace_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import narada.environment as environment_module
+
+    execution_trace_context = {
+        "type": "executionTraceContext",
+        "label": "Trace",
+        "traceId": "trace-1",
+        "executionTraceS3Key": "user-test/recording-trace-1/execution-trace/index.json",
+    }
+    fake_session = _RemoteDispatchFakeClientSession()
+
+    def get_with_trace(url: str, **kwargs: Any) -> _FakeResponse:
+        del kwargs
+        if "/remote-dispatch/responses/" not in url:
+            raise AssertionError(f"Unexpected GET URL: {url}")
+        return _FakeResponse(
+            {
+                "status": "success",
+                "response": {
+                    "text": "ok",
+                    "output": {"type": "text", "content": "ok"},
+                    "executionTraceContext": execution_trace_context,
+                },
+                "usage": {"actions": 1, "credits": 1},
+                "createdAt": "2026-01-01T00:00:00Z",
+                "completedAt": "2026-01-01T00:00:01Z",
+                "activeInputRequest": None,
+            }
+        )
+
+    fake_session.get = get_with_trace  # type: ignore[method-assign]
+    monkeypatch.setattr(
+        environment_module.aiohttp, "ClientSession", lambda: fake_session
+    )
+
+    response = await Agent(environment=_CountingEnvironment()).run("return trace")
+
+    assert response.execution_trace_context == execution_trace_context
+    assert response.model_dump(by_alias=True)["executionTraceContext"] == execution_trace_context
+
+
+@pytest.mark.asyncio
+async def test_trace_context_manager_materializes_registered_response(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    import narada.environment as environment_module
+
+    trace_module = importlib.import_module("narada.tracing")
+
+    execution_trace_context = {
+        "type": "executionTraceContext",
+        "label": "Trace",
+        "traceId": "trace-1",
+        "executionTraceS3Key": "user-test/recording-trace-1/execution-trace/index.json",
+    }
+    calls: list[dict[str, Any]] = []
+
+    async def fake_materialize(context: dict[str, Any], **kwargs: Any) -> Any:
+        calls.append({"context": context, **kwargs})
+
+        class _Result:
+            path = tmp_path / "proof"
+
+        return _Result()
+
+    fake_session = _RemoteDispatchFakeClientSession()
+
+    def get_with_trace(url: str, **kwargs: Any) -> _FakeResponse:
+        del kwargs
+        if "/remote-dispatch/responses/" not in url:
+            raise AssertionError(f"Unexpected GET URL: {url}")
+        return _FakeResponse(
+            {
+                "status": "success",
+                "response": {
+                    "text": "ok",
+                    "output": {"type": "text", "content": "ok"},
+                    "executionTraceContext": execution_trace_context,
+                },
+                "usage": {"actions": 1, "credits": 1},
+                "createdAt": "2026-01-01T00:00:00Z",
+                "completedAt": "2026-01-01T00:00:01Z",
+                "activeInputRequest": None,
+            }
+        )
+
+    fake_session.get = get_with_trace  # type: ignore[method-assign]
+    monkeypatch.setattr(
+        environment_module.aiohttp, "ClientSession", lambda: fake_session
+    )
+    monkeypatch.setattr(trace_module, "materialize_execution_trace_context", fake_materialize)
+
+    async with trace("unit-trace", out=tmp_path / "proof") as tr:
+        response = await Agent(environment=_CountingEnvironment()).run("return trace")
+
+    assert tr.path == tmp_path / "proof"
+    assert response.execution_trace_path == str(tmp_path / "proof")
+    assert calls[0]["context"] == execution_trace_context
+    assert calls[0]["out"] == tmp_path / "proof"
+
+
+@pytest.mark.asyncio
+async def test_agent_run_trace_true_materializes_single_response(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    import narada.agent as agent_module
+    import narada.environment as environment_module
+
+    execution_trace_context = {
+        "type": "executionTraceContext",
+        "label": "Trace",
+        "traceId": "trace-1",
+        "executionTraceS3Key": "user-test/recording-trace-1/execution-trace/index.json",
+    }
+    calls: list[dict[str, Any]] = []
+
+    async def fake_materialize(context: dict[str, Any], **kwargs: Any) -> Any:
+        calls.append({"context": context, **kwargs})
+
+        class _Result:
+            path = tmp_path / "proof"
+
+        return _Result()
+
+    fake_session = _RemoteDispatchFakeClientSession()
+
+    def get_with_trace(url: str, **kwargs: Any) -> _FakeResponse:
+        del kwargs
+        if "/remote-dispatch/responses/" not in url:
+            raise AssertionError(f"Unexpected GET URL: {url}")
+        return _FakeResponse(
+            {
+                "status": "success",
+                "response": {
+                    "text": "ok",
+                    "output": {"type": "text", "content": "ok"},
+                    "executionTraceContext": execution_trace_context,
+                },
+                "usage": {"actions": 1, "credits": 1},
+                "createdAt": "2026-01-01T00:00:00Z",
+                "completedAt": "2026-01-01T00:00:01Z",
+                "activeInputRequest": None,
+            }
+        )
+
+    fake_session.get = get_with_trace  # type: ignore[method-assign]
+    monkeypatch.setattr(
+        environment_module.aiohttp, "ClientSession", lambda: fake_session
+    )
+    monkeypatch.setattr(agent_module, "materialize_execution_trace_context", fake_materialize)
+
+    response = await Agent(environment=_CountingEnvironment()).run("return trace", trace=True)
+
+    assert response.execution_trace_path == str(tmp_path / "proof")
+    assert calls[0]["context"] == execution_trace_context
+    assert calls[0]["label"].startswith("agent-run-req-")
+
+
+@pytest.mark.asyncio
+async def test_agent_run_trace_true_inside_trace_context_materializes_once(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    import narada.agent as agent_module
+    import narada.environment as environment_module
+
+    trace_module = importlib.import_module("narada.tracing")
+    execution_trace_context = {
+        "type": "executionTraceContext",
+        "label": "Trace",
+        "traceId": "trace-1",
+        "executionTraceS3Key": "user-test/recording-trace-1/execution-trace/index.json",
+    }
+    agent_calls: list[dict[str, Any]] = []
+    context_calls: list[dict[str, Any]] = []
+
+    async def fake_agent_materialize(context: dict[str, Any], **kwargs: Any) -> Any:
+        agent_calls.append({"context": context, **kwargs})
+
+        class _Result:
+            path = tmp_path / "agent-proof"
+
+        return _Result()
+
+    async def fake_context_materialize(context: dict[str, Any], **kwargs: Any) -> Any:
+        context_calls.append({"context": context, **kwargs})
+
+        class _Result:
+            path = tmp_path / "context-proof"
+
+        return _Result()
+
+    fake_session = _RemoteDispatchFakeClientSession()
+
+    def get_with_trace(url: str, **kwargs: Any) -> _FakeResponse:
+        del kwargs
+        if "/remote-dispatch/responses/" not in url:
+            raise AssertionError(f"Unexpected GET URL: {url}")
+        return _FakeResponse(
+            {
+                "status": "success",
+                "response": {
+                    "text": "ok",
+                    "output": {"type": "text", "content": "ok"},
+                    "executionTraceContext": execution_trace_context,
+                },
+                "usage": {"actions": 1, "credits": 1},
+                "createdAt": "2026-01-01T00:00:00Z",
+                "completedAt": "2026-01-01T00:00:01Z",
+                "activeInputRequest": None,
+            }
+        )
+
+    fake_session.get = get_with_trace  # type: ignore[method-assign]
+    monkeypatch.setattr(
+        environment_module.aiohttp, "ClientSession", lambda: fake_session
+    )
+    monkeypatch.setattr(agent_module, "materialize_execution_trace_context", fake_agent_materialize)
+    monkeypatch.setattr(trace_module, "materialize_execution_trace_context", fake_context_materialize)
+
+    async with trace("unit-trace", out=tmp_path / "context-proof") as tr:
+        response = await Agent(environment=_CountingEnvironment()).run(
+            "return trace",
+            trace=True,
+        )
+
+    assert response.execution_trace_path == str(tmp_path / "agent-proof")
+    assert tr.path is None
+    assert len(agent_calls) == 1
+    assert context_calls == []

--- a/packages/narada/tests/test_workbench.py
+++ b/packages/narada/tests/test_workbench.py
@@ -1,0 +1,820 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from narada.cli import main
+from narada.workbench import (
+    materialize_execution_trace_context,
+    score_proof_root,
+    verify_proof_root,
+)
+
+TRACE_CONTEXT = {
+    "type": "executionTraceContext",
+    "label": "Trace",
+    "traceId": "trace-1",
+    "executionTraceS3Key": "user-test/recording-trace-1/execution-trace/index.json",
+}
+
+
+class _FakeResponse:
+    def __init__(self, *, payload: dict[str, Any] | None = None, body: bytes = b"") -> None:
+        self._payload = payload
+        self._body = body
+
+    async def __aenter__(self) -> "_FakeResponse":
+        return self
+
+    async def __aexit__(self, *args: Any) -> None:
+        return None
+
+    def raise_for_status(self) -> None:
+        return None
+
+    async def json(self) -> dict[str, Any]:
+        assert self._payload is not None
+        return self._payload
+
+    async def read(self) -> bytes:
+        return self._body
+
+
+class _FakeSession:
+    def __init__(self) -> None:
+        self.downloads = {
+            "https://signed.example.test/index.json?X-Amz-Signature=secret": json.dumps(
+                {"traceId": "trace-1"}
+            ).encode(),
+            "https://signed.example.test/frame.html?X-Amz-Signature=secret": b"<html>ok</html>",
+            "https://signed.example.test/screenshot.png?X-Amz-Signature=secret": b"png",
+        }
+
+    async def __aenter__(self) -> "_FakeSession":
+        return self
+
+    async def __aexit__(self, *args: Any) -> None:
+        return None
+
+    def post(self, url: str, **kwargs: Any) -> _FakeResponse:
+        assert url.endswith("/execution-trace/resolve")
+        assert kwargs["json"]["executionTraceContext"]["traceId"] == "trace-1"
+        return _FakeResponse(
+            payload={
+                "context": TRACE_CONTEXT,
+                "resolvedTrace": {
+                    "context": TRACE_CONTEXT,
+                    "manifest": {
+                        "traceId": "trace-1",
+                        "segmentId": "segment-1",
+                        "label": "Trace",
+                        "status": "completed",
+                        "artifacts": {},
+                    },
+                    "segments": [],
+                    "events": [
+                        {
+                            "traceId": "trace-1",
+                            "eventId": "event-1",
+                            "sequence": 1,
+                            "timestamp": 1,
+                            "kind": "test.event",
+                        }
+                    ],
+                    "scopes": [],
+                    "timeline_index": {
+                        "traceId": "trace-1",
+                        "generatedAt": 1,
+                        "events": [],
+                        "scopes": [],
+                        "frames": [
+                            {
+                                "label": "frame_1",
+                                "frameId": "frame-1",
+                                "frameS3Key": "user-test/recording-trace-1/execution-trace/frame.json",
+                                "eventLabels": [],
+                                "reason": "test",
+                                "page": {"url": "https://example.test", "title": "Example"},
+                            }
+                        ],
+                        "aliases": {},
+                    },
+                    "frames": [
+                        {
+                            "traceId": "trace-1",
+                            "frameId": "frame-1",
+                            "sequence": 1,
+                            "capturedAt": 1,
+                            "reason": "test",
+                            "page": {"url": "https://example.test", "title": "Example"},
+                            "eventIds": ["event-1"],
+                            "htmlS3Key": "user-test/recording-trace-1/execution-trace/frame.html",
+                            "screenshotS3Key": "user-test/recording-trace-1/execution-trace/screenshot.png",
+                        }
+                    ],
+                },
+                "artifacts": [
+                    {
+                        "role": "manifest",
+                        "s3Key": TRACE_CONTEXT["executionTraceS3Key"],
+                        "downloadUrl": "https://signed.example.test/index.json?X-Amz-Signature=secret",
+                        "contentType": "application/json",
+                        "sensitive": True,
+                    },
+                    {
+                        "role": "html",
+                        "s3Key": "user-test/recording-trace-1/execution-trace/frame.html",
+                        "downloadUrl": "https://signed.example.test/frame.html?X-Amz-Signature=secret",
+                        "contentType": "text/html",
+                        "sensitive": True,
+                        "frameId": "frame-1",
+                        "label": "frame_1",
+                    },
+                    {
+                        "role": "screenshot",
+                        "s3Key": "user-test/recording-trace-1/execution-trace/screenshot.png",
+                        "downloadUrl": "https://signed.example.test/screenshot.png?X-Amz-Signature=secret",
+                        "contentType": "image/png",
+                        "sensitive": True,
+                        "frameId": "frame-1",
+                        "label": "frame_1",
+                    },
+                ],
+            }
+        )
+
+    def get(self, url: str, **kwargs: Any) -> _FakeResponse:
+        del kwargs
+        return _FakeResponse(body=self.downloads[url])
+
+
+@pytest.mark.asyncio
+async def test_materializer_writes_proof_root_without_signed_url_leaks(tmp_path: Path) -> None:
+    result = await materialize_execution_trace_context(
+        TRACE_CONTEXT,
+        out=tmp_path,
+        source_run={
+            "type": "remote-dispatch",
+            "authority": "agent-run-response",
+            "status": "success",
+            "requestId": "req-test",
+        },
+        auth_headers={"x-api-key": "test"},
+        base_url="https://api.example.test/fast/v2",
+        session_factory=_FakeSession,
+    )
+
+    assert result.path == tmp_path
+    assert (tmp_path / "manifest.json").exists()
+    assert (tmp_path / "trace" / "resolved.json").exists()
+    assert (tmp_path / "trace" / "frames" / "frame-1" / "page.html").exists()
+    assert (tmp_path / "trace" / "frames" / "frame-1" / "screenshot.png").exists()
+    assert "X-Amz-Signature" not in (tmp_path / "trace" / "artifacts" / "index.jsonl").read_text()
+
+    score = score_proof_root(tmp_path)
+    assert score["status"] == "passed"
+    assert verify_proof_root(tmp_path)["verified"] is True
+
+
+@pytest.mark.asyncio
+async def test_materializer_taints_preexisting_proof_root(tmp_path: Path) -> None:
+    (tmp_path / "old-file.txt").write_text("old", encoding="utf-8")
+
+    result = await materialize_execution_trace_context(
+        TRACE_CONTEXT,
+        out=tmp_path,
+        source_run={
+            "type": "remote-dispatch",
+            "authority": "agent-run-response",
+            "status": "success",
+            "requestId": "req-test",
+        },
+        auth_headers={"x-api-key": "test"},
+        base_url="https://api.example.test/fast/v2",
+        session_factory=_FakeSession,
+    )
+
+    assert result.report["status"] == "tainted"
+    score = score_proof_root(tmp_path)
+    assert score["status"] == "tainted"
+    assert any(taint["code"] == "manifest_taint" for taint in score["taints"])
+
+
+@pytest.mark.asyncio
+async def test_materializer_taints_missing_source_run_status(tmp_path: Path) -> None:
+    result = await materialize_execution_trace_context(
+        TRACE_CONTEXT,
+        out=tmp_path,
+        auth_headers={"x-api-key": "test"},
+        base_url="https://api.example.test/fast/v2",
+        session_factory=_FakeSession,
+    )
+
+    assert result.report["status"] == "tainted"
+    score = score_proof_root(tmp_path)
+    assert score["status"] == "tainted"
+    assert any(taint["code"] == "source_run_status_unknown" for taint in score["taints"])
+
+
+def _write_clean_minimal_root(root: Path) -> None:
+    (root / "trace" / "artifacts").mkdir(parents=True)
+    (root / "reports").mkdir()
+    (root / "cleanup").mkdir()
+    context = TRACE_CONTEXT
+    resolved = {
+        "context": context,
+        "manifest": {
+            "traceId": context["traceId"],
+            "segmentId": "segment-1",
+            "label": "Trace",
+            "status": "completed",
+            "artifacts": {},
+        },
+        "segments": [],
+        "events": [
+            {
+                "traceId": context["traceId"],
+                "eventId": "event-1",
+                "sequence": 1,
+                "timestamp": 1,
+                "kind": "test.event",
+            }
+        ],
+        "scopes": [],
+        "timeline_index": {
+            "traceId": context["traceId"],
+            "generatedAt": 1,
+            "events": [],
+            "scopes": [],
+            "frames": [],
+            "aliases": {},
+        },
+        "frames": [],
+    }
+    manifest_bytes = json.dumps({"traceId": context["traceId"]}).encode()
+    manifest_hash = hashlib.sha256(manifest_bytes).hexdigest()
+    (root / "trace" / "artifacts" / "manifest_1.json").write_bytes(manifest_bytes)
+    context_hash = hashlib.sha256(
+        json.dumps(context, sort_keys=True, separators=(",", ":")).encode()
+    ).hexdigest()
+    resolved_hash = hashlib.sha256(
+        json.dumps(resolved, sort_keys=True, separators=(",", ":")).encode()
+    ).hexdigest()
+    (root / "manifest.json").write_text(
+        json.dumps(
+            {
+                "status": "materialized",
+                "traceContext": context,
+                "traceId": context["traceId"],
+                "sourceRun": {
+                    "type": "remote-dispatch",
+                    "authority": "agent-run-response",
+                    "status": "success",
+                    "requestId": "req-test",
+                },
+                "traceContextHash": context_hash,
+                "resolvedTraceHash": resolved_hash,
+                "traceManifestStatus": "completed",
+            }
+        ),
+        encoding="utf-8",
+    )
+    (root / "commands.jsonl").write_text(
+        json.dumps(
+            {
+                "commandId": "cmd_test",
+                "runId": root.name,
+                "command": "trace.materialize",
+                "status": "passed",
+                "ids": {
+                    "traceId": context["traceId"],
+                    "contextHash": context_hash,
+                    "resolvedTraceHash": resolved_hash,
+                },
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (root / "trace" / "context.json").write_text(json.dumps(context), encoding="utf-8")
+    (root / "trace" / "resolved.json").write_text(json.dumps(resolved), encoding="utf-8")
+    (root / "trace" / "events.jsonl").write_text(
+        json.dumps(resolved["events"][0]) + "\n",
+        encoding="utf-8",
+    )
+    (root / "trace" / "scopes.jsonl").write_text("", encoding="utf-8")
+    (root / "trace" / "timeline.json").write_text(
+        json.dumps(resolved["timeline_index"]),
+        encoding="utf-8",
+    )
+    (root / "trace" / "artifacts" / "index.jsonl").write_text(
+        json.dumps(
+            {
+                "role": "manifest",
+                "sourceS3Key": context["executionTraceS3Key"],
+                "localPath": "trace/artifacts/manifest_1.json",
+                "sha256": manifest_hash,
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (root / "reports" / "materialization-report.json").write_text("{}", encoding="utf-8")
+    (root / "cleanup" / "status.json").write_text(
+        json.dumps({"status": "not_applicable"}),
+        encoding="utf-8",
+    )
+
+
+def test_score_fails_signed_url_leak(tmp_path: Path) -> None:
+    _write_clean_minimal_root(tmp_path)
+    (tmp_path / "trace" / "leak.txt").write_text("X-Amz-Signature=secret", encoding="utf-8")
+
+    score = score_proof_root(tmp_path)
+
+    assert score["status"] == "failed"
+    assert any(failure["code"] == "signed_url_leak" for failure in score["failures"])
+
+
+def test_score_fails_missing_trace_file(tmp_path: Path) -> None:
+    _write_clean_minimal_root(tmp_path)
+    (tmp_path / "trace" / "resolved.json").unlink()
+
+    score = score_proof_root(tmp_path)
+
+    assert score["status"] == "failed"
+    assert any(
+        failure == {"code": "missing_required_file", "path": "trace/resolved.json"}
+        for failure in score["failures"]
+    )
+
+
+def test_score_fails_empty_shell_root(tmp_path: Path) -> None:
+    _write_clean_minimal_root(tmp_path)
+    (tmp_path / "trace" / "resolved.json").write_text(
+        json.dumps(
+            {
+                "context": TRACE_CONTEXT,
+                "manifest": {"traceId": "trace-1", "status": "completed"},
+                "events": [],
+                "scopes": [],
+                "frames": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    score = score_proof_root(tmp_path)
+
+    assert score["status"] == "failed"
+    assert any(failure["code"] == "empty_resolved_trace" for failure in score["failures"])
+
+
+def test_score_fails_resolved_trace_id_mismatch(tmp_path: Path) -> None:
+    _write_clean_minimal_root(tmp_path)
+    resolved = json.loads((tmp_path / "trace" / "resolved.json").read_text())
+    resolved["manifest"]["traceId"] = "trace-other"
+    (tmp_path / "trace" / "resolved.json").write_text(json.dumps(resolved), encoding="utf-8")
+
+    score = score_proof_root(tmp_path)
+
+    assert score["status"] == "failed"
+    assert any(
+        failure["code"] == "resolved_manifest_trace_id_mismatch"
+        for failure in score["failures"]
+    )
+
+
+def test_score_fails_missing_referenced_artifact(tmp_path: Path) -> None:
+    _write_clean_minimal_root(tmp_path)
+    (tmp_path / "trace" / "artifacts" / "index.jsonl").write_text(
+        json.dumps(
+            {
+                "role": "html",
+                "localPath": "trace/frames/frame-1/page.html",
+                "sha256": "missing",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    score = score_proof_root(tmp_path)
+
+    assert score["status"] == "failed"
+    assert any(failure["code"] == "artifact_file_missing" for failure in score["failures"])
+
+
+def test_score_fails_missing_resolved_artifact_download(tmp_path: Path) -> None:
+    _write_clean_minimal_root(tmp_path)
+    (tmp_path / "trace" / "artifacts" / "index.jsonl").write_text("", encoding="utf-8")
+
+    score = score_proof_root(tmp_path)
+
+    assert score["status"] == "failed"
+    assert any(
+        failure["code"] == "resolved_artifact_not_downloaded"
+        for failure in score["failures"]
+    )
+
+
+def test_score_fails_foreign_artifact_source_key(tmp_path: Path) -> None:
+    _write_clean_minimal_root(tmp_path)
+    artifact_path = tmp_path / "trace" / "artifacts" / "foreign.json"
+    artifact_path.write_text("{}", encoding="utf-8")
+    (tmp_path / "trace" / "artifacts" / "index.jsonl").write_text(
+        json.dumps(
+            {
+                "role": "manifest",
+                "sourceS3Key": "user-test/recording-other/execution-trace/index.json",
+                "localPath": "trace/artifacts/foreign.json",
+                "sha256": hashlib.sha256(b"{}").hexdigest(),
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    score = score_proof_root(tmp_path)
+
+    assert score["status"] == "failed"
+    assert any(
+        failure["code"] == "artifact_source_not_in_resolved_trace"
+        for failure in score["failures"]
+    )
+
+
+def test_score_fails_artifact_path_escape(tmp_path: Path) -> None:
+    _write_clean_minimal_root(tmp_path)
+    (tmp_path / "trace" / "artifacts" / "index.jsonl").write_text(
+        json.dumps(
+            {
+                "role": "html",
+                "localPath": "../old-run/page.html",
+                "sha256": "stale",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    score = score_proof_root(tmp_path)
+
+    assert score["status"] == "failed"
+    assert any(failure["code"] == "artifact_path_escape" for failure in score["failures"])
+
+
+def test_score_fails_secret_leak(tmp_path: Path) -> None:
+    _write_clean_minimal_root(tmp_path)
+    (tmp_path / "trace" / "secret.txt").write_text(
+        "Authorization: Bearer abc123",
+        encoding="utf-8",
+    )
+
+    score = score_proof_root(tmp_path)
+
+    assert score["status"] == "failed"
+    assert any(failure["code"] == "secret_leak" for failure in score["failures"])
+
+
+def test_score_fails_lowercase_signed_url_leak(tmp_path: Path) -> None:
+    _write_clean_minimal_root(tmp_path)
+    (tmp_path / "trace" / "leak.txt").write_text("x-amz-signature=secret", encoding="utf-8")
+
+    score = score_proof_root(tmp_path)
+
+    assert score["status"] == "failed"
+    assert any(failure["code"] == "signed_url_leak" for failure in score["failures"])
+
+
+def test_score_fails_failed_trace_status(tmp_path: Path) -> None:
+    _write_clean_minimal_root(tmp_path)
+    resolved = json.loads((tmp_path / "trace" / "resolved.json").read_text())
+    resolved["manifest"]["status"] = "failed"
+    (tmp_path / "trace" / "resolved.json").write_text(json.dumps(resolved), encoding="utf-8")
+
+    score = score_proof_root(tmp_path)
+
+    assert score["status"] == "failed"
+    assert any(failure["code"] == "trace_status_failed" for failure in score["failures"])
+
+
+def test_score_fails_missing_source_run(tmp_path: Path) -> None:
+    _write_clean_minimal_root(tmp_path)
+    manifest = json.loads((tmp_path / "manifest.json").read_text())
+    del manifest["sourceRun"]
+    (tmp_path / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+
+    score = score_proof_root(tmp_path)
+
+    assert score["status"] == "failed"
+    assert any(failure["code"] == "source_run_missing" for failure in score["failures"])
+
+
+def test_score_fails_failed_source_run(tmp_path: Path) -> None:
+    _write_clean_minimal_root(tmp_path)
+    manifest = json.loads((tmp_path / "manifest.json").read_text())
+    manifest["sourceRun"]["status"] = "failed"
+    (tmp_path / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+
+    score = score_proof_root(tmp_path)
+
+    assert score["status"] == "failed"
+    assert any(failure["code"] == "source_run_failed" for failure in score["failures"])
+
+
+def test_score_taints_unknown_source_run_status(tmp_path: Path) -> None:
+    _write_clean_minimal_root(tmp_path)
+    manifest = json.loads((tmp_path / "manifest.json").read_text())
+    manifest["sourceRun"]["status"] = "unknown"
+    (tmp_path / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+
+    score = score_proof_root(tmp_path)
+
+    assert score["status"] == "tainted"
+    assert any(taint["code"] == "source_run_status_unknown" for taint in score["taints"])
+
+
+def test_score_taints_unverified_source_run_authority(tmp_path: Path) -> None:
+    _write_clean_minimal_root(tmp_path)
+    manifest = json.loads((tmp_path / "manifest.json").read_text())
+    manifest["sourceRun"]["authority"] = "caller-attested"
+    (tmp_path / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+
+    score = score_proof_root(tmp_path)
+
+    assert score["status"] == "tainted"
+    assert any(
+        taint["code"] == "source_run_authority_unverified" for taint in score["taints"]
+    )
+    assert verify_proof_root(tmp_path)["verified"] is False
+
+
+def test_score_fails_non_terminal_source_run_status(tmp_path: Path) -> None:
+    _write_clean_minimal_root(tmp_path)
+    manifest = json.loads((tmp_path / "manifest.json").read_text())
+    manifest["sourceRun"]["status"] = "input-required"
+    (tmp_path / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+
+    score = score_proof_root(tmp_path)
+
+    assert score["status"] == "failed"
+    assert any(failure["code"] == "source_run_not_terminal" for failure in score["failures"])
+
+
+def test_score_fails_missing_manifest_hash(tmp_path: Path) -> None:
+    _write_clean_minimal_root(tmp_path)
+    manifest = json.loads((tmp_path / "manifest.json").read_text())
+    del manifest["resolvedTraceHash"]
+    (tmp_path / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+
+    score = score_proof_root(tmp_path)
+
+    assert score["status"] == "failed"
+    assert any(
+        failure["code"] == "manifest_resolved_trace_hash_missing"
+        for failure in score["failures"]
+    )
+
+
+def test_score_fails_materialize_command_hash_mismatch(tmp_path: Path) -> None:
+    _write_clean_minimal_root(tmp_path)
+    command = json.loads((tmp_path / "commands.jsonl").read_text().splitlines()[0])
+    command["ids"]["resolvedTraceHash"] = "wrong"
+    (tmp_path / "commands.jsonl").write_text(json.dumps(command) + "\n", encoding="utf-8")
+
+    score = score_proof_root(tmp_path)
+
+    assert score["status"] == "failed"
+    assert any(
+        failure["code"] == "materialize_command_id_mismatch"
+        for failure in score["failures"]
+    )
+
+
+def test_score_fails_static_answer_marker(tmp_path: Path) -> None:
+    _write_clean_minimal_root(tmp_path)
+    (tmp_path / "trace" / "answers.py").write_text(
+        "VALUE_RULES = {}",
+        encoding="utf-8",
+    )
+
+    score = score_proof_root(tmp_path)
+
+    assert score["status"] == "failed"
+    assert any(failure["code"] == "static_answer_marker" for failure in score["failures"])
+
+
+def test_score_fails_renamed_answer_map_marker(tmp_path: Path) -> None:
+    _write_clean_minimal_root(tmp_path)
+    (tmp_path / "trace" / "answers.py").write_text(
+        "ANSWER_MAP = {}",
+        encoding="utf-8",
+    )
+
+    score = score_proof_root(tmp_path)
+
+    assert score["status"] == "failed"
+    assert any(failure["code"] == "static_answer_marker" for failure in score["failures"])
+
+
+def test_score_fails_missing_materialize_command(tmp_path: Path) -> None:
+    _write_clean_minimal_root(tmp_path)
+    (tmp_path / "commands.jsonl").write_text(
+        json.dumps({"command": "score", "status": "passed"}) + "\n",
+        encoding="utf-8",
+    )
+
+    score = score_proof_root(tmp_path)
+
+    assert score["status"] == "failed"
+    assert any(
+        failure["code"] == "missing_materialize_command"
+        for failure in score["failures"]
+    )
+
+
+def test_score_taints_workflow_self_review_marker(tmp_path: Path) -> None:
+    _write_clean_minimal_root(tmp_path)
+    (tmp_path / "trace" / "self-review.json").write_text(
+        json.dumps({"workflowSelfApproved": True}),
+        encoding="utf-8",
+    )
+
+    score = score_proof_root(tmp_path)
+
+    assert score["status"] == "tainted"
+    assert any(taint["code"] == "workflow_self_review_marker" for taint in score["taints"])
+
+
+def test_score_taints_renamed_self_review_marker(tmp_path: Path) -> None:
+    _write_clean_minimal_root(tmp_path)
+    (tmp_path / "trace" / "self-review.json").write_text(
+        json.dumps({"approvedBy": "workflow", "reviewStatus": "accepted"}),
+        encoding="utf-8",
+    )
+
+    score = score_proof_root(tmp_path)
+
+    assert score["status"] == "tainted"
+    assert any(taint["code"] == "workflow_self_review_marker" for taint in score["taints"])
+
+
+def test_score_taints_cleanup_failure(tmp_path: Path) -> None:
+    _write_clean_minimal_root(tmp_path)
+    (tmp_path / "cleanup" / "status.json").write_text(
+        json.dumps({"status": "failed"}),
+        encoding="utf-8",
+    )
+
+    score = score_proof_root(tmp_path)
+
+    assert score["status"] == "tainted"
+    assert any(taint["code"] == "cleanup_failed" for taint in score["taints"])
+
+
+def test_score_taints_prior_failed_command(tmp_path: Path) -> None:
+    _write_clean_minimal_root(tmp_path)
+    with (tmp_path / "commands.jsonl").open("a", encoding="utf-8") as handle:
+        handle.write(
+            json.dumps(
+                {
+                    "commandId": "cmd_failed",
+                    "runId": tmp_path.name,
+                    "command": "trace.materialize",
+                    "status": "failed",
+                }
+            )
+            + "\n"
+        )
+
+    score = score_proof_root(tmp_path)
+
+    assert score["status"] == "tainted"
+    assert any(taint["code"] == "materialize_command_not_clean" for taint in score["taints"])
+
+
+def test_cli_score_returns_nonzero_for_failed_root(tmp_path: Path) -> None:
+    _write_clean_minimal_root(tmp_path)
+    (tmp_path / "trace" / "leak.txt").write_text("X-Amz-Credential=secret", encoding="utf-8")
+
+    assert main(["workbench", "score", str(tmp_path), "--json"]) == 1
+
+
+def test_cli_materialize_context_file_uses_materializer(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    import narada.cli as cli_module
+
+    context_file = tmp_path / "context.json"
+    context_file.write_text(json.dumps({"executionTraceContext": TRACE_CONTEXT}), encoding="utf-8")
+    calls: list[dict[str, Any]] = []
+
+    async def fake_materialize(context: dict[str, Any], **kwargs: Any) -> Any:
+        calls.append({"context": context, **kwargs})
+
+        class _Result:
+            path = tmp_path / "proof"
+            report = {"status": "passed", "artifactCount": 0, "warnings": []}
+
+        return _Result()
+
+    monkeypatch.setattr(cli_module, "materialize_execution_trace_context", fake_materialize)
+
+    assert main(
+        [
+            "workbench",
+            "trace",
+            "materialize",
+            "--context-file",
+            str(context_file),
+            "--out",
+            str(tmp_path / "proof"),
+            "--json",
+        ]
+    ) == 0
+    assert calls[0]["context"] == TRACE_CONTEXT
+    assert calls[0]["source_run"] is None
+
+
+def test_cli_materialize_context_file_with_source_status_is_caller_attested(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    import narada.cli as cli_module
+
+    context_file = tmp_path / "context.json"
+    context_file.write_text(json.dumps({"executionTraceContext": TRACE_CONTEXT}), encoding="utf-8")
+    calls: list[dict[str, Any]] = []
+
+    async def fake_materialize(context: dict[str, Any], **kwargs: Any) -> Any:
+        calls.append({"context": context, **kwargs})
+
+        class _Result:
+            path = tmp_path / "proof"
+            report = {"status": "tainted", "artifactCount": 0, "warnings": []}
+
+        return _Result()
+
+    monkeypatch.setattr(cli_module, "materialize_execution_trace_context", fake_materialize)
+
+    assert main(
+        [
+            "workbench",
+            "trace",
+            "materialize",
+            "--context-file",
+            str(context_file),
+            "--source-status",
+            "completed",
+            "--source-request-id",
+            "req-123",
+            "--json",
+        ]
+    ) == 1
+    assert calls[0]["source_run"] == {
+        "type": "external",
+        "authority": "caller-attested",
+        "status": "completed",
+        "requestId": "req-123",
+    }
+
+
+def test_cli_materialize_request_id_uses_request_materializer(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    import narada.cli as cli_module
+
+    calls: list[dict[str, Any]] = []
+
+    async def fake_materialize(request_id: str, **kwargs: Any) -> Any:
+        calls.append({"request_id": request_id, **kwargs})
+
+        class _Result:
+            path = tmp_path / "proof"
+            report = {"status": "passed", "artifactCount": 0, "warnings": []}
+
+        return _Result()
+
+    monkeypatch.setattr(
+        cli_module,
+        "materialize_execution_trace_from_request_id",
+        fake_materialize,
+    )
+
+    assert main(
+        [
+            "workbench",
+            "trace",
+            "materialize",
+            "--request-id",
+            "req-123",
+            "--json",
+        ]
+    ) == 0
+    assert calls[0]["request_id"] == "req-123"

--- a/packages/narada/tests/test_workbench.py
+++ b/packages/narada/tests/test_workbench.py
@@ -22,7 +22,9 @@ TRACE_CONTEXT = {
 
 
 class _FakeResponse:
-    def __init__(self, *, payload: dict[str, Any] | None = None, body: bytes = b"") -> None:
+    def __init__(
+        self, *, payload: dict[str, Any] | None = None, body: bytes = b""
+    ) -> None:
         self._payload = payload
         self._body = body
 
@@ -97,7 +99,10 @@ class _FakeSession:
                                 "frameS3Key": "user-test/recording-trace-1/execution-trace/frame.json",
                                 "eventLabels": [],
                                 "reason": "test",
-                                "page": {"url": "https://example.test", "title": "Example"},
+                                "page": {
+                                    "url": "https://example.test",
+                                    "title": "Example",
+                                },
                             }
                         ],
                         "aliases": {},
@@ -152,7 +157,9 @@ class _FakeSession:
 
 
 @pytest.mark.asyncio
-async def test_materializer_writes_proof_root_without_signed_url_leaks(tmp_path: Path) -> None:
+async def test_materializer_writes_proof_root_without_signed_url_leaks(
+    tmp_path: Path,
+) -> None:
     result = await materialize_execution_trace_context(
         TRACE_CONTEXT,
         out=tmp_path,
@@ -172,7 +179,10 @@ async def test_materializer_writes_proof_root_without_signed_url_leaks(tmp_path:
     assert (tmp_path / "trace" / "resolved.json").exists()
     assert (tmp_path / "trace" / "frames" / "frame-1" / "page.html").exists()
     assert (tmp_path / "trace" / "frames" / "frame-1" / "screenshot.png").exists()
-    assert "X-Amz-Signature" not in (tmp_path / "trace" / "artifacts" / "index.jsonl").read_text()
+    assert (
+        "X-Amz-Signature"
+        not in (tmp_path / "trace" / "artifacts" / "index.jsonl").read_text()
+    )
 
     score = score_proof_root(tmp_path)
     assert score["status"] == "passed"
@@ -216,7 +226,9 @@ async def test_materializer_taints_missing_source_run_status(tmp_path: Path) -> 
     assert result.report["status"] == "tainted"
     score = score_proof_root(tmp_path)
     assert score["status"] == "tainted"
-    assert any(taint["code"] == "source_run_status_unknown" for taint in score["taints"])
+    assert any(
+        taint["code"] == "source_run_status_unknown" for taint in score["taints"]
+    )
 
 
 def _write_clean_minimal_root(root: Path) -> None:
@@ -300,7 +312,9 @@ def _write_clean_minimal_root(root: Path) -> None:
         encoding="utf-8",
     )
     (root / "trace" / "context.json").write_text(json.dumps(context), encoding="utf-8")
-    (root / "trace" / "resolved.json").write_text(json.dumps(resolved), encoding="utf-8")
+    (root / "trace" / "resolved.json").write_text(
+        json.dumps(resolved), encoding="utf-8"
+    )
     (root / "trace" / "events.jsonl").write_text(
         json.dumps(resolved["events"][0]) + "\n",
         encoding="utf-8",
@@ -322,7 +336,9 @@ def _write_clean_minimal_root(root: Path) -> None:
         + "\n",
         encoding="utf-8",
     )
-    (root / "reports" / "materialization-report.json").write_text("{}", encoding="utf-8")
+    (root / "reports" / "materialization-report.json").write_text(
+        "{}", encoding="utf-8"
+    )
     (root / "cleanup" / "status.json").write_text(
         json.dumps({"status": "not_applicable"}),
         encoding="utf-8",
@@ -331,7 +347,9 @@ def _write_clean_minimal_root(root: Path) -> None:
 
 def test_score_fails_signed_url_leak(tmp_path: Path) -> None:
     _write_clean_minimal_root(tmp_path)
-    (tmp_path / "trace" / "leak.txt").write_text("X-Amz-Signature=secret", encoding="utf-8")
+    (tmp_path / "trace" / "leak.txt").write_text(
+        "X-Amz-Signature=secret", encoding="utf-8"
+    )
 
     score = score_proof_root(tmp_path)
 
@@ -370,14 +388,18 @@ def test_score_fails_empty_shell_root(tmp_path: Path) -> None:
     score = score_proof_root(tmp_path)
 
     assert score["status"] == "failed"
-    assert any(failure["code"] == "empty_resolved_trace" for failure in score["failures"])
+    assert any(
+        failure["code"] == "empty_resolved_trace" for failure in score["failures"]
+    )
 
 
 def test_score_fails_resolved_trace_id_mismatch(tmp_path: Path) -> None:
     _write_clean_minimal_root(tmp_path)
     resolved = json.loads((tmp_path / "trace" / "resolved.json").read_text())
     resolved["manifest"]["traceId"] = "trace-other"
-    (tmp_path / "trace" / "resolved.json").write_text(json.dumps(resolved), encoding="utf-8")
+    (tmp_path / "trace" / "resolved.json").write_text(
+        json.dumps(resolved), encoding="utf-8"
+    )
 
     score = score_proof_root(tmp_path)
 
@@ -405,7 +427,9 @@ def test_score_fails_missing_referenced_artifact(tmp_path: Path) -> None:
     score = score_proof_root(tmp_path)
 
     assert score["status"] == "failed"
-    assert any(failure["code"] == "artifact_file_missing" for failure in score["failures"])
+    assert any(
+        failure["code"] == "artifact_file_missing" for failure in score["failures"]
+    )
 
 
 def test_score_fails_missing_resolved_artifact_download(tmp_path: Path) -> None:
@@ -464,7 +488,9 @@ def test_score_fails_artifact_path_escape(tmp_path: Path) -> None:
     score = score_proof_root(tmp_path)
 
     assert score["status"] == "failed"
-    assert any(failure["code"] == "artifact_path_escape" for failure in score["failures"])
+    assert any(
+        failure["code"] == "artifact_path_escape" for failure in score["failures"]
+    )
 
 
 def test_score_fails_secret_leak(tmp_path: Path) -> None:
@@ -482,7 +508,9 @@ def test_score_fails_secret_leak(tmp_path: Path) -> None:
 
 def test_score_fails_lowercase_signed_url_leak(tmp_path: Path) -> None:
     _write_clean_minimal_root(tmp_path)
-    (tmp_path / "trace" / "leak.txt").write_text("x-amz-signature=secret", encoding="utf-8")
+    (tmp_path / "trace" / "leak.txt").write_text(
+        "x-amz-signature=secret", encoding="utf-8"
+    )
 
     score = score_proof_root(tmp_path)
 
@@ -494,12 +522,16 @@ def test_score_fails_failed_trace_status(tmp_path: Path) -> None:
     _write_clean_minimal_root(tmp_path)
     resolved = json.loads((tmp_path / "trace" / "resolved.json").read_text())
     resolved["manifest"]["status"] = "failed"
-    (tmp_path / "trace" / "resolved.json").write_text(json.dumps(resolved), encoding="utf-8")
+    (tmp_path / "trace" / "resolved.json").write_text(
+        json.dumps(resolved), encoding="utf-8"
+    )
 
     score = score_proof_root(tmp_path)
 
     assert score["status"] == "failed"
-    assert any(failure["code"] == "trace_status_failed" for failure in score["failures"])
+    assert any(
+        failure["code"] == "trace_status_failed" for failure in score["failures"]
+    )
 
 
 def test_score_fails_missing_source_run(tmp_path: Path) -> None:
@@ -535,7 +567,9 @@ def test_score_taints_unknown_source_run_status(tmp_path: Path) -> None:
     score = score_proof_root(tmp_path)
 
     assert score["status"] == "tainted"
-    assert any(taint["code"] == "source_run_status_unknown" for taint in score["taints"])
+    assert any(
+        taint["code"] == "source_run_status_unknown" for taint in score["taints"]
+    )
 
 
 def test_score_taints_unverified_source_run_authority(tmp_path: Path) -> None:
@@ -562,7 +596,9 @@ def test_score_fails_non_terminal_source_run_status(tmp_path: Path) -> None:
     score = score_proof_root(tmp_path)
 
     assert score["status"] == "failed"
-    assert any(failure["code"] == "source_run_not_terminal" for failure in score["failures"])
+    assert any(
+        failure["code"] == "source_run_not_terminal" for failure in score["failures"]
+    )
 
 
 def test_score_fails_missing_manifest_hash(tmp_path: Path) -> None:
@@ -584,7 +620,9 @@ def test_score_fails_materialize_command_hash_mismatch(tmp_path: Path) -> None:
     _write_clean_minimal_root(tmp_path)
     command = json.loads((tmp_path / "commands.jsonl").read_text().splitlines()[0])
     command["ids"]["resolvedTraceHash"] = "wrong"
-    (tmp_path / "commands.jsonl").write_text(json.dumps(command) + "\n", encoding="utf-8")
+    (tmp_path / "commands.jsonl").write_text(
+        json.dumps(command) + "\n", encoding="utf-8"
+    )
 
     score = score_proof_root(tmp_path)
 
@@ -605,7 +643,9 @@ def test_score_fails_static_answer_marker(tmp_path: Path) -> None:
     score = score_proof_root(tmp_path)
 
     assert score["status"] == "failed"
-    assert any(failure["code"] == "static_answer_marker" for failure in score["failures"])
+    assert any(
+        failure["code"] == "static_answer_marker" for failure in score["failures"]
+    )
 
 
 def test_score_fails_renamed_answer_map_marker(tmp_path: Path) -> None:
@@ -618,7 +658,9 @@ def test_score_fails_renamed_answer_map_marker(tmp_path: Path) -> None:
     score = score_proof_root(tmp_path)
 
     assert score["status"] == "failed"
-    assert any(failure["code"] == "static_answer_marker" for failure in score["failures"])
+    assert any(
+        failure["code"] == "static_answer_marker" for failure in score["failures"]
+    )
 
 
 def test_score_fails_missing_materialize_command(tmp_path: Path) -> None:
@@ -647,7 +689,9 @@ def test_score_taints_workflow_self_review_marker(tmp_path: Path) -> None:
     score = score_proof_root(tmp_path)
 
     assert score["status"] == "tainted"
-    assert any(taint["code"] == "workflow_self_review_marker" for taint in score["taints"])
+    assert any(
+        taint["code"] == "workflow_self_review_marker" for taint in score["taints"]
+    )
 
 
 def test_score_taints_renamed_self_review_marker(tmp_path: Path) -> None:
@@ -660,7 +704,9 @@ def test_score_taints_renamed_self_review_marker(tmp_path: Path) -> None:
     score = score_proof_root(tmp_path)
 
     assert score["status"] == "tainted"
-    assert any(taint["code"] == "workflow_self_review_marker" for taint in score["taints"])
+    assert any(
+        taint["code"] == "workflow_self_review_marker" for taint in score["taints"]
+    )
 
 
 def test_score_taints_cleanup_failure(tmp_path: Path) -> None:
@@ -694,12 +740,16 @@ def test_score_taints_prior_failed_command(tmp_path: Path) -> None:
     score = score_proof_root(tmp_path)
 
     assert score["status"] == "tainted"
-    assert any(taint["code"] == "materialize_command_not_clean" for taint in score["taints"])
+    assert any(
+        taint["code"] == "materialize_command_not_clean" for taint in score["taints"]
+    )
 
 
 def test_cli_score_returns_nonzero_for_failed_root(tmp_path: Path) -> None:
     _write_clean_minimal_root(tmp_path)
-    (tmp_path / "trace" / "leak.txt").write_text("X-Amz-Credential=secret", encoding="utf-8")
+    (tmp_path / "trace" / "leak.txt").write_text(
+        "X-Amz-Credential=secret", encoding="utf-8"
+    )
 
     assert main(["workbench", "score", str(tmp_path), "--json"]) == 1
 
@@ -711,7 +761,9 @@ def test_cli_materialize_context_file_uses_materializer(
     import narada.cli as cli_module
 
     context_file = tmp_path / "context.json"
-    context_file.write_text(json.dumps({"executionTraceContext": TRACE_CONTEXT}), encoding="utf-8")
+    context_file.write_text(
+        json.dumps({"executionTraceContext": TRACE_CONTEXT}), encoding="utf-8"
+    )
     calls: list[dict[str, Any]] = []
 
     async def fake_materialize(context: dict[str, Any], **kwargs: Any) -> Any:
@@ -723,20 +775,25 @@ def test_cli_materialize_context_file_uses_materializer(
 
         return _Result()
 
-    monkeypatch.setattr(cli_module, "materialize_execution_trace_context", fake_materialize)
+    monkeypatch.setattr(
+        cli_module, "materialize_execution_trace_context", fake_materialize
+    )
 
-    assert main(
-        [
-            "workbench",
-            "trace",
-            "materialize",
-            "--context-file",
-            str(context_file),
-            "--out",
-            str(tmp_path / "proof"),
-            "--json",
-        ]
-    ) == 0
+    assert (
+        main(
+            [
+                "workbench",
+                "trace",
+                "materialize",
+                "--context-file",
+                str(context_file),
+                "--out",
+                str(tmp_path / "proof"),
+                "--json",
+            ]
+        )
+        == 0
+    )
     assert calls[0]["context"] == TRACE_CONTEXT
     assert calls[0]["source_run"] is None
 
@@ -748,7 +805,9 @@ def test_cli_materialize_context_file_with_source_status_is_caller_attested(
     import narada.cli as cli_module
 
     context_file = tmp_path / "context.json"
-    context_file.write_text(json.dumps({"executionTraceContext": TRACE_CONTEXT}), encoding="utf-8")
+    context_file.write_text(
+        json.dumps({"executionTraceContext": TRACE_CONTEXT}), encoding="utf-8"
+    )
     calls: list[dict[str, Any]] = []
 
     async def fake_materialize(context: dict[str, Any], **kwargs: Any) -> Any:
@@ -760,22 +819,27 @@ def test_cli_materialize_context_file_with_source_status_is_caller_attested(
 
         return _Result()
 
-    monkeypatch.setattr(cli_module, "materialize_execution_trace_context", fake_materialize)
+    monkeypatch.setattr(
+        cli_module, "materialize_execution_trace_context", fake_materialize
+    )
 
-    assert main(
-        [
-            "workbench",
-            "trace",
-            "materialize",
-            "--context-file",
-            str(context_file),
-            "--source-status",
-            "completed",
-            "--source-request-id",
-            "req-123",
-            "--json",
-        ]
-    ) == 1
+    assert (
+        main(
+            [
+                "workbench",
+                "trace",
+                "materialize",
+                "--context-file",
+                str(context_file),
+                "--source-status",
+                "completed",
+                "--source-request-id",
+                "req-123",
+                "--json",
+            ]
+        )
+        == 1
+    )
     assert calls[0]["source_run"] == {
         "type": "external",
         "authority": "caller-attested",
@@ -807,14 +871,17 @@ def test_cli_materialize_request_id_uses_request_materializer(
         fake_materialize,
     )
 
-    assert main(
-        [
-            "workbench",
-            "trace",
-            "materialize",
-            "--request-id",
-            "req-123",
-            "--json",
-        ]
-    ) == 0
+    assert (
+        main(
+            [
+                "workbench",
+                "trace",
+                "materialize",
+                "--request-id",
+                "req-123",
+                "--json",
+            ]
+        )
+        == 0
+    )
     assert calls[0]["request_id"] == "req-123"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,9 @@ build-backend = "hatchling.build"
 [tool.ruff.lint]
 extend-select = ["I"]
 
+[tool.pytest.ini_options]
+addopts = ["--import-mode=importlib"]
+
 [tool.uv.workspace]
 members = ["packages/*"]
 

--- a/uv.lock
+++ b/uv.lock
@@ -312,7 +312,7 @@ wheels = [
 
 [[package]]
 name = "narada"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "packages/narada" }
 dependencies = [
     { name = "aiohttp" },
@@ -345,7 +345,7 @@ dev = [
 
 [[package]]
 name = "narada-core"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "packages/narada-core" }
 dependencies = [
     { name = "pydantic" },
@@ -356,7 +356,7 @@ requires-dist = [{ name = "pydantic", specifier = "==2.12.5" }]
 
 [[package]]
 name = "narada-pyodide"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "packages/narada-pyodide" }
 dependencies = [
     { name = "narada-core" },


### PR DESCRIPTION
## Summary

Adds the SDK-side M1 verifier spine for Agent Maker Workbench:

- exposes `execution_trace_context` on CPython and Pyodide `Agent.run()` responses
- adds shared ExecutionTrace context model support
- adds `trace()` and `Agent.run(trace=True)` materialization paths
- adds `narada workbench trace materialize`, `score`, and `verify`
- writes local proof roots with manifest, command ledger, resolved trace files, artifact index, score, and verification reports
- hardens provenance and anti-reward-hacking checks for source-run authority, non-terminal runs, stale roots, missing artifacts, signed URL leaks, secret leaks, static answer maps, self-review markers, and cleanup failures

## Validation

- `uv run ruff check packages/narada packages/narada-core packages/narada-pyodide` → passed
- `uv run pytest packages/narada/tests packages/narada-pyodide/tests/test_cloud_browser.py` → 85 passed
- Final clean signed-stack proof: `/tmp/narada-e2e-runs/20260609T000509Z-stack-m1-clean-trace-proof-20260608170509`
- Clean nested APA trace proof: `/tmp/narada-e2e-runs/20260609T000658Z-executiontrace-1c09a9402aed4eae9ac6973ea9afd5bb`
- Clean SDK request-id materialization proof: `/tmp/narada-workbench-runs/m1-clean-sdk-request-materialized-20260609T001137Z`
- Independent review subagent verdict: `PASS`

## Codex sibling refs

- frontend: main
- caddie: NaradaAI/caddie#6601
- narada-python-sdk:
- architecture-docs: NaradaAI/architecture-docs#24
