### PR TITLE
[Narada Code 4] Add browser exploration workbench CLI

### DIFF
--- a/packages/narada-core/src/narada_core/actions/models.py
+++ b/packages/narada-core/src/narada_core/actions/models.py
@@ -419,6 +419,128 @@ class ExecuteJavaScriptOnPageResponse(BaseModel):
     result: JsonValue
 
 
+class BrowserPageSnapshotRequest(BaseModel):
+    name: Literal["browser_page_snapshot"] = "browser_page_snapshot"
+    snapshot_id: str | None = None
+    max_html_bytes: int = Field(default=500_000, ge=1, le=950_000)
+    include_visible_text: bool = True
+    max_visible_text_bytes: int = Field(default=200_000, ge=1, le=500_000)
+
+
+class BrowserPageSnapshotResponse(BaseModel):
+    snapshot_id: str
+    url: str
+    title: str
+    active: bool
+    html: str
+    html_truncated: bool
+    visible_text: str | None = None
+    visible_text_truncated: bool = False
+    elements: list[dict[str, JsonValue]] = Field(default_factory=list)
+    frames: list[dict[str, JsonValue]] = Field(default_factory=list)
+    meta: dict[str, JsonValue] = Field(default_factory=dict)
+
+
+class BrowserFindInSnapshotRequest(BaseModel):
+    name: Literal["browser_find_in_snapshot"] = "browser_find_in_snapshot"
+    text: str | None = None
+    tag_name: str | None = None
+    data_nrd: str | None = None
+    interactive_only: bool = False
+    limit: int = Field(default=20, ge=1, le=100)
+
+
+class BrowserFindInSnapshotResponse(BaseModel):
+    matches: list[dict[str, JsonValue]]
+
+
+class BrowserElementHandle(BaseModel):
+    snapshot_id: str = Field(min_length=1)
+    frame_id: str = Field(min_length=1)
+    data_nrd: str = Field(min_length=1)
+    snapshot_url: str = Field(min_length=1)
+    element_fingerprint: str = Field(min_length=1)
+
+
+class BrowserElementInfoRequest(BaseModel):
+    name: Literal["browser_element_info"] = "browser_element_info"
+    handle: BrowserElementHandle
+
+
+class BrowserElementInfoResponse(BaseModel):
+    element: dict[str, JsonValue]
+
+
+class BrowserGetSelectorsRequest(BaseModel):
+    name: Literal["browser_get_selectors"] = "browser_get_selectors"
+    handle: BrowserElementHandle
+
+
+class BrowserGetSelectorsResponse(BaseModel):
+    selectors: dict[str, JsonValue]
+    diagnostic: bool = True
+
+
+class BrowserClickNrdRequest(BaseModel):
+    name: Literal["browser_click_nrd"] = "browser_click_nrd"
+    handle: BrowserElementHandle
+    post_snapshot: bool = True
+
+
+class BrowserFillNrdRequest(BaseModel):
+    name: Literal["browser_fill_nrd"] = "browser_fill_nrd"
+    handle: BrowserElementHandle
+    value: str
+    clear: bool = True
+    post_snapshot: bool = True
+
+
+class BrowserSelectNrdRequest(BaseModel):
+    name: Literal["browser_select_nrd"] = "browser_select_nrd"
+    handle: BrowserElementHandle
+    value: str
+    post_snapshot: bool = True
+
+
+class BrowserActionResponse(BaseModel):
+    status: Literal["performed"] = "performed"
+    post_snapshot: BrowserPageSnapshotResponse | None = None
+
+
+class BrowserSnapshotDiffRequest(BaseModel):
+    name: Literal["browser_snapshot_diff"] = "browser_snapshot_diff"
+    before_html: str
+    after_html: str
+
+
+class BrowserSnapshotDiffResponse(BaseModel):
+    added_text: list[str]
+    removed_text: list[str]
+
+
+class BrowserScreenshotRequest(BaseModel):
+    name: Literal["browser_screenshot"] = "browser_screenshot"
+    timeout_ms: int | None = Field(default=None, ge=1_000, le=60_000)
+
+
+class BrowserScreenshotResponse(BaseModel):
+    base64_content: str
+    name: str
+    mime_type: str
+    timestamp: str
+
+
+class BrowserDownloadsRequest(BaseModel):
+    name: Literal["browser_downloads"] = "browser_downloads"
+    started_after: str | None = None
+
+
+class BrowserDownloadsResponse(BaseModel):
+    downloads: list[dict[str, JsonValue]]
+    capture_supported: bool = True
+    warning: str | None = None
+
+
 class PromptForUserInputVariable(BaseModel):
     name: str
     type: Literal["string", "number", "boolean", "enum", "dataTable", "object", "array"]
@@ -477,6 +599,16 @@ type ExtensionActionRequest = (
     | GetScreenshotRequest
     | GetUrlRequest
     | ExecuteJavaScriptOnPageRequest
+    | BrowserPageSnapshotRequest
+    | BrowserFindInSnapshotRequest
+    | BrowserElementInfoRequest
+    | BrowserGetSelectorsRequest
+    | BrowserClickNrdRequest
+    | BrowserFillNrdRequest
+    | BrowserSelectNrdRequest
+    | BrowserSnapshotDiffRequest
+    | BrowserScreenshotRequest
+    | BrowserDownloadsRequest
     | PromptForUserInputRequest
     | UserApprovalRequest
 )

--- a/packages/narada/src/narada/_workbench_contract.py
+++ b/packages/narada/src/narada/_workbench_contract.py
@@ -31,6 +31,5 @@ BINARY_SCAN_SUFFIXES: Final[tuple[str, ...]] = (
 CLEAN_COMMAND_STATUSES: Final[tuple[str, ...]] = (
     "passed",
     "materialized",
-    "needs_review",
     "not_applicable",
 )

--- a/packages/narada/src/narada/browser_workbench.py
+++ b/packages/narada/src/narada/browser_workbench.py
@@ -1,9 +1,16 @@
 from __future__ import annotations
 
+import asyncio
 import base64
 import json
+import os
 import re
 import shutil
+import signal
+import socket
+import subprocess
+import sys
+import time
 import uuid
 from dataclasses import dataclass
 from datetime import datetime
@@ -44,6 +51,7 @@ from narada.workbench import (
 )
 
 BROWSER_WORKBENCH_SCREENSHOT_TIMEOUT_MS = 45_000
+LOCAL_BROWSER_PROCESS_CLEANUP_TIMEOUT_S = 5.0
 
 
 @dataclass(frozen=True)
@@ -152,6 +160,238 @@ def _append_jsonl(path: Path, row: dict[str, Any]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     with path.open("a", encoding="utf-8") as handle:
         handle.write(json.dumps(row, sort_keys=True) + "\n")
+
+
+def _positive_int(value: Any) -> int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int) and value > 0:
+        return value
+    if isinstance(value, str) and value.isdigit():
+        parsed = int(value)
+        return parsed if parsed > 0 else None
+    return None
+
+
+def _local_process_is_running(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    except OSError:
+        return False
+    return True
+
+
+async def _terminate_local_process(
+    pid: int, *, timeout_s: float = LOCAL_BROWSER_PROCESS_CLEANUP_TIMEOUT_S
+) -> dict[str, Any]:
+    if not _local_process_is_running(pid):
+        return {"status": "already_exited", "pid": pid}
+
+    if sys.platform == "win32":
+        try:
+            result = await asyncio.to_thread(
+                subprocess.run,
+                ["taskkill", "/PID", str(pid), "/T", "/F"],
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=timeout_s,
+            )
+        except Exception as exc:  # pragma: no cover - platform-specific fallback.
+            return {
+                "status": "terminate_failed",
+                "pid": pid,
+                "error": _redact_sensitive_text(f"{type(exc).__name__}: {exc}"),
+            }
+        if result.returncode == 0 or not _local_process_is_running(pid):
+            return {"status": "terminated", "pid": pid}
+        return {
+            "status": "terminate_failed",
+            "pid": pid,
+            "error": _redact_sensitive_text(result.stderr or result.stdout),
+        }
+
+    try:
+        process_group_id = os.getpgid(pid)
+    except ProcessLookupError:
+        return {"status": "already_exited", "pid": pid}
+    except Exception as exc:
+        return {
+            "status": "terminate_failed",
+            "pid": pid,
+            "error": _redact_sensitive_text(f"{type(exc).__name__}: {exc}"),
+        }
+
+    try:
+        os.killpg(process_group_id, signal.SIGTERM)
+    except ProcessLookupError:
+        return {"status": "already_exited", "pid": pid}
+    except PermissionError as exc:
+        return {
+            "status": "terminate_failed",
+            "pid": pid,
+            "error": _redact_sensitive_text(f"{type(exc).__name__}: {exc}"),
+        }
+
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        if not _local_process_is_running(pid):
+            return {"status": "terminated", "pid": pid}
+        await asyncio.sleep(0.1)
+
+    try:
+        os.killpg(process_group_id, signal.SIGKILL)
+    except ProcessLookupError:
+        return {"status": "terminated", "pid": pid}
+    except PermissionError as exc:
+        return {
+            "status": "terminate_failed",
+            "pid": pid,
+            "error": _redact_sensitive_text(f"{type(exc).__name__}: {exc}"),
+        }
+
+    deadline = time.monotonic() + min(timeout_s, 2.0)
+    while time.monotonic() < deadline:
+        if not _local_process_is_running(pid):
+            return {"status": "terminated", "pid": pid, "forced": True}
+        await asyncio.sleep(0.1)
+
+    return {"status": "terminate_failed", "pid": pid, "error": "process remained alive"}
+
+
+def _process_command_line(pid: int) -> str | None:
+    if sys.platform == "win32":
+        try:
+            result = subprocess.run(
+                [
+                    "wmic",
+                    "process",
+                    "where",
+                    f"ProcessId={pid}",
+                    "get",
+                    "CommandLine",
+                    "/value",
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=2,
+            )
+        except Exception:
+            return None
+        if result.returncode != 0:
+            return None
+        for line in result.stdout.splitlines():
+            if line.startswith("CommandLine="):
+                return line.removeprefix("CommandLine=").strip() or None
+        return None
+
+    try:
+        result = subprocess.run(
+            ["ps", "-p", str(pid), "-o", "command="],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=2,
+        )
+    except Exception:
+        return None
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip() or None
+
+
+def _command_line_has_exact_option_value(
+    command_line: str,
+    option: str,
+    value: Any,
+) -> bool:
+    if value is None:
+        return False
+    expected = f"--{option}={value}"
+    return re.search(rf"(?<!\S){re.escape(expected)}(?!\S)", command_line) is not None
+
+
+def _local_process_identity_status(pid: int, record: dict[str, Any]) -> dict[str, Any]:
+    command_line = _process_command_line(pid)
+    if not command_line:
+        return {"status": "identity_unverified", "pid": pid}
+
+    expected_options = {
+        "remote-debugging-port": record.get("cdpPort"),
+        "user-data-dir": record.get("userDataDir"),
+    }
+    if any(value is None for value in expected_options.values()):
+        return {"status": "identity_unverified", "pid": pid}
+
+    missing = [
+        f"--{option}={value}"
+        for option, value in expected_options.items()
+        if not _command_line_has_exact_option_value(command_line, option, value)
+    ]
+    if missing:
+        return {
+            "status": "identity_mismatch",
+            "pid": pid,
+            "missingMarkers": missing,
+        }
+    return {"status": "verified", "pid": pid}
+
+
+def _tcp_port_is_listening(port: int, host: str | None = None) -> bool:
+    hosts = (host,) if host else ("127.0.0.1", "::1")
+    for candidate_host in hosts:
+        try:
+            with socket.create_connection((candidate_host, port), timeout=0.25):
+                return True
+        except OSError:
+            continue
+    return False
+
+
+async def _cleanup_sdk_created_local_browser_process(
+    record: dict[str, Any],
+) -> tuple[dict[str, Any], list[str], list[str]]:
+    process_id = _positive_int(record.get("browserProcessId"))
+    cdp_port = _positive_int(record.get("cdpPort"))
+    cdp_host = record.get("cdpHost")
+    updates: dict[str, Any] = {}
+    warnings: list[str] = []
+    failures: list[str] = []
+
+    if process_id is None:
+        updates["localBrowserProcessStatus"] = "not_tracked"
+    elif _local_process_is_running(process_id):
+        identity = _local_process_identity_status(process_id, record)
+        updates["localBrowserProcessIdentity"] = identity
+        if identity["status"] != "verified":
+            updates["localBrowserProcessStatus"] = identity["status"]
+            failures.append("local_browser_process_identity_not_verified")
+        else:
+            process_cleanup = await _terminate_local_process(process_id)
+            updates["localBrowserProcessStatus"] = process_cleanup["status"]
+            updates["localBrowserProcessCleanup"] = process_cleanup
+            if process_cleanup["status"] == "terminated":
+                warnings.append("local_browser_process_terminated_after_remote_close")
+            elif process_cleanup["status"] != "already_exited":
+                failures.append("local_browser_process_cleanup_failed")
+    else:
+        updates["localBrowserProcessStatus"] = "already_exited"
+
+    if cdp_port is not None:
+        if _tcp_port_is_listening(
+            cdp_port, cdp_host if isinstance(cdp_host, str) else None
+        ):
+            updates["localBrowserCdpPortStatus"] = "listening"
+            failures.append("local_browser_cdp_port_still_listening")
+        else:
+            updates["localBrowserCdpPortStatus"] = "closed"
+
+    return updates, warnings, failures
 
 
 def _artifact(
@@ -465,6 +705,11 @@ async def env_open(
         )
 
     config = BrowserConfig(
+        executable_path=os.environ.get(
+            "NARADA_LOCAL_DEV_CHROME_EXECUTABLE_PATH",
+            BrowserConfig().executable_path,
+        ),
+        cdp_host=os.environ.get("NARADA_LOCAL_DEV_CDP_HOST", BrowserConfig().cdp_host),
         initialization_url=initialization_url or BrowserConfig().initialization_url,
         cdp_port=cdp_port or BrowserConfig().cdp_port,
         extension_id=extension_id or BrowserConfig().extension_id,
@@ -489,9 +734,13 @@ async def env_open(
         "apiBaseUrl": api_base_url,
         "apiBaseUrlOrigin": _origin(api_base_url),
         "initializationUrlOrigin": _origin(config.initialization_url),
+        "chromeExecutablePath": config.executable_path,
+        "cdpHost": config.cdp_host,
         "cdpPort": config.cdp_port,
         "extensionId": config.extension_id,
+        "userDataDir": config.user_data_dir,
         "attachToExisting": attach_to_existing,
+        "ownership": "sdk-created" if not attach_to_existing else "adopted",
     }
     artifact = _write_env(root, name, record)
     await env._stop_playwright()
@@ -543,6 +792,10 @@ async def env_close(
     root = _browser_root(proof_root, f"browser-env-{env_id}")
     record = _load_env(root, env_id)
     is_adopted = record.get("adoptedBrowserWindow") is True
+    is_sdk_created_local = (
+        record.get("ownership") == "sdk-created"
+        and record.get("attachToExisting") is not True
+    )
     warnings: list[str] = []
     if is_adopted and not close_adopted:
         record = {
@@ -553,19 +806,62 @@ async def env_close(
         warnings.append("adopted_browser_not_closed")
     else:
         env = _remote_env(record, base_url=base_url)
-        await env.close(timeout=30)
-        record = {**record, "status": "closed", "closeBehavior": "closed"}
+        try:
+            await env.close(timeout=30)
+        except Exception as exc:
+            close_error = _redact_sensitive_text(
+                f"{type(exc).__name__}: {str(exc) or '<empty>'}"
+            )
+            record = {
+                **record,
+                "status": "close_failed",
+                "closeBehavior": "close_failed",
+                "closeError": close_error,
+            }
+            warnings.append("browser_environment_close_failed")
+        else:
+            cleanup_failures: list[str] = []
+            if is_sdk_created_local:
+                (
+                    process_updates,
+                    process_warnings,
+                    cleanup_failures,
+                ) = await _cleanup_sdk_created_local_browser_process(record)
+                record = {**record, **process_updates}
+                warnings.extend(process_warnings)
+            if cleanup_failures:
+                record = {
+                    **record,
+                    "status": "close_failed",
+                    "closeBehavior": "process_cleanup_failed",
+                    "closeError": "; ".join(cleanup_failures),
+                }
+                warnings.append("browser_environment_process_cleanup_failed")
+            else:
+                record = {**record, "status": "closed", "closeBehavior": "closed"}
     artifact = _write_env_lifecycle_snapshot(
         root, env_id, str(record["status"]), record
     )
     _write_json(
         root / "cleanup" / "status.json",
-        {"status": "passed", "browserEnvironmentStatus": record["status"]},
+        {
+            "status": "failed" if record["status"] == "close_failed" else "passed",
+            "browserEnvironmentStatus": record["status"],
+            "browserProcessId": record.get("browserProcessId"),
+            "localBrowserProcessStatus": record.get("localBrowserProcessStatus"),
+            "localBrowserProcessIdentity": record.get("localBrowserProcessIdentity"),
+            "localBrowserCdpPortStatus": record.get("localBrowserCdpPortStatus"),
+            **(
+                {"error": record["closeError"]}
+                if record.get("closeError") is not None
+                else {}
+            ),
+        },
     )
     return _finish_command(
         root,
         command="env.close",
-        status="passed",
+        status="failed" if record["status"] == "close_failed" else "passed",
         payload={"environment": record},
         artifacts=[artifact],
         warnings=warnings,

--- a/packages/narada/src/narada/browser_workbench.py
+++ b/packages/narada/src/narada/browser_workbench.py
@@ -1,0 +1,963 @@
+from __future__ import annotations
+
+import base64
+import json
+import re
+import shutil
+import uuid
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlsplit, urlunsplit
+
+from narada_core.actions.models import (
+    BrowserActionResponse,
+    BrowserClickNrdRequest,
+    BrowserDownloadsRequest,
+    BrowserDownloadsResponse,
+    BrowserElementHandle,
+    BrowserFillNrdRequest,
+    BrowserPageSnapshotRequest,
+    BrowserPageSnapshotResponse,
+    BrowserScreenshotRequest,
+    BrowserScreenshotResponse,
+    BrowserSelectNrdRequest,
+    GetUrlRequest,
+    GetUrlResponse,
+    GoToUrlRequest,
+)
+
+from narada.config import BrowserConfig
+from narada.environment import BrowserEnvironment, RemoteBrowserEnvironment
+from narada.workbench import (
+    _default_out_dir,
+    _redact_sensitive_text,
+    _redact_url,
+    _sha256_file,
+    _update_manifest_hash,
+    _write_json,
+    _write_redaction_report,
+    append_command,
+    default_api_base_url,
+    default_auth_headers,
+)
+
+BROWSER_WORKBENCH_SCREENSHOT_TIMEOUT_MS = 45_000
+
+
+@dataclass(frozen=True)
+class BrowserWorkbenchCommandResult:
+    status: str
+    payload: dict[str, Any]
+    command_id: str
+    proof_root: Path
+
+
+def _safe_slug(value: str) -> str:
+    cleaned = re.sub(r"[^A-Za-z0-9._-]+", "-", value).strip("-._")
+    return cleaned[:80] or "browser"
+
+
+def _parse_iso_datetime(value: Any) -> datetime | None:
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def _proof_root_started_after(root: Path) -> str | None:
+    commands_path = root / "commands.jsonl"
+    if not commands_path.exists():
+        return None
+    for line in commands_path.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        try:
+            row = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        started_at = row.get("startedAt")
+        if isinstance(started_at, str) and _parse_iso_datetime(started_at):
+            return started_at
+    return None
+
+
+def _download_is_in_scope(download: dict[str, Any], started_after: str | None) -> bool:
+    lower_bound = _parse_iso_datetime(started_after)
+    if lower_bound is None:
+        return True
+    start_time = _parse_iso_datetime(
+        download.get("start_time") or download.get("startTime")
+    )
+    end_time = _parse_iso_datetime(download.get("end_time") or download.get("endTime"))
+    observed_time = start_time or end_time
+    if observed_time is None:
+        return True
+    return observed_time >= lower_bound
+
+
+def _origin(value: str) -> str:
+    split = urlsplit(value)
+    return urlunsplit((split.scheme, split.netloc, "", "", ""))
+
+
+def _browser_root(proof_root: str | Path | None, label: str) -> Path:
+    root = Path(proof_root) if proof_root is not None else _default_out_dir(label)
+    preexisting_root = root.exists() and any(root.iterdir())
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "browser").mkdir(parents=True, exist_ok=True)
+    (root / "cleanup").mkdir(parents=True, exist_ok=True)
+    manifest_path = root / "manifest.json"
+    if not manifest_path.exists():
+        _write_json(
+            manifest_path,
+            {
+                "schemaVersion": 1,
+                "proofRootKind": "browser-workbench",
+                "runId": root.name,
+                "label": label,
+                "status": "materialized",
+                "sensitiveArtifacts": True,
+                "taints": ["proof_root_preexisting"] if preexisting_root else [],
+                "failures": [],
+            },
+        )
+    cleanup_path = root / "cleanup" / "status.json"
+    if not cleanup_path.exists():
+        _write_json(
+            cleanup_path,
+            {"status": "open", "reason": "browser workbench environment may be active"},
+        )
+    _write_redaction_report(root)
+    return root
+
+
+def _add_manifest_taint(root: Path, taint: str) -> None:
+    manifest_path = root / "manifest.json"
+    if not manifest_path.exists():
+        return
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    if not isinstance(manifest, dict):
+        return
+    taints = manifest.setdefault("taints", [])
+    if isinstance(taints, list) and taint not in taints:
+        taints.append(taint)
+    _write_json(manifest_path, manifest)
+
+
+def _append_jsonl(path: Path, row: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(row, sort_keys=True) + "\n")
+
+
+def _artifact(
+    root: Path, path: Path, role: str, *, sensitive: bool = True
+) -> dict[str, Any]:
+    return {
+        "path": path.relative_to(root).as_posix(),
+        "role": role,
+        "sha256": _sha256_file(path),
+        "sensitive": sensitive,
+    }
+
+
+def _append_artifacts(root: Path, artifacts: list[dict[str, Any]]) -> None:
+    artifact_index = root / "browser" / "artifacts.jsonl"
+    for artifact in artifacts:
+        _append_jsonl(artifact_index, artifact)
+
+
+def _finish_command(
+    root: Path,
+    *,
+    command: str,
+    status: str,
+    payload: dict[str, Any],
+    command_id: str | None = None,
+    artifacts: list[dict[str, Any]] | None = None,
+    warnings: list[str] | None = None,
+    taints: list[str] | None = None,
+    ids: dict[str, Any] | None = None,
+    inputs: dict[str, Any] | None = None,
+) -> BrowserWorkbenchCommandResult:
+    artifact_rows = artifacts or []
+    if artifact_rows:
+        _append_artifacts(root, artifact_rows)
+    row = append_command(
+        root,
+        command=command,
+        status=status,
+        command_id=command_id,
+        artifacts=artifact_rows,
+        warnings=warnings,
+        taints=taints,
+        ids=ids,
+        inputs=inputs,
+    )
+    _write_redaction_report(root)
+    _update_manifest_hash(root, "commandLedgerHash", root / "commands.jsonl")
+    artifact_index = root / "browser" / "artifacts.jsonl"
+    if artifact_index.exists():
+        _update_manifest_hash(root, "browserArtifactIndexHash", artifact_index)
+    return BrowserWorkbenchCommandResult(
+        status=status,
+        payload={
+            **payload,
+            "schemaVersion": 1,
+            "status": status,
+            "proofRoot": str(root),
+        },
+        command_id=row["commandId"],
+        proof_root=root,
+    )
+
+
+def _env_path(root: Path, env_id: str) -> Path:
+    return root / "browser" / "environments" / f"{_safe_slug(env_id)}.json"
+
+
+def _load_env(root: Path, env_id: str) -> dict[str, Any]:
+    path = _env_path(root, env_id)
+    if not path.exists():
+        raise ValueError(f"Unknown browser environment {env_id!r} in {root}")
+    loaded = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(loaded, dict):
+        raise ValueError(f"Browser environment record {path} is not an object")
+    return loaded
+
+
+def _remote_env(
+    record: dict[str, Any], *, base_url: str | None
+) -> RemoteBrowserEnvironment:
+    browser_window_id = record.get("browserWindowId")
+    if not isinstance(browser_window_id, str) or not browser_window_id:
+        raise ValueError("Browser environment record has no browserWindowId")
+    return RemoteBrowserEnvironment(
+        browser_window_id=browser_window_id,
+        auth_headers=default_auth_headers(),
+        base_url=base_url or record.get("apiBaseUrl") or default_api_base_url(),
+    )
+
+
+def _write_env(root: Path, env_id: str, record: dict[str, Any]) -> dict[str, Any]:
+    path = _env_path(root, env_id)
+    _write_json(path, record)
+    return _artifact(root, path, "browser-environment", sensitive=False)
+
+
+def _write_env_lifecycle_snapshot(
+    root: Path, env_id: str, status: str, record: dict[str, Any]
+) -> dict[str, Any]:
+    path = root / "browser" / "environments" / f"{_safe_slug(env_id)}-{status}.json"
+    _write_json(path, record)
+    return _artifact(root, path, "browser-environment", sensitive=False)
+
+
+def _snapshot_dir(root: Path, snapshot_id: str) -> Path:
+    return root / "browser" / "snapshots" / _safe_slug(snapshot_id)
+
+
+def _write_snapshot(
+    root: Path, snapshot: BrowserPageSnapshotResponse
+) -> list[dict[str, Any]]:
+    snapshot_id = snapshot.snapshot_id
+    directory = _snapshot_dir(root, snapshot_id)
+    summary = snapshot.model_dump(
+        exclude={"html", "visible_text", "elements", "frames"}
+    )
+    summary["paths"] = {
+        "html": f"browser/snapshots/{_safe_slug(snapshot_id)}/simplified.html",
+        "visibleText": f"browser/snapshots/{_safe_slug(snapshot_id)}/visible-text.txt",
+        "elements": f"browser/snapshots/{_safe_slug(snapshot_id)}/elements.json",
+        "frames": f"browser/snapshots/{_safe_slug(snapshot_id)}/frames.json",
+    }
+    summary_path = directory / "summary.json"
+    html_path = directory / "simplified.html"
+    text_path = directory / "visible-text.txt"
+    elements_path = directory / "elements.json"
+    frames_path = directory / "frames.json"
+    _write_json(summary_path, summary)
+    html_path.write_text(snapshot.html, encoding="utf-8")
+    text_path.write_text(snapshot.visible_text or "", encoding="utf-8")
+    _write_json(elements_path, snapshot.elements)
+    _write_json(frames_path, snapshot.frames)
+    _append_jsonl(
+        root / "browser" / "page-snapshots.jsonl",
+        {
+            "snapshotId": snapshot_id,
+            "url": snapshot.url,
+            "title": snapshot.title,
+            "htmlTruncated": snapshot.html_truncated,
+            "visibleTextTruncated": snapshot.visible_text_truncated,
+            "summaryPath": summary_path.relative_to(root).as_posix(),
+        },
+    )
+    return [
+        _artifact(root, summary_path, "browser-snapshot-summary", sensitive=False),
+        _artifact(root, html_path, "browser-snapshot-html"),
+        _artifact(root, text_path, "browser-snapshot-visible-text"),
+        _artifact(root, elements_path, "browser-snapshot-elements"),
+        _artifact(root, frames_path, "browser-snapshot-frames"),
+    ]
+
+
+def _load_snapshot_summary(root: Path, snapshot_id: str) -> dict[str, Any]:
+    path = _snapshot_dir(root, snapshot_id) / "summary.json"
+    if not path.exists():
+        raise ValueError(f"Unknown browser snapshot {snapshot_id!r}")
+    loaded = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(loaded, dict):
+        raise ValueError(f"Browser snapshot summary {path} is not an object")
+    return loaded
+
+
+def _load_snapshot_elements(root: Path, snapshot_id: str) -> list[dict[str, Any]]:
+    path = _snapshot_dir(root, snapshot_id) / "elements.json"
+    if not path.exists():
+        raise ValueError(f"Browser snapshot {snapshot_id!r} has no elements.json")
+    loaded = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(loaded, list):
+        raise ValueError(f"Browser snapshot elements {path} is not a list")
+    return [item for item in loaded if isinstance(item, dict)]
+
+
+def _element_for_handle(
+    root: Path,
+    *,
+    snapshot_id: str,
+    frame_id: str,
+    data_nrd: str,
+) -> dict[str, Any]:
+    for element in _load_snapshot_elements(root, snapshot_id):
+        if element.get("data_nrd") == data_nrd and element.get("frame_id") == frame_id:
+            return element
+    raise ValueError(
+        f"No element with data-nrd {data_nrd!r} and frame {frame_id!r} in snapshot {snapshot_id!r}"
+    )
+
+
+def _handle(
+    root: Path, snapshot_id: str, frame_id: str, data_nrd: str
+) -> BrowserElementHandle:
+    summary = _load_snapshot_summary(root, snapshot_id)
+    element = _element_for_handle(
+        root, snapshot_id=snapshot_id, frame_id=frame_id, data_nrd=data_nrd
+    )
+    fingerprint = element.get("fingerprint")
+    return BrowserElementHandle(
+        snapshot_id=snapshot_id,
+        frame_id=frame_id,
+        data_nrd=data_nrd,
+        snapshot_url=str(summary.get("url") or ""),
+        element_fingerprint=fingerprint if isinstance(fingerprint, str) else None,
+    )
+
+
+def _selectors_for_element(element: dict[str, Any]) -> dict[str, Any]:
+    candidates: dict[str, Any] = {"naradaId": element.get("data_nrd")}
+    tag_name = element.get("tag_name")
+    text = element.get("text")
+    if isinstance(tag_name, str) and tag_name:
+        candidates["tagName"] = {"value": tag_name}
+    if isinstance(text, str) and text:
+        candidates["textContent"] = {"value": text[:200]}
+    for key, selector_name in (
+        ("aria_label", "ariaLabel"),
+        ("placeholder", "placeholder"),
+        ("href", "href"),
+    ):
+        value = element.get(key)
+        if isinstance(value, str) and value:
+            candidates[selector_name] = {"value": value}
+    return candidates
+
+
+def _line_set(text: str) -> set[str]:
+    return {line.strip() for line in text.splitlines() if line.strip()}
+
+
+def _diff_visible_text(root: Path, before: str, after: str) -> dict[str, list[str]]:
+    before_text = (_snapshot_dir(root, before) / "visible-text.txt").read_text(
+        encoding="utf-8"
+    )
+    after_text = (_snapshot_dir(root, after) / "visible-text.txt").read_text(
+        encoding="utf-8"
+    )
+    before_lines = _line_set(before_text)
+    after_lines = _line_set(after_text)
+    return {
+        "added_text": sorted(after_lines - before_lines)[:100],
+        "removed_text": sorted(before_lines - after_lines)[:100],
+    }
+
+
+def _decode_base64_content(value: str) -> bytes:
+    content = value.strip()
+    if content.lower().startswith("data:") and "," in content:
+        content = content.split(",", 1)[1]
+    content = re.sub(r"\s+", "", content)
+    padding = (-len(content)) % 4
+    if padding:
+        content += "=" * padding
+    return base64.b64decode(content, validate=False)
+
+
+async def env_open(
+    *,
+    name: str,
+    kind: str,
+    proof_root: str | Path | None,
+    base_url: str | None = None,
+    initialization_url: str | None = None,
+    cdp_port: int | None = None,
+    extension_id: str | None = None,
+    user_data_dir: str | None = None,
+    profile_directory: str | None = None,
+    attach_to_existing: bool = False,
+    browser_window_id: str | None = None,
+) -> BrowserWorkbenchCommandResult:
+    if kind != "local":
+        raise ValueError("M4 supports only --kind local")
+    root = _browser_root(proof_root, f"browser-env-{name}")
+    if (root / "commands.jsonl").exists():
+        _add_manifest_taint(root, "proof_root_preexisting")
+    api_base_url = base_url or default_api_base_url()
+    if browser_window_id is not None:
+        remote = RemoteBrowserEnvironment(
+            browser_window_id=browser_window_id,
+            auth_headers=default_auth_headers(),
+            base_url=api_base_url,
+        )
+        current_url = (
+            await remote._run_extension_action(GetUrlRequest(), GetUrlResponse)
+        ).url
+        record = {
+            "schemaVersion": 1,
+            "id": name,
+            "kind": kind,
+            "status": "open",
+            "browserWindowId": browser_window_id,
+            "browserProcessId": None,
+            "apiBaseUrl": api_base_url,
+            "apiBaseUrlOrigin": _origin(api_base_url),
+            "initializationUrlOrigin": _origin(initialization_url)
+            if initialization_url
+            else None,
+            "cdpPort": cdp_port,
+            "extensionId": extension_id,
+            "attachToExisting": True,
+            "adoptedBrowserWindow": True,
+            "verifiedCurrentUrl": current_url,
+        }
+        artifact = _write_env(root, name, record)
+        return _finish_command(
+            root,
+            command="env.open",
+            status="passed",
+            payload={"environment": record},
+            artifacts=[artifact],
+            ids={"envId": name, "browserWindowId": browser_window_id},
+            inputs={"kind": kind, "apiBaseUrlOrigin": record["apiBaseUrlOrigin"]},
+        )
+
+    config = BrowserConfig(
+        initialization_url=initialization_url or BrowserConfig().initialization_url,
+        cdp_port=cdp_port or BrowserConfig().cdp_port,
+        extension_id=extension_id or BrowserConfig().extension_id,
+        user_data_dir=user_data_dir or BrowserConfig().user_data_dir,
+        profile_directory=profile_directory or BrowserConfig().profile_directory,
+        interactive=False,
+    )
+    env = BrowserEnvironment(
+        auth_headers=default_auth_headers(),
+        base_url=api_base_url,
+        config=config,
+        attach_to_existing=attach_to_existing,
+    )
+    await env.start()
+    record = {
+        "schemaVersion": 1,
+        "id": name,
+        "kind": kind,
+        "status": "open",
+        "browserWindowId": env.browser_window_id,
+        "browserProcessId": env.browser_process_id,
+        "apiBaseUrl": api_base_url,
+        "apiBaseUrlOrigin": _origin(api_base_url),
+        "initializationUrlOrigin": _origin(config.initialization_url),
+        "cdpPort": config.cdp_port,
+        "extensionId": config.extension_id,
+        "attachToExisting": attach_to_existing,
+    }
+    artifact = _write_env(root, name, record)
+    await env._stop_playwright()
+    return _finish_command(
+        root,
+        command="env.open",
+        status="passed",
+        payload={"environment": record},
+        artifacts=[artifact],
+        ids={"envId": name, "browserWindowId": env.browser_window_id},
+        inputs={"kind": kind, "apiBaseUrlOrigin": record["apiBaseUrlOrigin"]},
+    )
+
+
+async def env_status(
+    *,
+    env_id: str,
+    proof_root: str | Path,
+    base_url: str | None = None,
+) -> BrowserWorkbenchCommandResult:
+    root = _browser_root(proof_root, f"browser-env-{env_id}")
+    record = _load_env(root, env_id)
+    env = _remote_env(record, base_url=base_url)
+    warnings: list[str] = []
+    url: str | None = None
+    try:
+        response = await env._run_extension_action(GetUrlRequest(), GetUrlResponse)
+        url = response.url
+    except Exception as exc:
+        warnings.append(_redact_sensitive_text(str(exc)))
+    payload = {"environment": record, "currentUrl": url}
+    return _finish_command(
+        root,
+        command="env.status",
+        status="passed" if url is not None else "needs_review",
+        payload=payload,
+        warnings=warnings,
+        ids={"envId": env_id, "browserWindowId": record.get("browserWindowId")},
+    )
+
+
+async def env_close(
+    *,
+    env_id: str,
+    proof_root: str | Path,
+    base_url: str | None = None,
+    close_adopted: bool = False,
+) -> BrowserWorkbenchCommandResult:
+    root = _browser_root(proof_root, f"browser-env-{env_id}")
+    record = _load_env(root, env_id)
+    is_adopted = record.get("adoptedBrowserWindow") is True
+    warnings: list[str] = []
+    if is_adopted and not close_adopted:
+        record = {
+            **record,
+            "status": "detached",
+            "closeBehavior": "adopted_browser_not_closed",
+        }
+        warnings.append("adopted_browser_not_closed")
+    else:
+        env = _remote_env(record, base_url=base_url)
+        await env.close(timeout=30)
+        record = {**record, "status": "closed", "closeBehavior": "closed"}
+    artifact = _write_env_lifecycle_snapshot(
+        root, env_id, str(record["status"]), record
+    )
+    _write_json(
+        root / "cleanup" / "status.json",
+        {"status": "passed", "browserEnvironmentStatus": record["status"]},
+    )
+    return _finish_command(
+        root,
+        command="env.close",
+        status="passed",
+        payload={"environment": record},
+        artifacts=[artifact],
+        warnings=warnings,
+        ids={"envId": env_id, "browserWindowId": record.get("browserWindowId")},
+    )
+
+
+async def browser_goto(
+    *,
+    env_id: str,
+    url: str,
+    proof_root: str | Path,
+    base_url: str | None = None,
+    new_tab: bool = False,
+) -> BrowserWorkbenchCommandResult:
+    root = _browser_root(proof_root, f"browser-{env_id}")
+    record = _load_env(root, env_id)
+    env = _remote_env(record, base_url=base_url)
+    await env._run_extension_action(
+        GoToUrlRequest(url=url, new_tab=new_tab), timeout=60
+    )
+    action_row = {
+        "type": "goto",
+        "envId": env_id,
+        "url": url,
+        "newTab": new_tab,
+    }
+    _append_jsonl(root / "browser" / "actions.jsonl", action_row)
+    return _finish_command(
+        root,
+        command="browser.goto",
+        status="passed",
+        payload=action_row,
+        ids={"envId": env_id, "browserWindowId": record.get("browserWindowId")},
+        inputs={"url": url},
+    )
+
+
+async def browser_snapshot(
+    *,
+    env_id: str,
+    proof_root: str | Path,
+    base_url: str | None = None,
+    max_html_bytes: int = 500_000,
+) -> BrowserWorkbenchCommandResult:
+    root = _browser_root(proof_root, f"browser-{env_id}")
+    record = _load_env(root, env_id)
+    env = _remote_env(record, base_url=base_url)
+    snapshot_id = f"snap_{uuid.uuid4().hex}"
+    snapshot = await env._run_extension_action(
+        BrowserPageSnapshotRequest(
+            snapshot_id=snapshot_id,
+            max_html_bytes=max_html_bytes,
+            include_visible_text=True,
+        ),
+        BrowserPageSnapshotResponse,
+        timeout=60,
+    )
+    artifacts = _write_snapshot(root, snapshot)
+    warnings = ["html_truncated"] if snapshot.html_truncated else []
+    return _finish_command(
+        root,
+        command="browser.snapshot",
+        status="needs_review" if warnings else "passed",
+        payload={
+            "snapshotId": snapshot.snapshot_id,
+            "url": snapshot.url,
+            "title": snapshot.title,
+            "htmlTruncated": snapshot.html_truncated,
+            "elementCount": len(snapshot.elements),
+        },
+        artifacts=artifacts,
+        warnings=warnings,
+        ids={"envId": env_id, "snapshotId": snapshot.snapshot_id},
+    )
+
+
+async def browser_find(
+    *,
+    env_id: str,
+    snapshot_id: str,
+    proof_root: str | Path,
+    text: str | None = None,
+    tag_name: str | None = None,
+    data_nrd: str | None = None,
+    interactive_only: bool = False,
+    limit: int = 20,
+) -> BrowserWorkbenchCommandResult:
+    root = _browser_root(proof_root, f"browser-{env_id}")
+    matches: list[dict[str, Any]] = []
+    needle = text.lower() if text is not None else None
+    tag = tag_name.lower() if tag_name is not None else None
+    for element in _load_snapshot_elements(root, snapshot_id):
+        if data_nrd is not None and element.get("data_nrd") != data_nrd:
+            continue
+        if tag is not None and str(element.get("tag_name") or "").lower() != tag:
+            continue
+        if interactive_only and element.get("interactive") is not True:
+            continue
+        if needle is not None:
+            haystack = " ".join(
+                str(element.get(key) or "")
+                for key in ("text", "aria_label", "placeholder", "href")
+            ).lower()
+            if needle not in haystack:
+                continue
+        matches.append(element)
+        if len(matches) >= limit:
+            break
+    row = {"envId": env_id, "snapshotId": snapshot_id, "matches": matches}
+    _append_jsonl(root / "browser" / "findings.jsonl", row)
+    return _finish_command(
+        root,
+        command="browser.find",
+        status="passed",
+        payload={"matches": matches, "matchCount": len(matches)},
+        ids={"envId": env_id, "snapshotId": snapshot_id},
+        inputs={
+            "text": text,
+            "tagName": tag_name,
+            "dataNrd": data_nrd,
+            "interactiveOnly": interactive_only,
+        },
+    )
+
+
+async def browser_selectors(
+    *,
+    env_id: str,
+    snapshot_id: str,
+    frame_id: str,
+    data_nrd: str,
+    proof_root: str | Path,
+) -> BrowserWorkbenchCommandResult:
+    root = _browser_root(proof_root, f"browser-{env_id}")
+    element = _element_for_handle(
+        root, snapshot_id=snapshot_id, frame_id=frame_id, data_nrd=data_nrd
+    )
+    selectors = _selectors_for_element(element)
+    row = {
+        "envId": env_id,
+        "snapshotId": snapshot_id,
+        "frameId": frame_id,
+        "dataNrd": data_nrd,
+        "selectors": selectors,
+        "diagnostic": True,
+    }
+    _append_jsonl(root / "browser" / "selectors.jsonl", row)
+    return _finish_command(
+        root,
+        command="browser.selectors",
+        status="passed",
+        payload=row,
+        ids={"envId": env_id, "snapshotId": snapshot_id, "dataNrd": data_nrd},
+    )
+
+
+async def browser_nrd_action(
+    *,
+    env_id: str,
+    action: str,
+    snapshot_id: str,
+    frame_id: str,
+    data_nrd: str,
+    proof_root: str | Path,
+    base_url: str | None = None,
+    value: str | None = None,
+    post_snapshot: bool = True,
+) -> BrowserWorkbenchCommandResult:
+    root = _browser_root(proof_root, f"browser-{env_id}")
+    record = _load_env(root, env_id)
+    env = _remote_env(record, base_url=base_url)
+    handle = _handle(root, snapshot_id, frame_id, data_nrd)
+    if action == "click":
+        request = BrowserClickNrdRequest(handle=handle, post_snapshot=post_snapshot)
+        command = "browser.click-nrd"
+    elif action == "fill":
+        if value is None:
+            raise ValueError("fill-nrd requires a value")
+        request = BrowserFillNrdRequest(
+            handle=handle, value=value, post_snapshot=post_snapshot
+        )
+        command = "browser.fill-nrd"
+    elif action == "select":
+        if value is None:
+            raise ValueError("select-nrd requires a value")
+        request = BrowserSelectNrdRequest(
+            handle=handle, value=value, post_snapshot=post_snapshot
+        )
+        command = "browser.select-nrd"
+    else:
+        raise ValueError(f"Unsupported browser nrd action {action!r}")
+    response = await env._run_extension_action(
+        request, BrowserActionResponse, timeout=60
+    )
+    artifacts: list[dict[str, Any]] = []
+    payload: dict[str, Any] = {
+        "envId": env_id,
+        "action": action,
+        "snapshotId": snapshot_id,
+        "frameId": frame_id,
+        "dataNrd": data_nrd,
+        "performed": response.status == "performed",
+    }
+    if response.post_snapshot is not None:
+        artifacts.extend(_write_snapshot(root, response.post_snapshot))
+        payload["postSnapshotId"] = response.post_snapshot.snapshot_id
+    status = "passed" if response.post_snapshot is not None else "needs_review"
+    warnings = (
+        []
+        if response.post_snapshot is not None
+        else ["browser_action_post_snapshot_missing"]
+    )
+    _append_jsonl(root / "browser" / "actions.jsonl", payload)
+    return _finish_command(
+        root,
+        command=command,
+        status=status,
+        payload=payload,
+        artifacts=artifacts,
+        warnings=warnings,
+        ids={
+            "envId": env_id,
+            "snapshotId": snapshot_id,
+            "dataNrd": data_nrd,
+            "postSnapshotId": payload.get("postSnapshotId"),
+        },
+    )
+
+
+async def browser_diff(
+    *,
+    env_id: str,
+    before: str,
+    after: str,
+    proof_root: str | Path,
+) -> BrowserWorkbenchCommandResult:
+    root = _browser_root(proof_root, f"browser-{env_id}")
+    diff = _diff_visible_text(root, before, after)
+    row = {"envId": env_id, "before": before, "after": after, **diff}
+    _append_jsonl(root / "browser" / "snapshot-diffs.jsonl", row)
+    return _finish_command(
+        root,
+        command="browser.diff",
+        status="passed",
+        payload=row,
+        ids={"envId": env_id, "beforeSnapshotId": before, "afterSnapshotId": after},
+    )
+
+
+async def browser_screenshot(
+    *,
+    env_id: str,
+    proof_root: str | Path,
+    base_url: str | None = None,
+) -> BrowserWorkbenchCommandResult:
+    root = _browser_root(proof_root, f"browser-{env_id}")
+    record = _load_env(root, env_id)
+    env = _remote_env(record, base_url=base_url)
+    try:
+        screenshot = await env._run_extension_action(
+            BrowserScreenshotRequest(
+                timeout_ms=BROWSER_WORKBENCH_SCREENSHOT_TIMEOUT_MS
+            ),
+            BrowserScreenshotResponse,
+            timeout=75,
+        )
+    except Exception as exc:
+        row = {
+            "envId": env_id,
+            "captureSupported": False,
+            "status": "failed",
+            "error": _redact_sensitive_text(str(exc)),
+        }
+        _append_jsonl(root / "browser" / "screenshots.jsonl", row)
+        return _finish_command(
+            root,
+            command="browser.screenshot",
+            status="needs_review",
+            payload=row,
+            warnings=["browser_screenshot_capture_failed"],
+            ids={"envId": env_id},
+        )
+    data = _decode_base64_content(screenshot.base64_content)
+    path = root / "browser" / "screenshots" / f"{uuid.uuid4().hex}.png"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(data)
+    artifact = _artifact(root, path, "browser-screenshot")
+    row = {
+        "envId": env_id,
+        "path": artifact["path"],
+        "sha256": artifact["sha256"],
+        "mimeType": screenshot.mime_type,
+        "timestamp": screenshot.timestamp,
+    }
+    _append_jsonl(root / "browser" / "screenshots.jsonl", row)
+    return _finish_command(
+        root,
+        command="browser.screenshot",
+        status="passed",
+        payload=row,
+        artifacts=[artifact],
+        ids={"envId": env_id},
+    )
+
+
+async def browser_downloads(
+    *,
+    env_id: str,
+    proof_root: str | Path,
+    base_url: str | None = None,
+) -> BrowserWorkbenchCommandResult:
+    root = _browser_root(proof_root, f"browser-{env_id}")
+    record = _load_env(root, env_id)
+    env = _remote_env(record, base_url=base_url)
+    started_after = _proof_root_started_after(root)
+    response = await env._run_extension_action(
+        BrowserDownloadsRequest(started_after=started_after),
+        BrowserDownloadsResponse,
+        timeout=30,
+    )
+    command_id = f"cmd_{uuid.uuid4().hex}"
+    download_artifacts: list[dict[str, Any]] = []
+    sanitized_downloads: list[dict[str, Any]] = []
+    download_dir = root / "downloads" / command_id
+    warnings = []
+    stale_download_count = 0
+    for index, download in enumerate(response.downloads):
+        if not _download_is_in_scope(download, started_after):
+            stale_download_count += 1
+            continue
+        sanitized = {
+            key: value
+            for key, value in download.items()
+            if key not in {"local_path", "filename", "url", "final_url"}
+        }
+        if url := download.get("url"):
+            sanitized["redactedUrl"] = _redact_sensitive_text(_redact_url(str(url)))
+        if final_url := download.get("final_url"):
+            sanitized["redactedFinalUrl"] = _redact_sensitive_text(
+                _redact_url(str(final_url))
+            )
+        local_path_value = download.get("local_path") or download.get("filename")
+        copied_artifact: dict[str, Any] | None = None
+        if isinstance(local_path_value, str) and local_path_value:
+            local_path = Path(local_path_value).expanduser()
+            if local_path.exists() and local_path.is_file():
+                download_dir.mkdir(parents=True, exist_ok=True)
+                file_name = str(
+                    sanitized.get("file_name")
+                    or sanitized.get("fileName")
+                    or local_path.name
+                    or f"download-{index}"
+                )
+                destination = download_dir / _safe_slug(file_name)
+                if not destination.suffix and local_path.suffix:
+                    destination = destination.with_suffix(local_path.suffix)
+                shutil.copyfile(local_path, destination)
+                copied_artifact = _artifact(root, destination, "browser-download")
+                copied_artifact["sensitive"] = True
+                download_artifacts.append(copied_artifact)
+                sanitized["path"] = copied_artifact["path"]
+                sanitized["sha256"] = copied_artifact["sha256"]
+                sanitized["byteSize"] = destination.stat().st_size
+            else:
+                warnings.append("download_local_path_unavailable")
+        else:
+            warnings.append("download_local_path_missing")
+        sanitized_downloads.append(sanitized)
+    row = {
+        "envId": env_id,
+        "downloads": sanitized_downloads,
+        "captureSupported": response.capture_supported,
+        "startedAfter": started_after,
+        "staleDownloadCount": stale_download_count,
+        "warning": response.warning,
+    }
+    _append_jsonl(root / "downloads.jsonl", row)
+    status = "passed" if download_artifacts else "needs_review"
+    if response.warning:
+        warnings.append(response.warning)
+    if not response.downloads:
+        warnings.append("download_capture_empty")
+    elif not download_artifacts:
+        warnings.append("download_bytes_not_materialized")
+    return _finish_command(
+        root,
+        command="browser.downloads",
+        status=status,
+        payload=row,
+        artifacts=download_artifacts,
+        warnings=warnings,
+        command_id=command_id,
+        ids={"envId": env_id},
+    )

--- a/packages/narada/src/narada/cli.py
+++ b/packages/narada/src/narada/cli.py
@@ -7,6 +7,19 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from narada.browser_workbench import (
+    browser_diff,
+    browser_downloads,
+    browser_find,
+    browser_goto,
+    browser_nrd_action,
+    browser_screenshot,
+    browser_selectors,
+    browser_snapshot,
+    env_close,
+    env_open,
+    env_status,
+)
 from narada.studio import (
     AgentStudioWorkbenchClient,
     studio_delete,
@@ -204,6 +217,142 @@ async def _studio_delete(args: argparse.Namespace) -> int:
     return 0 if result.status == "passed" else 1
 
 
+async def _env_open(args: argparse.Namespace) -> int:
+    result = await env_open(
+        name=args.name,
+        kind=args.kind,
+        proof_root=args.proof_root,
+        base_url=args.base_url,
+        initialization_url=args.initialization_url,
+        cdp_port=args.cdp_port,
+        extension_id=args.extension_id,
+        user_data_dir=args.user_data_dir,
+        profile_directory=args.profile_directory,
+        attach_to_existing=args.attach_to_existing,
+        browser_window_id=args.browser_window_id,
+    )
+    _print({**result.payload, "commandId": result.command_id}, as_json=args.json)
+    return 0 if result.status == "passed" else 1
+
+
+async def _env_status(args: argparse.Namespace) -> int:
+    result = await env_status(
+        env_id=args.env,
+        proof_root=args.proof_root,
+        base_url=args.base_url,
+    )
+    _print({**result.payload, "commandId": result.command_id}, as_json=args.json)
+    return 0 if result.status == "passed" else 1
+
+
+async def _env_close(args: argparse.Namespace) -> int:
+    result = await env_close(
+        env_id=args.env,
+        proof_root=args.proof_root,
+        base_url=args.base_url,
+        close_adopted=args.close_adopted,
+    )
+    _print({**result.payload, "commandId": result.command_id}, as_json=args.json)
+    return 0 if result.status == "passed" else 1
+
+
+async def _browser_goto(args: argparse.Namespace) -> int:
+    result = await browser_goto(
+        env_id=args.env,
+        url=args.url,
+        proof_root=args.proof_root,
+        base_url=args.base_url,
+        new_tab=args.new_tab,
+    )
+    _print({**result.payload, "commandId": result.command_id}, as_json=args.json)
+    return 0 if result.status == "passed" else 1
+
+
+async def _browser_snapshot(args: argparse.Namespace) -> int:
+    result = await browser_snapshot(
+        env_id=args.env,
+        proof_root=args.proof_root,
+        base_url=args.base_url,
+        max_html_bytes=args.max_html_bytes,
+    )
+    _print({**result.payload, "commandId": result.command_id}, as_json=args.json)
+    return 0 if result.status == "passed" else 1
+
+
+async def _browser_find(args: argparse.Namespace) -> int:
+    result = await browser_find(
+        env_id=args.env,
+        snapshot_id=args.snapshot_id,
+        proof_root=args.proof_root,
+        text=args.text,
+        tag_name=args.tag_name,
+        data_nrd=args.data_nrd,
+        interactive_only=args.interactive_only,
+        limit=args.limit,
+    )
+    _print({**result.payload, "commandId": result.command_id}, as_json=args.json)
+    return 0 if result.status == "passed" else 1
+
+
+async def _browser_selectors(args: argparse.Namespace) -> int:
+    result = await browser_selectors(
+        env_id=args.env,
+        snapshot_id=args.snapshot_id,
+        frame_id=args.frame_id,
+        data_nrd=args.data_nrd,
+        proof_root=args.proof_root,
+    )
+    _print({**result.payload, "commandId": result.command_id}, as_json=args.json)
+    return 0 if result.status == "passed" else 1
+
+
+async def _browser_nrd_action(args: argparse.Namespace, action: str) -> int:
+    result = await browser_nrd_action(
+        env_id=args.env,
+        action=action,
+        snapshot_id=args.snapshot_id,
+        frame_id=args.frame_id,
+        data_nrd=args.data_nrd,
+        proof_root=args.proof_root,
+        base_url=args.base_url,
+        value=getattr(args, "value", None),
+        post_snapshot=args.post_snapshot,
+    )
+    _print({**result.payload, "commandId": result.command_id}, as_json=args.json)
+    return 0 if result.status == "passed" else 1
+
+
+async def _browser_diff(args: argparse.Namespace) -> int:
+    result = await browser_diff(
+        env_id=args.env,
+        before=args.before,
+        after=args.after,
+        proof_root=args.proof_root,
+    )
+    _print({**result.payload, "commandId": result.command_id}, as_json=args.json)
+    return 0 if result.status == "passed" else 1
+
+
+async def _browser_screenshot(args: argparse.Namespace) -> int:
+    result = await browser_screenshot(
+        env_id=args.env,
+        proof_root=args.proof_root,
+        base_url=args.base_url,
+    )
+    _print({**result.payload, "commandId": result.command_id}, as_json=args.json)
+    return 0 if result.status == "passed" else 1
+
+
+async def _browser_downloads(args: argparse.Namespace) -> int:
+    result = await browser_downloads(
+        env_id=args.env,
+        proof_root=args.proof_root,
+        base_url=args.base_url,
+    )
+    _print({**result.payload, "commandId": result.command_id}, as_json=args.json)
+    return 0 if result.status == "passed" else 1
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="narada")
     subparsers = parser.add_subparsers(dest="command")
@@ -233,6 +382,150 @@ def build_parser() -> argparse.ArgumentParser:
     verify.add_argument("proof_root")
     verify.add_argument("--json", action="store_true")
     verify.set_defaults(handler=_verify)
+
+    env_parser = workbench_subparsers.add_parser("env")
+    env_subparsers = env_parser.add_subparsers(dest="env_command")
+
+    env_open_parser = env_subparsers.add_parser("open")
+    env_open_parser.add_argument("--kind", default="local")
+    env_open_parser.add_argument("--name", required=True)
+    env_open_parser.add_argument("--proof-root", required=True)
+    env_open_parser.add_argument("--base-url")
+    env_open_parser.add_argument("--initialization-url")
+    env_open_parser.add_argument("--cdp-port", type=int)
+    env_open_parser.add_argument("--extension-id")
+    env_open_parser.add_argument("--user-data-dir")
+    env_open_parser.add_argument("--profile-directory")
+    env_open_parser.add_argument("--attach-to-existing", action="store_true")
+    env_open_parser.add_argument("--browser-window-id")
+    env_open_parser.add_argument("--json", action="store_true")
+    env_open_parser.set_defaults(handler=lambda args: asyncio.run(_env_open(args)))
+
+    env_status_parser = env_subparsers.add_parser("status")
+    env_status_parser.add_argument("env")
+    env_status_parser.add_argument("--proof-root", required=True)
+    env_status_parser.add_argument("--base-url")
+    env_status_parser.add_argument("--json", action="store_true")
+    env_status_parser.set_defaults(handler=lambda args: asyncio.run(_env_status(args)))
+
+    env_close_parser = env_subparsers.add_parser("close")
+    env_close_parser.add_argument("env")
+    env_close_parser.add_argument("--proof-root", required=True)
+    env_close_parser.add_argument("--base-url")
+    env_close_parser.add_argument(
+        "--close-adopted",
+        action="store_true",
+        help="Also close an adopted browser window. By default adopted windows are detached, not closed.",
+    )
+    env_close_parser.add_argument("--json", action="store_true")
+    env_close_parser.set_defaults(handler=lambda args: asyncio.run(_env_close(args)))
+
+    browser_parser = workbench_subparsers.add_parser("browser")
+    browser_subparsers = browser_parser.add_subparsers(dest="browser_command")
+
+    browser_goto_parser = browser_subparsers.add_parser("goto")
+    browser_goto_parser.add_argument("env")
+    browser_goto_parser.add_argument("--url", required=True)
+    browser_goto_parser.add_argument("--proof-root", required=True)
+    browser_goto_parser.add_argument("--base-url")
+    browser_goto_parser.add_argument("--new-tab", action="store_true")
+    browser_goto_parser.add_argument("--json", action="store_true")
+    browser_goto_parser.set_defaults(
+        handler=lambda args: asyncio.run(_browser_goto(args))
+    )
+
+    browser_snapshot_parser = browser_subparsers.add_parser("snapshot")
+    browser_snapshot_parser.add_argument("env")
+    browser_snapshot_parser.add_argument("--proof-root", required=True)
+    browser_snapshot_parser.add_argument("--base-url")
+    browser_snapshot_parser.add_argument("--max-html-bytes", type=int, default=500_000)
+    browser_snapshot_parser.add_argument("--json", action="store_true")
+    browser_snapshot_parser.set_defaults(
+        handler=lambda args: asyncio.run(_browser_snapshot(args))
+    )
+
+    browser_find_parser = browser_subparsers.add_parser("find")
+    browser_find_parser.add_argument("env")
+    browser_find_parser.add_argument("--snapshot-id", required=True)
+    browser_find_parser.add_argument("--proof-root", required=True)
+    browser_find_parser.add_argument("--text")
+    browser_find_parser.add_argument("--tag-name")
+    browser_find_parser.add_argument("--data-nrd")
+    browser_find_parser.add_argument("--interactive-only", action="store_true")
+    browser_find_parser.add_argument("--limit", type=int, default=20)
+    browser_find_parser.add_argument("--json", action="store_true")
+    browser_find_parser.set_defaults(
+        handler=lambda args: asyncio.run(_browser_find(args))
+    )
+
+    browser_selectors_parser = browser_subparsers.add_parser("selectors")
+    browser_selectors_parser.add_argument("env")
+    browser_selectors_parser.add_argument("--snapshot-id", required=True)
+    browser_selectors_parser.add_argument("--frame-id", required=True)
+    browser_selectors_parser.add_argument("--data-nrd", required=True)
+    browser_selectors_parser.add_argument("--proof-root", required=True)
+    browser_selectors_parser.add_argument("--json", action="store_true")
+    browser_selectors_parser.set_defaults(
+        handler=lambda args: asyncio.run(_browser_selectors(args))
+    )
+
+    for command_name, action_name in (
+        ("click-nrd", "click"),
+        ("fill-nrd", "fill"),
+        ("select-nrd", "select"),
+    ):
+        nrd_parser = browser_subparsers.add_parser(command_name)
+        nrd_parser.add_argument("env")
+        nrd_parser.add_argument("--snapshot-id", required=True)
+        nrd_parser.add_argument("--frame-id", required=True)
+        nrd_parser.add_argument("--data-nrd", required=True)
+        nrd_parser.add_argument("--proof-root", required=True)
+        nrd_parser.add_argument("--base-url")
+        if action_name in {"fill", "select"}:
+            nrd_parser.add_argument("--value", required=True)
+        nrd_parser.add_argument(
+            "--post-snapshot",
+            action=argparse.BooleanOptionalAction,
+            default=True,
+            help=(
+                "Capture a post-action snapshot for proof. Use --no-post-snapshot "
+                "only for diagnostic commands that should verify as needs_review."
+            ),
+        )
+        nrd_parser.add_argument("--json", action="store_true")
+        nrd_parser.set_defaults(
+            handler=lambda args, selected_action=action_name: asyncio.run(
+                _browser_nrd_action(args, selected_action)
+            )
+        )
+
+    browser_diff_parser = browser_subparsers.add_parser("diff")
+    browser_diff_parser.add_argument("env")
+    browser_diff_parser.add_argument("--before", required=True)
+    browser_diff_parser.add_argument("--after", required=True)
+    browser_diff_parser.add_argument("--proof-root", required=True)
+    browser_diff_parser.add_argument("--json", action="store_true")
+    browser_diff_parser.set_defaults(
+        handler=lambda args: asyncio.run(_browser_diff(args))
+    )
+
+    browser_screenshot_parser = browser_subparsers.add_parser("screenshot")
+    browser_screenshot_parser.add_argument("env")
+    browser_screenshot_parser.add_argument("--proof-root", required=True)
+    browser_screenshot_parser.add_argument("--base-url")
+    browser_screenshot_parser.add_argument("--json", action="store_true")
+    browser_screenshot_parser.set_defaults(
+        handler=lambda args: asyncio.run(_browser_screenshot(args))
+    )
+
+    browser_downloads_parser = browser_subparsers.add_parser("downloads")
+    browser_downloads_parser.add_argument("env")
+    browser_downloads_parser.add_argument("--proof-root", required=True)
+    browser_downloads_parser.add_argument("--base-url")
+    browser_downloads_parser.add_argument("--json", action="store_true")
+    browser_downloads_parser.set_defaults(
+        handler=lambda args: asyncio.run(_browser_downloads(args))
+    )
 
     studio_parser = workbench_subparsers.add_parser("studio")
     studio_subparsers = studio_parser.add_subparsers(dest="studio_command")
@@ -330,7 +623,21 @@ def main(argv: list[str] | None = None) -> int:
     try:
         return int(handler(args))
     except Exception as exc:
-        print(f"error: {_redact_sensitive_text(str(exc))}", file=sys.stderr)
+        message = _redact_sensitive_text(str(exc))
+        if getattr(args, "json", False):
+            print(
+                json.dumps(
+                    {
+                        "schemaVersion": 1,
+                        "status": "failed",
+                        "error": message,
+                    },
+                    indent=2,
+                    sort_keys=True,
+                )
+            )
+        else:
+            print(f"error: {message}", file=sys.stderr)
         return 1
 
 

--- a/packages/narada/src/narada/environment.py
+++ b/packages/narada/src/narada/environment.py
@@ -940,12 +940,14 @@ class BrowserEnvironment(BaseBrowserEnvironment):
         *,
         api_key: str | None = None,
         auth_headers: dict[str, str] | None = None,
+        base_url: str | None = None,
         config: BrowserConfig | None = None,
         attach_to_existing: bool = False,
     ) -> None:
         super().__init__(
             api_key=api_key,
             auth_headers=auth_headers,
+            base_url=base_url,
         )
         self._browser_process_id = None
         self._config = config or BrowserConfig()
@@ -1037,7 +1039,10 @@ class BrowserEnvironment(BaseBrowserEnvironment):
 
         # Generate a unique tag for the initialization URL
         window_tag = uuid4().hex
-        tagged_initialization_url = f"{self._config.initialization_url}?t={window_tag}"
+        tagged_initialization_url = _with_query_params(
+            self._config.initialization_url,
+            {"t": window_tag},
+        )
 
         # Open the initialization page in a new tab in the default context.
         context = browser.contexts[0]
@@ -1058,7 +1063,17 @@ class BrowserEnvironment(BaseBrowserEnvironment):
         context = browser.contexts[0]
 
         side_panel_url = create_side_panel_url(self._config, browser_window_id)
-        side_panel_page = next(p for p in context.pages if p.url == side_panel_url)
+        side_panel_page = next(
+            (p for p in context.pages if p.url == side_panel_url), None
+        )
+        if side_panel_page is None:
+            visible_urls = [p.url for p in context.pages]
+            raise RuntimeError(
+                "Narada side panel was not found for browser window "
+                f"{browser_window_id!r} and extension id {self._config.extension_id!r}. "
+                "If you are attaching to a dev extension, pass the matching extension id. "
+                f"Visible page URLs: {visible_urls!r}"
+            )
 
         await self._fix_download_behavior(side_panel_page)
 
@@ -1076,7 +1091,10 @@ class BrowserEnvironment(BaseBrowserEnvironment):
         # was opened, since otherwise when more than one initialization page is opened in the same
         # browser instance, we wouldn't be able to tell them apart.
         window_tag = uuid4().hex
-        tagged_initialization_url = f"{config.initialization_url}?t={window_tag}"
+        tagged_initialization_url = _with_query_params(
+            config.initialization_url,
+            {"t": window_tag},
+        )
 
         # When proxy auth is needed, launch with about:blank to avoid Chrome's startup auth prompt.
         # We'll set up the CDP auth handler and then navigate to the init URL.
@@ -1376,10 +1394,12 @@ class RemoteBrowserEnvironment(BaseBrowserEnvironment):
         cloud_browser_session_id: str | None = None,
         api_key: str | None = None,
         auth_headers: dict[str, str] | None = None,
+        base_url: str | None = None,
     ) -> None:
         super().__init__(
             api_key=api_key,
             auth_headers=auth_headers,
+            base_url=base_url,
             browser_window_id=browser_window_id,
         )
         self._cloud_browser_session_id = cloud_browser_session_id

--- a/packages/narada/src/narada/environment.py
+++ b/packages/narada/src/narada/environment.py
@@ -1113,6 +1113,14 @@ class BrowserEnvironment(BaseBrowserEnvironment):
             launch_url,
         ]
 
+        # Local branch-dev verification only: keep this out of the public CLI surface.
+        # It lets the existing SDK/workbench launch path load an unpacked dev extension.
+        local_dev_extension_paths = _local_dev_extension_launch_paths_from_env()
+        if local_dev_extension_paths:
+            extension_arg = ",".join(str(path) for path in local_dev_extension_paths)
+            browser_args.insert(3, f"--load-extension={extension_arg}")
+            browser_args.insert(3, f"--disable-extensions-except={extension_arg}")
+
         # Add proxy arguments if configured.
         if config.proxy is not None:
             config.proxy.validate()
@@ -1886,3 +1894,28 @@ async def _stop_cloud_browser_session(
 
 def create_side_panel_url(config: BrowserConfig, browser_window_id: str) -> str:
     return f"chrome-extension://{config.extension_id}/sidepanel.html?browserWindowId={browser_window_id}"
+
+
+def _local_dev_extension_launch_paths_from_env() -> list[Path]:
+    raw_paths = os.environ.get("NARADA_LOCAL_DEV_EXTENSION_LOAD_PATH")
+    if not raw_paths:
+        return []
+
+    paths: list[Path] = []
+    for raw_path in raw_paths.split(os.pathsep):
+        if not raw_path:
+            continue
+        path = Path(raw_path).expanduser().resolve()
+        if not path.is_dir():
+            raise RuntimeError(
+                "NARADA_LOCAL_DEV_EXTENSION_LOAD_PATH must point to an unpacked "
+                f"Chrome extension directory; got {str(path)!r}"
+            )
+        if not (path / "manifest.json").is_file():
+            raise RuntimeError(
+                "NARADA_LOCAL_DEV_EXTENSION_LOAD_PATH must contain manifest.json; "
+                f"got {str(path)!r}"
+            )
+        paths.append(path)
+
+    return paths

--- a/packages/narada/src/narada/workbench.py
+++ b/packages/narada/src/narada/workbench.py
@@ -188,6 +188,16 @@ def _redact_sensitive_text(value: str) -> str:
     return redacted
 
 
+def _warning_codes(warnings: list[dict[str, Any]]) -> list[str]:
+    return sorted(
+        {
+            str(warning.get("code"))
+            for warning in warnings
+            if warning.get("code") not in {"command_warning"}
+        }
+    )
+
+
 def _frame_dir(root: Path, frame: dict[str, Any], index: int) -> Path:
     frame_id = str(frame.get("frameId") or f"frame_{index}")
     return root / "trace" / "frames" / _safe_slug(frame_id)
@@ -235,6 +245,11 @@ def _is_clean_source_authority(value: Any) -> bool:
 
 def _status_exit_code(status: str) -> int:
     return 0 if status in CLEAN_COMMAND_STATUSES or status == "passed" else 1
+
+
+def _artifact_ref(root: Path, relative_path: str, role: str) -> dict[str, Any]:
+    path = root / relative_path
+    return {"path": relative_path, "role": role, "sha256": _sha256_file(path)}
 
 
 def _source_run_problems(source_run: dict[str, Any]) -> tuple[list[str], list[str]]:
@@ -636,6 +651,7 @@ def append_command(
     *,
     command: str,
     status: str,
+    command_id: str | None = None,
     exit_code: int | None = None,
     artifacts: list[dict[str, Any]] | None = None,
     warnings: list[str] | None = None,
@@ -646,7 +662,7 @@ def append_command(
     now = _now_iso()
     row = {
         "schemaVersion": 1,
-        "commandId": f"cmd_{uuid.uuid4().hex}",
+        "commandId": command_id or f"cmd_{uuid.uuid4().hex}",
         "runId": proof_root.name,
         "command": command,
         "status": status,
@@ -781,7 +797,20 @@ def score_proof_root(proof_root: str | Path, *, write: bool = True) -> dict[str,
     taints: list[dict[str, Any]] = []
     warnings: list[dict[str, Any]] = []
 
-    for relative_path in REQUIRED_PROOF_FILES:
+    manifest_path = root / "manifest.json"
+    manifest_kind = "trace"
+    if manifest_path.exists():
+        loaded_for_kind = _load_json(manifest_path)
+        if isinstance(loaded_for_kind, dict):
+            manifest_kind = str(loaded_for_kind.get("proofRootKind") or "trace")
+    is_browser_workbench_root = manifest_kind == "browser-workbench"
+    required_files = (
+        ("manifest.json", "commands.jsonl", "cleanup/status.json")
+        if is_browser_workbench_root
+        else REQUIRED_PROOF_FILES
+    )
+
+    for relative_path in required_files:
         if not (root / relative_path).exists():
             failures.append({"code": "missing_required_file", "path": relative_path})
 
@@ -791,10 +820,10 @@ def score_proof_root(proof_root: str | Path, *, write: bool = True) -> dict[str,
     resolved_trace: dict[str, Any] | None = None
     expected_artifact_keys: set[str] = set()
 
-    manifest_path = root / "manifest.json"
     context_path = root / "trace" / "context.json"
     resolved_path = root / "trace" / "resolved.json"
     index_path = root / "trace" / "artifacts" / "index.jsonl"
+    browser_index_path = root / "browser" / "artifacts.jsonl"
     if manifest_path.exists():
         loaded = _load_json(manifest_path)
         manifest = loaded if isinstance(loaded, dict) else None
@@ -877,25 +906,26 @@ def score_proof_root(proof_root: str | Path, *, write: bool = True) -> dict[str,
     if manifest is not None:
         manifest_context = manifest.get("traceContext")
         source_run = manifest.get("sourceRun")
-        if not isinstance(source_run, dict):
-            failures.append({"code": "source_run_missing"})
-        else:
-            source_failures, source_taints = _source_run_problems(source_run)
-            for code in source_failures:
-                failures.append(
-                    {
-                        "code": code,
-                        "status": source_run.get("status"),
-                    }
-                )
-            for code in source_taints:
-                taints.append(
-                    {
-                        "code": code,
-                        "status": source_run.get("status"),
-                        "authority": source_run.get("authority"),
-                    }
-                )
+        if not is_browser_workbench_root:
+            if not isinstance(source_run, dict):
+                failures.append({"code": "source_run_missing"})
+            else:
+                source_failures, source_taints = _source_run_problems(source_run)
+                for code in source_failures:
+                    failures.append(
+                        {
+                            "code": code,
+                            "status": source_run.get("status"),
+                        }
+                    )
+                for code in source_taints:
+                    taints.append(
+                        {
+                            "code": code,
+                            "status": source_run.get("status"),
+                            "authority": source_run.get("authority"),
+                        }
+                    )
         if context is not None and manifest_context != context:
             failures.append({"code": "manifest_context_mismatch"})
         if context is not None and manifest.get("traceId") not in {
@@ -918,6 +948,17 @@ def score_proof_root(proof_root: str | Path, *, write: bool = True) -> dict[str,
                 failures.append({"code": "manifest_artifact_index_hash_missing"})
             elif manifest.get("artifactIndexHash") != _sha256_file(index_path):
                 failures.append({"code": "manifest_artifact_index_hash_mismatch"})
+        if browser_index_path.exists():
+            if not manifest.get("browserArtifactIndexHash"):
+                failures.append(
+                    {"code": "manifest_browser_artifact_index_hash_missing"}
+                )
+            elif manifest.get("browserArtifactIndexHash") != _sha256_file(
+                browser_index_path
+            ):
+                failures.append(
+                    {"code": "manifest_browser_artifact_index_hash_mismatch"}
+                )
         commands_path = root / "commands.jsonl"
         if commands_path.exists():
             if not manifest.get("commandLedgerHash"):
@@ -1029,6 +1070,38 @@ def score_proof_root(proof_root: str | Path, *, write: bool = True) -> dict[str,
                     "sourceS3Key": source_key,
                 }
             )
+    browser_artifact_rows: list[dict[str, Any]] = []
+    if browser_index_path.exists():
+        browser_artifact_rows = _load_jsonl(browser_index_path)
+        for row in browser_artifact_rows:
+            local_path_value = row.get("path")
+            if not isinstance(local_path_value, str) or not local_path_value:
+                failures.append({"code": "browser_artifact_missing_path", "row": row})
+                continue
+            if os.path.isabs(local_path_value):
+                failures.append(
+                    {"code": "browser_artifact_absolute_path", "path": local_path_value}
+                )
+                continue
+            local_path = root / local_path_value
+            if not local_path.resolve().is_relative_to(root.resolve()):
+                failures.append(
+                    {"code": "browser_artifact_path_escape", "path": local_path_value}
+                )
+                continue
+            if not local_path.exists():
+                failures.append(
+                    {"code": "browser_artifact_file_missing", "path": local_path_value}
+                )
+                continue
+            expected_sha = row.get("sha256")
+            if expected_sha != _sha256_file(local_path):
+                failures.append(
+                    {
+                        "code": "browser_artifact_hash_mismatch",
+                        "path": local_path_value,
+                    }
+                )
 
     redaction_report = _write_redaction_report(root) if write else _scan_redaction(root)
     for finding in redaction_report["findings"]:
@@ -1050,13 +1123,25 @@ def score_proof_root(proof_root: str | Path, *, write: bool = True) -> dict[str,
     commands_path = root / "commands.jsonl"
     if commands_path.exists():
         command_rows = _load_jsonl(commands_path)
+        needs_review = False
         if not command_rows:
             failures.append({"code": "empty_command_ledger"})
         materialize_commands = [
             row for row in command_rows if row.get("command") == "trace.materialize"
         ]
-        if not materialize_commands:
+        browser_commands = [
+            row
+            for row in command_rows
+            if isinstance(row.get("command"), str)
+            and (
+                str(row.get("command")).startswith("browser.")
+                or str(row.get("command")).startswith("env.")
+            )
+        ]
+        if not materialize_commands and not is_browser_workbench_root:
             failures.append({"code": "missing_materialize_command"})
+        if is_browser_workbench_root and not browser_commands:
+            failures.append({"code": "missing_browser_workbench_command"})
         for row in materialize_commands:
             if row.get("status") not in CLEAN_COMMAND_STATUSES:
                 continue
@@ -1110,18 +1195,171 @@ def score_proof_root(proof_root: str | Path, *, write: bool = True) -> dict[str,
                 )
             elif _is_failed_status(row_status):
                 taints.append({"code": "prior_command_failed", "status": row_status})
+            elif row_status not in CLEAN_COMMAND_STATUSES:
+                needs_review = True
+                warnings.append(
+                    {
+                        "code": "command_status_needs_review",
+                        "command": row.get("command"),
+                        "status": row_status,
+                    }
+                )
+            if (
+                row.get("command")
+                in {"browser.click-nrd", "browser.fill-nrd", "browser.select-nrd"}
+                and row_status in CLEAN_COMMAND_STATUSES
+            ):
+                ids = row.get("ids")
+                if not isinstance(ids, dict) or not ids.get("postSnapshotId"):
+                    needs_review = True
+                    warnings.append(
+                        {
+                            "code": "browser_action_post_snapshot_missing",
+                            "command": row.get("command"),
+                        }
+                    )
+            row_command = row.get("command")
+            for warning in row.get("warnings") or []:
+                if row_command in {"score", "verify"}:
+                    continue
+                warnings.append(
+                    {
+                        "code": "command_warning",
+                        "command": row_command,
+                        "warning": warning,
+                    }
+                )
             for taint in row.get("taints") or []:
                 taints.append({"code": "command_taint", "taint": taint})
+            artifacts = row.get("artifacts")
+            if isinstance(artifacts, list):
+                for artifact in artifacts:
+                    if not isinstance(artifact, dict):
+                        failures.append(
+                            {
+                                "code": "command_artifact_not_object",
+                                "command": row.get("command"),
+                            }
+                        )
+                        continue
+                    artifact_path = artifact.get("path")
+                    if not isinstance(artifact_path, str) or not artifact_path:
+                        failures.append(
+                            {
+                                "code": "command_artifact_missing_path",
+                                "command": row.get("command"),
+                            }
+                        )
+                        continue
+                    if os.path.isabs(artifact_path):
+                        failures.append(
+                            {
+                                "code": "command_artifact_absolute_path",
+                                "path": artifact_path,
+                            }
+                        )
+                        continue
+                    local_path = root / artifact_path
+                    if not local_path.resolve().is_relative_to(root.resolve()):
+                        failures.append(
+                            {
+                                "code": "command_artifact_path_escape",
+                                "path": artifact_path,
+                            }
+                        )
+                        continue
+                    if not local_path.exists():
+                        failures.append(
+                            {
+                                "code": "command_artifact_file_missing",
+                                "path": artifact_path,
+                            }
+                        )
+                        continue
+                    expected_hash = artifact.get("sha256")
+                    if expected_hash is not None and expected_hash != _sha256_file(
+                        local_path
+                    ):
+                        failures.append(
+                            {
+                                "code": "command_artifact_hash_mismatch",
+                                "path": artifact_path,
+                            }
+                        )
+            ids = row.get("ids")
+            if isinstance(ids, dict):
+                report_hash_fields = {
+                    "scoreHash": ("scorePath", "scorer/score.json"),
+                    "proofStatusHash": (
+                        "proofStatusPath",
+                        "reports/proof-status.json",
+                    ),
+                    "verificationReportHash": (
+                        "verificationReportPath",
+                        "reports/verification-report.json",
+                    ),
+                }
+                for field, (
+                    path_field,
+                    default_relative_path,
+                ) in report_hash_fields.items():
+                    if field not in ids:
+                        continue
+                    path_override = ids.get(path_field)
+                    relative_path = (
+                        path_override
+                        if isinstance(path_override, str) and path_override
+                        else default_relative_path
+                    )
+                    report_path = root / relative_path
+                    if not report_path.exists():
+                        failures.append(
+                            {
+                                "code": "report_hash_target_missing",
+                                "field": field,
+                                "path": relative_path,
+                            }
+                        )
+                    elif ids[field] != _sha256_file(report_path):
+                        failures.append(
+                            {
+                                "code": "report_hash_mismatch",
+                                "field": field,
+                                "path": relative_path,
+                            }
+                        )
+    else:
+        needs_review = False
 
     cleanup_path = root / "cleanup" / "status.json"
     if cleanup_path.exists():
         cleanup = _load_json(cleanup_path)
-        if isinstance(cleanup, dict) and cleanup.get("status") == "failed":
-            taints.append({"code": "cleanup_failed"})
+        if not isinstance(cleanup, dict):
+            failures.append({"code": "cleanup_status_not_object"})
+        else:
+            cleanup_status = cleanup.get("status")
+            if cleanup_status == "failed":
+                taints.append({"code": "cleanup_failed"})
+            elif is_browser_workbench_root and cleanup_status != "passed":
+                needs_review = True
+                warnings.append(
+                    {
+                        "code": "cleanup_status_not_terminal",
+                        "status": cleanup_status,
+                    }
+                )
     else:
         taints.append({"code": "cleanup_status_missing"})
 
-    status = "failed" if failures else ("tainted" if taints else "passed")
+    status = (
+        "failed"
+        if failures
+        else "tainted"
+        if taints
+        else "needs_review"
+        if needs_review
+        else "passed"
+    )
     score = {
         "schemaVersion": 1,
         "status": status,
@@ -1129,31 +1367,47 @@ def score_proof_root(proof_root: str | Path, *, write: bool = True) -> dict[str,
         "failures": failures,
         "taints": taints,
         "warnings": warnings,
-        "artifactCount": len(artifact_rows),
+        "artifactCount": len(artifact_rows) + len(browser_artifact_rows),
+        "structuralOnly": is_browser_workbench_root,
     }
     if write:
+        score_command_id = f"cmd_{uuid.uuid4().hex}"
         score_path = root / "scorer" / "score.json"
         proof_status_path = root / "reports" / "proof-status.json"
+        score_history_relative_path = f"scorer/history/{score_command_id}.json"
+        proof_status_history_relative_path = (
+            f"reports/history/proof-status-{score_command_id}.json"
+        )
         _write_json(score_path, score)
+        _write_json(root / score_history_relative_path, score)
         (root / "scorer" / "score.md").write_text(
             f"# Score\n\nStatus: {status}\n\nFailures: {len(failures)}\n\nTaints: {len(taints)}\n",
             encoding="utf-8",
         )
         _write_json(proof_status_path, score)
+        _write_json(root / proof_status_history_relative_path, score)
         (root / "reports" / "proof-status.md").write_text(
             f"# Proof Status\n\nStatus: {status}\n",
             encoding="utf-8",
         )
         append_command(
             root,
+            command_id=score_command_id,
             command="score",
             status=status,
-            artifacts=[{"path": "scorer/score.json", "role": "score"}],
-            warnings=[warning["code"] for warning in warnings],
+            artifacts=[
+                _artifact_ref(root, score_history_relative_path, "score"),
+                _artifact_ref(root, proof_status_history_relative_path, "proof-status"),
+            ],
+            warnings=_warning_codes(warnings),
             taints=[taint["code"] for taint in taints],
             ids={
-                "scoreHash": _sha256_file(score_path),
-                "proofStatusHash": _sha256_file(proof_status_path),
+                "scorePath": score_history_relative_path,
+                "scoreHash": _sha256_file(root / score_history_relative_path),
+                "proofStatusPath": proof_status_history_relative_path,
+                "proofStatusHash": _sha256_file(
+                    root / proof_status_history_relative_path
+                ),
             },
         )
         _update_manifest_hash(root, "commandLedgerHash", root / "commands.jsonl")
@@ -1169,27 +1423,16 @@ def verify_proof_root(proof_root: str | Path, *, write: bool = True) -> dict[str
     }
     if write:
         root = Path(proof_root)
+        verify_command_id = f"cmd_{uuid.uuid4().hex}"
         verification_report_path = root / "reports" / "verification-report.json"
+        verification_history_relative_path = (
+            f"reports/history/verification-report-{verify_command_id}.json"
+        )
         _write_json(verification_report_path, verified)
         (root / "reports" / "verification-report.md").write_text(
             f"# Verification Report\n\nVerified: {str(verified['verified']).lower()}\n\nStatus: {score['status']}\n",
             encoding="utf-8",
         )
-        append_command(
-            root,
-            command="verify",
-            status=score["status"],
-            artifacts=[
-                {"path": "reports/proof-status.json", "role": "proof-status"},
-                {
-                    "path": "reports/verification-report.json",
-                    "role": "verification-report",
-                },
-            ],
-            taints=[taint["code"] for taint in score["taints"]],
-            ids={"verificationReportHash": _sha256_file(verification_report_path)},
-        )
-        _update_manifest_hash(root, "commandLedgerHash", root / "commands.jsonl")
         final_redaction_report = _write_redaction_report(root)
         if final_redaction_report["findings"]:
             final_status = (
@@ -1211,4 +1454,26 @@ def verify_proof_root(proof_root: str | Path, *, write: bool = True) -> dict[str
                 f"# Verification Report\n\nVerified: false\n\nStatus: {final_status}\n",
                 encoding="utf-8",
             )
+        _write_json(root / verification_history_relative_path, verified)
+        append_command(
+            root,
+            command_id=verify_command_id,
+            command="verify",
+            status=verified["status"],
+            artifacts=[
+                _artifact_ref(
+                    root, verification_history_relative_path, "verification-report"
+                ),
+            ],
+            warnings=_warning_codes(score["warnings"]),
+            taints=[taint["code"] for taint in score["taints"]],
+            ids={
+                "verificationReportPath": verification_history_relative_path,
+                "verificationReportHash": _sha256_file(
+                    root / verification_history_relative_path
+                ),
+            },
+        )
+        _update_manifest_hash(root, "commandLedgerHash", root / "commands.jsonl")
+        _write_redaction_report(root)
     return verified

--- a/packages/narada/tests/test_browser_environment_login.py
+++ b/packages/narada/tests/test_browser_environment_login.py
@@ -6,6 +6,19 @@ from narada.config import BrowserConfig
 from narada_core.errors import NaradaExtensionUnauthenticatedError
 
 
+def test_initialization_tag_preserves_existing_query_params() -> None:
+    import narada.environment as environment_module
+
+    tagged_url = environment_module._with_query_params(
+        "http://localhost:3000/blank?narada-sidepanel-test=1",
+        {"t": "window-tag"},
+    )
+
+    assert (
+        tagged_url == "http://localhost:3000/blank?narada-sidepanel-test=1&t=window-tag"
+    )
+
+
 @pytest.mark.asyncio
 async def test_browser_environment_does_not_fetch_login_token_when_already_authenticated(
     monkeypatch: pytest.MonkeyPatch,

--- a/packages/narada/tests/test_browser_workbench.py
+++ b/packages/narada/tests/test_browser_workbench.py
@@ -1,0 +1,702 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+import narada.browser_workbench as browser_module
+import pytest
+from narada.browser_workbench import (
+    browser_downloads,
+    browser_find,
+    browser_nrd_action,
+    browser_screenshot,
+    browser_selectors,
+    browser_snapshot,
+    env_close,
+    env_open,
+)
+from narada.cli import main
+from narada.workbench import score_proof_root, verify_proof_root
+from narada_core.actions.models import (
+    BrowserActionResponse,
+    BrowserClickNrdRequest,
+    BrowserDownloadsRequest,
+    BrowserDownloadsResponse,
+    BrowserPageSnapshotRequest,
+    BrowserPageSnapshotResponse,
+    BrowserScreenshotRequest,
+    BrowserScreenshotResponse,
+    GetUrlRequest,
+    GetUrlResponse,
+)
+
+
+def _snapshot(snapshot_id: str = "snap_1") -> BrowserPageSnapshotResponse:
+    return BrowserPageSnapshotResponse(
+        snapshot_id=snapshot_id,
+        url="https://fixture.test",
+        title="Fixture",
+        active=True,
+        html=(
+            '<body><button data-nrd="main:submit" aria-label="Submit order">'
+            "Submit</button></body>"
+        ),
+        html_truncated=False,
+        visible_text="Submit",
+        visible_text_truncated=False,
+        elements=[
+            {
+                "data_nrd": "main:submit",
+                "frame_id": "main",
+                "tag_name": "button",
+                "text": "Submit",
+                "aria_label": "Submit order",
+                "interactive": True,
+                "fingerprint": "abc123",
+            }
+        ],
+        frames=[
+            {
+                "frame_id": "main",
+                "title": "Fixture",
+                "url": "https://fixture.test",
+            }
+        ],
+        meta={"i": ["main:submit"], "h": [], "s": [], "sc": []},
+    )
+
+
+def _write_env_record(
+    root: Path,
+    *,
+    env_id: str = "dev",
+    browser_window_id: str = "window-1",
+    api_base_url: str = "https://api.test",
+    extra: dict[str, Any] | None = None,
+) -> None:
+    browser_module._browser_root(root, "browser-test")
+    (root / "cleanup" / "status.json").write_text(
+        json.dumps({"status": "passed", "browserEnvironmentStatus": "test"}),
+        encoding="utf-8",
+    )
+    env_dir = root / "browser" / "environments"
+    env_dir.mkdir(parents=True, exist_ok=True)
+    (env_dir / f"{env_id}.json").write_text(
+        json.dumps(
+            {
+                "browserWindowId": browser_window_id,
+                "apiBaseUrl": api_base_url,
+                **(extra or {}),
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+class _FakeRemoteEnvironment:
+    calls: list[Any] = []
+    fail_screenshot: bool = False
+    download_path: Path | None = None
+    stale_download_path: Path | None = None
+
+    def __init__(self, **kwargs: Any) -> None:
+        self.kwargs = kwargs
+
+    async def _run_extension_action(
+        self, request: Any, response_model: Any = None, **kwargs: Any
+    ) -> Any:
+        del kwargs
+        self.__class__.calls.append(request)
+        if isinstance(request, BrowserPageSnapshotRequest):
+            return _snapshot(request.snapshot_id or "snap_1")
+        if isinstance(request, BrowserClickNrdRequest):
+            return BrowserActionResponse(
+                post_snapshot=_snapshot("post_1") if request.post_snapshot else None
+            )
+        if isinstance(request, BrowserScreenshotRequest):
+            if self.__class__.fail_screenshot:
+                raise RuntimeError("Failed to take screenshot")
+            content = base64.b64encode(b"png-bytes").decode("ascii").rstrip("=")
+            return BrowserScreenshotResponse(
+                base64_content=f"data:image/png;base64,{content}",
+                name="screenshot.png",
+                mime_type="image/png",
+                timestamp="2026-06-09T00:00:00Z",
+            )
+        if isinstance(request, BrowserDownloadsRequest):
+            if self.__class__.download_path is None:
+                return BrowserDownloadsResponse(
+                    downloads=[],
+                    capture_supported=True,
+                    warning="No completed Chrome downloads found.",
+                )
+            download_path = self.__class__.download_path
+            downloads: list[dict[str, Any]] = []
+            if self.__class__.stale_download_path is not None:
+                stale_download_path = self.__class__.stale_download_path
+                downloads.append(
+                    {
+                        "file_name": stale_download_path.name,
+                        "file_size": stale_download_path.stat().st_size,
+                        "state": "complete",
+                        "exists": True,
+                        "start_time": "2026-06-01T00:00:00Z",
+                        "url": "https://fixture.test/old-download?token=secret",
+                        "local_path": str(stale_download_path),
+                    }
+                )
+            downloads.append(
+                {
+                    "file_name": download_path.name,
+                    "file_size": download_path.stat().st_size,
+                    "state": "complete",
+                    "exists": True,
+                    "start_time": request.started_after or "2026-06-09T00:00:01Z",
+                    "url": "https://fixture.test/download?token=secret",
+                    "local_path": str(download_path),
+                }
+            )
+            return BrowserDownloadsResponse(
+                downloads=downloads,
+                capture_supported=True,
+            )
+        if isinstance(request, GetUrlRequest):
+            return GetUrlResponse(url="https://fixture.test/current")
+        if response_model is None:
+            return None
+        raise AssertionError(f"Unexpected request {request!r}")
+
+    async def close(self, *, timeout: int | None = None) -> None:
+        del timeout
+        self.__class__.calls.append("close")
+
+
+class _FakeLocalEnvironment:
+    instances: list["_FakeLocalEnvironment"] = []
+
+    def __init__(self, **kwargs: Any) -> None:
+        self.kwargs = kwargs
+        self.browser_window_id = "window-1"
+        self.browser_process_id = 123
+        self.__class__.instances.append(self)
+
+    async def start(self) -> None:
+        return None
+
+    async def _stop_playwright(self) -> None:
+        return None
+
+
+@pytest.fixture(autouse=True)
+def reset_fake_remote_environment() -> None:
+    _FakeRemoteEnvironment.calls = []
+    _FakeRemoteEnvironment.download_path = None
+    _FakeRemoteEnvironment.stale_download_path = None
+    _FakeLocalEnvironment.instances = []
+
+
+@pytest.mark.asyncio
+async def test_browser_snapshot_writes_canonical_artifacts(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(
+        browser_module, "RemoteBrowserEnvironment", _FakeRemoteEnvironment
+    )
+    _write_env_record(tmp_path)
+
+    result = await browser_snapshot(env_id="dev", proof_root=tmp_path)
+
+    assert result.status == "passed"
+    snapshot_id = result.payload["snapshotId"]
+    assert (tmp_path / "browser" / "snapshots" / snapshot_id / "summary.json").exists()
+    assert (
+        tmp_path / "browser" / "snapshots" / snapshot_id / "simplified.html"
+    ).exists()
+    assert (tmp_path / "browser" / "page-snapshots.jsonl").exists()
+    assert score_proof_root(tmp_path)["status"] == "passed"
+    assert verify_proof_root(tmp_path)["verified"] is True
+
+
+@pytest.mark.asyncio
+async def test_browser_find_and_selectors_are_snapshot_local(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(
+        browser_module, "RemoteBrowserEnvironment", _FakeRemoteEnvironment
+    )
+    _write_env_record(tmp_path)
+    snapshot = await browser_snapshot(env_id="dev", proof_root=tmp_path)
+    snapshot_id = snapshot.payload["snapshotId"]
+
+    found = await browser_find(
+        env_id="dev",
+        snapshot_id=snapshot_id,
+        proof_root=tmp_path,
+        text="submit",
+        interactive_only=True,
+    )
+    selectors = await browser_selectors(
+        env_id="dev",
+        snapshot_id=snapshot_id,
+        frame_id="main",
+        data_nrd="main:submit",
+        proof_root=tmp_path,
+    )
+
+    assert found.payload["matchCount"] == 1
+    assert selectors.payload["diagnostic"] is True
+    assert selectors.payload["selectors"]["naradaId"] == "main:submit"
+
+
+@pytest.mark.asyncio
+async def test_browser_click_nrd_validates_snapshot_handle_and_writes_post_snapshot(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(
+        browser_module, "RemoteBrowserEnvironment", _FakeRemoteEnvironment
+    )
+    _write_env_record(tmp_path)
+    snapshot = await browser_snapshot(env_id="dev", proof_root=tmp_path)
+
+    result = await browser_nrd_action(
+        env_id="dev",
+        action="click",
+        snapshot_id=snapshot.payload["snapshotId"],
+        frame_id="main",
+        data_nrd="main:submit",
+        proof_root=tmp_path,
+        post_snapshot=True,
+    )
+
+    assert result.status == "passed"
+    assert result.payload["postSnapshotId"] == "post_1"
+    assert isinstance(_FakeRemoteEnvironment.calls[-1], BrowserClickNrdRequest)
+
+
+@pytest.mark.asyncio
+async def test_browser_downloads_materializes_completed_local_files(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(
+        browser_module, "RemoteBrowserEnvironment", _FakeRemoteEnvironment
+    )
+    proof_root = tmp_path / "proof"
+    download_file = tmp_path / "source-downloads" / "fixture-download.txt"
+    download_file.parent.mkdir()
+    download_file.write_text("download bytes", encoding="utf-8")
+    _FakeRemoteEnvironment.download_path = download_file
+    _write_env_record(proof_root)
+
+    result = await browser_downloads(env_id="dev", proof_root=proof_root)
+
+    assert result.status == "passed"
+    assert (
+        result.payload["downloads"][0]["sha256"]
+        == hashlib.sha256(b"download bytes").hexdigest()
+    )
+    assert "local_path" not in result.payload["downloads"][0]
+    assert (
+        proof_root / result.payload["downloads"][0]["path"]
+    ).read_text() == "download bytes"
+    assert score_proof_root(proof_root)["status"] == "passed"
+    assert verify_proof_root(proof_root)["verified"] is True
+
+
+@pytest.mark.asyncio
+async def test_browser_downloads_filters_stale_profile_downloads(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(
+        browser_module, "RemoteBrowserEnvironment", _FakeRemoteEnvironment
+    )
+    proof_root = tmp_path / "proof"
+    download_file = tmp_path / "source-downloads" / "fixture-download.txt"
+    stale_file = tmp_path / "source-downloads" / "old-download.txt"
+    download_file.parent.mkdir()
+    download_file.write_text("download bytes", encoding="utf-8")
+    stale_file.write_text("old bytes", encoding="utf-8")
+    _FakeRemoteEnvironment.download_path = download_file
+    _FakeRemoteEnvironment.stale_download_path = stale_file
+    _write_env_record(proof_root)
+    browser_module.append_command(proof_root, command="env.open", status="passed")
+
+    result = await browser_downloads(env_id="dev", proof_root=proof_root)
+
+    assert result.status == "passed"
+    assert result.payload["staleDownloadCount"] == 1
+    assert "token=secret" not in result.payload["downloads"][0]["redactedUrl"]
+    assert result.payload["downloads"][0]["redactedUrl"] == (
+        "https://fixture.test/download"
+    )
+    assert [download["file_name"] for download in result.payload["downloads"]] == [
+        "fixture-download.txt"
+    ]
+    assert (
+        proof_root / result.payload["downloads"][0]["path"]
+    ).read_text() == "download bytes"
+    assert not any(
+        path.name == "old-download.txt"
+        for path in (proof_root / "downloads").glob("**/*")
+    )
+
+
+@pytest.mark.asyncio
+async def test_env_open_and_close_write_cleanup_status(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(browser_module, "BrowserEnvironment", _FakeLocalEnvironment)
+    monkeypatch.setattr(
+        browser_module, "RemoteBrowserEnvironment", _FakeRemoteEnvironment
+    )
+
+    opened = await env_open(
+        name="dev",
+        kind="local",
+        proof_root=tmp_path,
+        extension_id="dev-extension",
+    )
+    closed = await env_close(env_id="dev", proof_root=tmp_path)
+
+    assert opened.payload["environment"]["browserWindowId"] == "window-1"
+    assert opened.payload["environment"]["extensionId"] == "dev-extension"
+    assert _FakeLocalEnvironment.instances[0].kwargs["config"].extension_id == (
+        "dev-extension"
+    )
+    assert closed.payload["environment"]["status"] == "closed"
+    cleanup = json.loads((tmp_path / "cleanup" / "status.json").read_text())
+    assert cleanup["status"] == "passed"
+    assert (tmp_path / "browser" / "environments" / "dev-closed.json").exists()
+    assert score_proof_root(tmp_path)["status"] == "passed"
+    assert verify_proof_root(tmp_path)["verified"] is True
+
+
+@pytest.mark.asyncio
+async def test_env_open_can_adopt_existing_browser_window_id(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(browser_module, "BrowserEnvironment", _FakeLocalEnvironment)
+    monkeypatch.setattr(
+        browser_module, "RemoteBrowserEnvironment", _FakeRemoteEnvironment
+    )
+
+    opened = await env_open(
+        name="dev",
+        kind="local",
+        proof_root=tmp_path,
+        browser_window_id="window-adopted",
+        base_url="https://api.test",
+    )
+
+    assert opened.payload["environment"]["browserWindowId"] == "window-adopted"
+    assert opened.payload["environment"]["adoptedBrowserWindow"] is True
+    assert opened.payload["environment"]["verifiedCurrentUrl"] == (
+        "https://fixture.test/current"
+    )
+    assert _FakeLocalEnvironment.instances == []
+
+
+@pytest.mark.asyncio
+async def test_env_close_detaches_adopted_browser_by_default(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(
+        browser_module, "RemoteBrowserEnvironment", _FakeRemoteEnvironment
+    )
+    _write_env_record(tmp_path, browser_window_id="window-adopted")
+    env_path = tmp_path / "browser" / "environments" / "dev.json"
+    record = json.loads(env_path.read_text(encoding="utf-8"))
+    record["adoptedBrowserWindow"] = True
+    env_path.write_text(json.dumps(record), encoding="utf-8")
+
+    closed = await env_close(env_id="dev", proof_root=tmp_path)
+
+    assert closed.status == "passed"
+    assert closed.payload["environment"]["status"] == "detached"
+    assert closed.payload["environment"]["closeBehavior"] == (
+        "adopted_browser_not_closed"
+    )
+    assert "close" not in _FakeRemoteEnvironment.calls
+
+
+def test_cli_browser_find_requires_proof_root() -> None:
+    with pytest.raises(SystemExit) as exc_info:
+        main(["workbench", "browser", "find", "dev", "--snapshot-id", "snap"])
+
+    assert exc_info.value.code == 2
+
+
+def test_cli_json_mode_reports_runtime_errors_as_json(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    code = main(
+        [
+            "workbench",
+            "browser",
+            "snapshot",
+            "missing",
+            "--proof-root",
+            str(tmp_path),
+            "--json",
+        ]
+    )
+
+    assert code == 1
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert payload["status"] == "failed"
+    assert "Unknown browser environment" in payload["error"]
+    assert captured.err == ""
+
+
+def test_cli_json_mode_reports_snapshot_bound_errors(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    _write_env_record(tmp_path)
+
+    code = main(
+        [
+            "workbench",
+            "browser",
+            "snapshot",
+            "dev",
+            "--proof-root",
+            str(tmp_path),
+            "--max-html-bytes",
+            "2000000",
+            "--json",
+        ]
+    )
+
+    assert code == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["status"] == "failed"
+    assert "max_html_bytes" in payload["error"]
+
+
+@pytest.mark.asyncio
+async def test_browser_screenshot_accepts_data_url_without_padding(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _FakeRemoteEnvironment.fail_screenshot = False
+    monkeypatch.setattr(
+        browser_module, "RemoteBrowserEnvironment", _FakeRemoteEnvironment
+    )
+    _write_env_record(tmp_path)
+
+    result = await browser_screenshot(env_id="dev", proof_root=tmp_path)
+
+    assert result.status == "passed"
+    request = next(
+        call
+        for call in _FakeRemoteEnvironment.calls
+        if isinstance(call, BrowserScreenshotRequest)
+    )
+    assert request.timeout_ms == browser_module.BROWSER_WORKBENCH_SCREENSHOT_TIMEOUT_MS
+    screenshot_path = tmp_path / result.payload["path"]
+    assert screenshot_path.read_bytes() == b"png-bytes"
+    assert score_proof_root(tmp_path)["status"] == "passed"
+    assert verify_proof_root(tmp_path)["verified"] is True
+
+
+@pytest.mark.asyncio
+async def test_browser_workbench_verify_is_idempotent(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(
+        browser_module, "RemoteBrowserEnvironment", _FakeRemoteEnvironment
+    )
+    _write_env_record(tmp_path)
+
+    await browser_snapshot(env_id="dev", proof_root=tmp_path)
+
+    verified = verify_proof_root(tmp_path)
+    assert verified["verified"] is True
+
+    no_write_verified = verify_proof_root(tmp_path, write=False)
+    assert no_write_verified["status"] == "passed"
+    assert no_write_verified["failures"] == []
+
+
+@pytest.mark.asyncio
+async def test_browser_action_without_post_snapshot_is_review_gated(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(
+        browser_module, "RemoteBrowserEnvironment", _FakeRemoteEnvironment
+    )
+    _write_env_record(tmp_path)
+    snapshot = await browser_snapshot(env_id="dev", proof_root=tmp_path)
+
+    result = await browser_nrd_action(
+        env_id="dev",
+        action="click",
+        snapshot_id=snapshot.payload["snapshotId"],
+        frame_id="main",
+        data_nrd="main:submit",
+        proof_root=tmp_path,
+        post_snapshot=False,
+    )
+
+    assert result.status == "needs_review"
+    assert "postSnapshotId" not in result.payload
+    score = score_proof_root(tmp_path)
+    assert score["status"] == "needs_review"
+    assert any(
+        warning.get("warning") == "browser_action_post_snapshot_missing"
+        for warning in score["warnings"]
+    )
+
+
+@pytest.mark.asyncio
+async def test_browser_screenshot_failure_is_recorded_without_fake_artifact(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _FakeRemoteEnvironment.fail_screenshot = True
+    monkeypatch.setattr(
+        browser_module, "RemoteBrowserEnvironment", _FakeRemoteEnvironment
+    )
+    _write_env_record(tmp_path)
+
+    result = await browser_screenshot(env_id="dev", proof_root=tmp_path)
+
+    assert result.status == "needs_review"
+    assert result.payload["captureSupported"] is False
+    assert not list((tmp_path / "browser").glob("screenshots/*.png"))
+    score = score_proof_root(tmp_path)
+    assert score["status"] == "needs_review"
+    assert any(
+        warning.get("command") == "browser.screenshot" for warning in score["warnings"]
+    )
+    verified = verify_proof_root(tmp_path)
+    assert verified["verified"] is False
+    assert verified["status"] == "needs_review"
+
+    _FakeRemoteEnvironment.fail_screenshot = False
+
+
+def test_browser_workbench_score_fails_command_artifact_hash_mismatch(
+    tmp_path: Path,
+) -> None:
+    (tmp_path / "browser" / "snapshots" / "snap_1").mkdir(parents=True)
+    artifact = tmp_path / "browser" / "snapshots" / "snap_1" / "summary.json"
+    artifact.write_text("{}", encoding="utf-8")
+    (tmp_path / "manifest.json").write_text(
+        json.dumps(
+            {
+                "schemaVersion": 1,
+                "proofRootKind": "browser-workbench",
+                "runId": tmp_path.name,
+                "status": "materialized",
+                "commandLedgerHash": "placeholder",
+            }
+        ),
+        encoding="utf-8",
+    )
+    (tmp_path / "cleanup").mkdir()
+    (tmp_path / "cleanup" / "status.json").write_text(
+        json.dumps({"status": "passed"}), encoding="utf-8"
+    )
+    command = {
+        "schemaVersion": 1,
+        "commandId": "cmd_1",
+        "runId": tmp_path.name,
+        "command": "browser.snapshot",
+        "status": "passed",
+        "artifacts": [
+            {
+                "path": "browser/snapshots/snap_1/summary.json",
+                "role": "browser-snapshot-summary",
+                "sha256": "wrong",
+            }
+        ],
+    }
+    commands = tmp_path / "commands.jsonl"
+    commands.write_text(json.dumps(command) + "\n", encoding="utf-8")
+    manifest = json.loads((tmp_path / "manifest.json").read_text())
+    manifest["commandLedgerHash"] = hashlib.sha256(commands.read_bytes()).hexdigest()
+    (tmp_path / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+
+    score = score_proof_root(tmp_path)
+
+    assert score["status"] == "failed"
+    assert any(
+        failure["code"] == "command_artifact_hash_mismatch"
+        for failure in score["failures"]
+    )
+
+
+@pytest.mark.asyncio
+async def test_browser_workbench_open_cleanup_status_is_review_gated(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(browser_module, "BrowserEnvironment", _FakeLocalEnvironment)
+
+    await env_open(name="dev", kind="local", proof_root=tmp_path)
+
+    score = score_proof_root(tmp_path)
+    verified = verify_proof_root(tmp_path)
+
+    assert score["status"] == "needs_review"
+    assert verified["verified"] is False
+    assert any(
+        warning["code"] == "cleanup_status_not_terminal"
+        for warning in score["warnings"]
+    )
+
+
+@pytest.mark.asyncio
+async def test_browser_workbench_score_verify_do_not_amplify_warning_codes(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(
+        browser_module, "RemoteBrowserEnvironment", _FakeRemoteEnvironment
+    )
+    _write_env_record(tmp_path, browser_window_id="window-adopted")
+    env_path = tmp_path / "browser" / "environments" / "dev.json"
+    record = json.loads(env_path.read_text(encoding="utf-8"))
+    record["adoptedBrowserWindow"] = True
+    env_path.write_text(json.dumps(record), encoding="utf-8")
+
+    await env_close(env_id="dev", proof_root=tmp_path)
+    browser_module.append_command(
+        tmp_path,
+        command="score",
+        status="passed",
+        warnings=["command_warning"],
+    )
+    browser_module._update_manifest_hash(
+        tmp_path, "commandLedgerHash", tmp_path / "commands.jsonl"
+    )
+
+    score = score_proof_root(tmp_path)
+    verified = verify_proof_root(tmp_path)
+
+    assert score["status"] == "passed"
+    assert verified["verified"] is True
+    assert any(
+        warning["command"] == "env.close"
+        and warning["warning"] == "adopted_browser_not_closed"
+        for warning in verified["warnings"]
+    )
+    assert not any(
+        warning["command"] in {"score", "verify"}
+        and warning["warning"] == "command_warning"
+        for warning in verified["warnings"]
+    )

--- a/packages/narada/tests/test_browser_workbench.py
+++ b/packages/narada/tests/test_browser_workbench.py
@@ -357,6 +357,10 @@ async def test_env_open_and_close_write_cleanup_status(
     monkeypatch.setattr(
         browser_module, "RemoteBrowserEnvironment", _FakeRemoteEnvironment
     )
+    monkeypatch.setattr(browser_module, "_local_process_is_running", lambda pid: False)
+    monkeypatch.setattr(
+        browser_module, "_tcp_port_is_listening", lambda port, host=None: False
+    )
 
     opened = await env_open(
         name="dev",
@@ -372,8 +376,14 @@ async def test_env_open_and_close_write_cleanup_status(
         "dev-extension"
     )
     assert closed.payload["environment"]["status"] == "closed"
+    assert closed.payload["environment"]["localBrowserProcessStatus"] == (
+        "already_exited"
+    )
+    assert closed.payload["environment"]["localBrowserCdpPortStatus"] == "closed"
     cleanup = json.loads((tmp_path / "cleanup" / "status.json").read_text())
     assert cleanup["status"] == "passed"
+    assert cleanup["localBrowserProcessStatus"] == "already_exited"
+    assert cleanup["localBrowserCdpPortStatus"] == "closed"
     assert (tmp_path / "browser" / "environments" / "dev-closed.json").exists()
     assert score_proof_root(tmp_path)["status"] == "passed"
     assert verify_proof_root(tmp_path)["verified"] is True
@@ -427,6 +437,227 @@ async def test_env_close_detaches_adopted_browser_by_default(
         "adopted_browser_not_closed"
     )
     assert "close" not in _FakeRemoteEnvironment.calls
+
+
+@pytest.mark.asyncio
+async def test_env_close_terminates_sdk_created_local_browser_process(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(
+        browser_module, "RemoteBrowserEnvironment", _FakeRemoteEnvironment
+    )
+    monkeypatch.setattr(browser_module, "_local_process_is_running", lambda pid: True)
+    monkeypatch.setattr(
+        browser_module,
+        "_local_process_identity_status",
+        lambda pid, record: {"status": "verified", "pid": pid},
+    )
+    port_checks: list[tuple[int, str | None]] = []
+
+    def fake_port_probe(port: int, host: str | None = None) -> bool:
+        port_checks.append((port, host))
+        return False
+
+    monkeypatch.setattr(browser_module, "_tcp_port_is_listening", fake_port_probe)
+    terminated: list[int] = []
+
+    async def fake_terminate(pid: int) -> dict[str, Any]:
+        terminated.append(pid)
+        return {"status": "terminated", "pid": pid}
+
+    monkeypatch.setattr(browser_module, "_terminate_local_process", fake_terminate)
+    _write_env_record(
+        tmp_path,
+        extra={
+            "kind": "local",
+            "ownership": "sdk-created",
+            "attachToExisting": False,
+            "browserProcessId": 123,
+            "cdpHost": "127.0.0.42",
+            "cdpPort": 9333,
+            "userDataDir": "/tmp/narada-browser-dev",
+        },
+    )
+
+    closed = await env_close(env_id="dev", proof_root=tmp_path)
+
+    assert closed.status == "passed"
+    assert "close" in _FakeRemoteEnvironment.calls
+    assert terminated == [123]
+    assert closed.payload["environment"]["localBrowserProcessStatus"] == "terminated"
+    assert closed.payload["environment"]["localBrowserCdpPortStatus"] == "closed"
+    assert port_checks == [(9333, "127.0.0.42")]
+    command_row = json.loads(
+        (tmp_path / "commands.jsonl").read_text(encoding="utf-8").splitlines()[-1]
+    )
+    assert (
+        "local_browser_process_terminated_after_remote_close" in command_row["warnings"]
+    )
+    cleanup = json.loads((tmp_path / "cleanup" / "status.json").read_text())
+    assert cleanup["status"] == "passed"
+    assert cleanup["localBrowserProcessStatus"] == "terminated"
+    assert cleanup["localBrowserCdpPortStatus"] == "closed"
+
+
+@pytest.mark.asyncio
+async def test_env_close_refuses_to_kill_local_browser_when_identity_mismatches(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(
+        browser_module, "RemoteBrowserEnvironment", _FakeRemoteEnvironment
+    )
+    monkeypatch.setattr(browser_module, "_local_process_is_running", lambda pid: True)
+    monkeypatch.setattr(
+        browser_module,
+        "_local_process_identity_status",
+        lambda pid, record: {"status": "identity_mismatch", "pid": pid},
+    )
+    monkeypatch.setattr(
+        browser_module, "_tcp_port_is_listening", lambda port, host=None: False
+    )
+    terminated: list[int] = []
+
+    async def fake_terminate(pid: int) -> dict[str, Any]:
+        terminated.append(pid)
+        return {"status": "terminated", "pid": pid}
+
+    monkeypatch.setattr(browser_module, "_terminate_local_process", fake_terminate)
+    _write_env_record(
+        tmp_path,
+        extra={
+            "kind": "local",
+            "ownership": "sdk-created",
+            "attachToExisting": False,
+            "browserProcessId": 123,
+            "cdpHost": "127.0.0.1",
+            "cdpPort": 9333,
+            "userDataDir": "/tmp/narada-browser-dev",
+        },
+    )
+
+    closed = await env_close(env_id="dev", proof_root=tmp_path)
+
+    assert closed.status == "failed"
+    assert terminated == []
+    assert closed.payload["environment"]["status"] == "close_failed"
+    assert closed.payload["environment"]["localBrowserProcessStatus"] == (
+        "identity_mismatch"
+    )
+    assert closed.payload["environment"]["localBrowserProcessIdentity"] == {
+        "status": "identity_mismatch",
+        "pid": 123,
+    }
+    command_row = json.loads(
+        (tmp_path / "commands.jsonl").read_text(encoding="utf-8").splitlines()[-1]
+    )
+    assert "browser_environment_process_cleanup_failed" in command_row["warnings"]
+    cleanup = json.loads((tmp_path / "cleanup" / "status.json").read_text())
+    assert cleanup["status"] == "failed"
+    assert cleanup["localBrowserProcessStatus"] == "identity_mismatch"
+
+
+def test_local_process_identity_requires_exact_debug_port(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        browser_module,
+        "_process_command_line",
+        lambda pid: (
+            "/Applications/Chrome --remote-debugging-port=93330 "
+            "--user-data-dir=/tmp/narada-browser-dev"
+        ),
+    )
+
+    status = browser_module._local_process_identity_status(
+        123,
+        {"cdpPort": 9333, "userDataDir": "/tmp/narada-browser-dev"},
+    )
+
+    assert status["status"] == "identity_mismatch"
+    assert "--remote-debugging-port=9333" in status["missingMarkers"]
+
+
+def test_local_process_identity_requires_exact_user_data_dir(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        browser_module,
+        "_process_command_line",
+        lambda pid: (
+            "/Applications/Chrome --remote-debugging-port=9333 "
+            "--user-data-dir=/tmp/narada-browser-dev-old"
+        ),
+    )
+
+    status = browser_module._local_process_identity_status(
+        123,
+        {"cdpPort": 9333, "userDataDir": "/tmp/narada-browser-dev"},
+    )
+
+    assert status["status"] == "identity_mismatch"
+    assert "--user-data-dir=/tmp/narada-browser-dev" in status["missingMarkers"]
+
+
+def test_local_process_identity_accepts_exact_launch_markers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        browser_module,
+        "_process_command_line",
+        lambda pid: (
+            "/Applications/Chrome --remote-debugging-port=9333 "
+            "--user-data-dir=/tmp/narada-browser-dev --new-window"
+        ),
+    )
+
+    status = browser_module._local_process_identity_status(
+        123,
+        {"cdpPort": 9333, "userDataDir": "/tmp/narada-browser-dev"},
+    )
+
+    assert status == {"status": "verified", "pid": 123}
+
+
+@pytest.mark.asyncio
+async def test_env_close_fails_if_sdk_created_local_cdp_port_stays_open(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(
+        browser_module, "RemoteBrowserEnvironment", _FakeRemoteEnvironment
+    )
+    monkeypatch.setattr(browser_module, "_local_process_is_running", lambda pid: False)
+    monkeypatch.setattr(
+        browser_module, "_tcp_port_is_listening", lambda port, host=None: True
+    )
+    _write_env_record(
+        tmp_path,
+        extra={
+            "kind": "local",
+            "ownership": "sdk-created",
+            "attachToExisting": False,
+            "browserProcessId": 123,
+            "cdpPort": 9333,
+        },
+    )
+
+    closed = await env_close(env_id="dev", proof_root=tmp_path)
+
+    assert closed.status == "failed"
+    assert closed.payload["environment"]["status"] == "close_failed"
+    assert closed.payload["environment"]["closeBehavior"] == "process_cleanup_failed"
+    assert closed.payload["environment"]["localBrowserProcessStatus"] == (
+        "already_exited"
+    )
+    assert closed.payload["environment"]["localBrowserCdpPortStatus"] == "listening"
+    cleanup = json.loads((tmp_path / "cleanup" / "status.json").read_text())
+    assert cleanup["status"] == "failed"
+    assert cleanup["localBrowserCdpPortStatus"] == "listening"
+    score = score_proof_root(tmp_path)
+    assert score["status"] == "tainted"
+    assert any(taint["code"] == "cleanup_failed" for taint in score["taints"])
 
 
 def test_cli_browser_find_requires_proof_root() -> None:

--- a/packages/narada/tests/test_workbench.py
+++ b/packages/narada/tests/test_workbench.py
@@ -1095,6 +1095,9 @@ def test_cli_redacts_sensitive_exception_text(
         == 1
     )
     captured = capsys.readouterr()
-    assert "X-Amz-Signature" not in captured.err
-    assert "Bearer abc123" not in captured.err
-    assert "[REDACTED" in captured.err
+    payload = json.loads(captured.out)
+    assert payload["status"] == "failed"
+    assert "X-Amz-Signature" not in payload["error"]
+    assert "Bearer abc123" not in payload["error"]
+    assert "[REDACTED" in payload["error"]
+    assert captured.err == ""


### PR DESCRIPTION
## Summary

Adds the M4 Browser Exploration CLI/workbench layer to the Python SDK.

The CLI can open/adopt a local browser environment, navigate, snapshot, find elements, derive selector candidates, click/fill/select by snapshot-local `data-nrd`, diff snapshots, capture screenshots, materialize downloaded bytes, close/detach environments, and score/verify the proof root. The verifier hardening from the final review pass makes open browser roots review-gated, returns JSON error envelopes in `--json` mode, filters stale Chrome-profile downloads, and avoids recursively amplifying derived score/verify warnings.

## Validation

- `cd /Users/erenerdogan/ZenRep/narada-python-sdk && uv run ruff check packages/narada packages/narada-core packages/narada-pyodide`
- `cd /Users/erenerdogan/ZenRep/narada-python-sdk && uvx ruff@latest format --check --diff packages/narada packages/narada-core packages/narada-pyodide`
- `cd /Users/erenerdogan/ZenRep/narada-python-sdk && uv run pytest packages/narada/tests packages/narada-pyodide/tests/test_cloud_browser.py`
- Live SDK proof root: `/tmp/narada-workbench-runs/m4-browser-cli-final-proof-20260609T182140Z`
- Hardened final verify: `/tmp/narada-m4-final-hardened-verify.json`
- Negative roots: `/tmp/narada-workbench-runs/m4-browser-cli-negative-20260609T182637Z`, `/tmp/narada-workbench-runs/m4-browser-cli-negative-20260609T182637Z-review`

## Codex sibling refs

- caddie: https://github.com/NaradaAI/caddie/pull/6608
- frontend: https://github.com/NaradaAI/frontend/pull/1823
- narada-python-sdk: current PR
- architecture-docs: https://github.com/NaradaAI/architecture-docs/pull/27
- parent planning docs: local only
- narada-e2e-harness: skip
