### PR TITLE
[Narada Code 5] Add Cloud Browser parity to workbench browser CLI

### DIFF
--- a/packages/narada-pyodide/src/narada/__init__.py
+++ b/packages/narada-pyodide/src/narada/__init__.py
@@ -12,7 +12,7 @@ from narada_core.models import (
     ResponseContent,
 )
 
-from narada.agent import Agent
+from narada.agent import Agent, LocalBrowserWindow
 from narada.environment import (
     BaseBrowserEnvironment,
     BrowserEnvironment,
@@ -24,6 +24,10 @@ from narada.environment import (
 )
 from narada.utils import download_file, render_html
 from narada.version import __version__
+
+Agent.PRODUCTIVITY = AgentKind.PRODUCTIVITY  # type: ignore[attr-defined]
+Agent.OPERATOR = AgentKind.OPERATOR  # type: ignore[attr-defined]
+Agent.CORE_AGENT = AgentKind.CORE_AGENT  # type: ignore[attr-defined]
 
 __all__ = [
     "__version__",
@@ -39,6 +43,7 @@ __all__ = [
     "Environment",
     "File",
     "LambdaEnvironment",
+    "LocalBrowserWindow",
     "NaradaError",
     "NaradaTimeoutError",
     "ReasoningEffort",

--- a/packages/narada-pyodide/src/narada/agent.py
+++ b/packages/narada-pyodide/src/narada/agent.py
@@ -59,6 +59,7 @@ from pydantic import BaseModel
 
 from narada.environment import (
     BaseBrowserEnvironment,
+    BrowserEnvironment,
     Environment,
     InputRequiredCallback,
 )
@@ -578,5 +579,72 @@ class Agent(Generic[_StructuredOutput]):
         return await self._browser_environment()._run_extension_action(
             GetScreenshotRequest(),
             GetScreenshotResponse,
+            timeout=timeout,
+        )
+
+
+class LocalBrowserWindow(Agent[Any]):
+    """Backward-compatible browser-window helper for Python APA code.
+
+    Older Agent Studio Python workflows instantiate ``LocalBrowserWindow()`` and
+    call ``window.agent(...)``. The environment-based SDK keeps the same runtime
+    behavior by binding a normal ``Agent`` to the injected browser window.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(environment=BrowserEnvironment(), kind=AgentKind.OPERATOR)
+
+    async def agent(
+        self,
+        *,
+        prompt: str,
+        agent: AgentKind | str = AgentKind.OPERATOR,
+        reasoning: ReasoningEffort | None = None,
+        clear_chat: bool | None = None,
+        generate_gif: bool | None = None,
+        output_schema: type[BaseModel] | None = None,
+        previous_request_id: str | None = None,
+        chat_history: list[RemoteDispatchChatHistoryItem] | None = None,
+        additional_context: dict[str, str] | None = None,
+        attachment: File | IO[Any] | None = None,
+        time_zone: str = "America/Los_Angeles",
+        user_resource_credentials: UserResourceCredentials | None = None,
+        mcp_servers: list[McpServer] | None = None,
+        secret_variables: dict[str, str] | None = None,
+        input_variables: Mapping[str, Any] | None = None,
+        variables: Mapping[str, Any] | None = None,
+        callback_url: str | None = None,
+        callback_secret: str | None = None,
+        callback_headers: Mapping[str, Any] | None = None,
+        on_input_required: InputRequiredCallback | None = None,
+        critic: CriticConfig | None = None,
+        timeout: int = 1000,
+    ) -> AgentResponse:
+        if variables is not None and input_variables is not None:
+            raise ValueError("Pass either `variables` or `input_variables`, not both.")
+
+        scoped_agent = Agent(environment=self.environment, kind=agent)
+        return await scoped_agent.run(
+            prompt,
+            reasoning=reasoning,
+            clear_chat=clear_chat,
+            generate_gif=generate_gif,
+            output_schema=output_schema,
+            previous_request_id=previous_request_id,
+            chat_history=chat_history,
+            additional_context=additional_context,
+            attachment=attachment,
+            time_zone=time_zone,
+            user_resource_credentials=user_resource_credentials,
+            mcp_servers=mcp_servers,
+            secret_variables=secret_variables,
+            input_variables=input_variables
+            if input_variables is not None
+            else variables,
+            callback_url=callback_url,
+            callback_secret=callback_secret,
+            callback_headers=callback_headers,
+            on_input_required=on_input_required,
+            critic=critic,
             timeout=timeout,
         )

--- a/packages/narada-pyodide/src/narada/environment.py
+++ b/packages/narada-pyodide/src/narada/environment.py
@@ -218,6 +218,7 @@ class SessionDownloadItem:
     file_name: str
     size: int
     download_url: str
+    source_key: str | None = None
 
 
 class Environment(ABC):
@@ -728,6 +729,18 @@ class Environment(ABC):
                     and response_content is not None
                     else None
                 )
+                action_trace_raw: list[dict[str, Any]] | None = None
+                if response_content is not None:
+                    explicit_action_trace = response_content.get("actionTrace")
+                    if isinstance(explicit_action_trace, list):
+                        action_trace_raw = explicit_action_trace
+                    else:
+                        workflow_trace = response_content.get("workflowTrace")
+                        if isinstance(workflow_trace, dict) and isinstance(
+                            workflow_trace.get("children"), list
+                        ):
+                            action_trace_raw = workflow_trace["children"]
+
                 _trace.emit_sub_agent_call(
                     ts_start=trace_start_ms,
                     agent_type=agent_type_str,
@@ -736,11 +749,7 @@ class Environment(ABC):
                     request_id=request_id,
                     text=trace_text,
                     error_message=trace_error,
-                    action_trace_raw=(
-                        response_content.get("actionTrace")
-                        if response_content is not None
-                        else None
-                    ),
+                    action_trace_raw=action_trace_raw,
                     execution_trace_context=(
                         response_content.get("executionTraceContext")
                         if response_content is not None
@@ -1296,6 +1305,7 @@ async def _get_cloud_browser_downloads(
             file_name=item["file_name"],
             size=item["size"],
             download_url=presigned_urls[index],
+            source_key=item.get("key"),
         )
         for index, item in enumerate(files)
     ]

--- a/packages/narada-pyodide/tests/test_cloud_browser.py
+++ b/packages/narada-pyodide/tests/test_cloud_browser.py
@@ -12,6 +12,7 @@ from narada_core.actions.models import (
     DEFAULT_HITL_TIMEOUT_SECONDS,
     PromptForUserInputVariable,
 )
+from narada_core.models import AgentKind
 from packaging.version import InvalidVersion
 
 PROJECT_ROOT = Path(__file__).resolve().parents[3]
@@ -147,6 +148,24 @@ async def test_cloud_browser_environment_maps_backend_response(
         "require_extension": True,
         "initiator_remote_dispatch_request_id": "request-maps-123",
     }
+
+
+def test_local_browser_window_legacy_import_surface(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("NARADA_API_KEY", "test-api-key")
+    monkeypatch.setenv("NARADA_BROWSER_WINDOW_ID", "browser-window-123")
+    pyfetch = AsyncMock(side_effect=[_sdk_config_response()])
+    narada_pkg, _ = _import_pyodide_narada(monkeypatch, pyfetch=pyfetch)
+
+    window = narada_pkg.LocalBrowserWindow()
+
+    assert isinstance(window, narada_pkg.Agent)
+    assert window.kind is AgentKind.OPERATOR
+    assert window.environment.browser_window_id == "browser-window-123"
+    assert narada_pkg.Agent.OPERATOR is AgentKind.OPERATOR
+    assert narada_pkg.Agent.PRODUCTIVITY is AgentKind.PRODUCTIVITY
+    assert narada_pkg.Agent.CORE_AGENT is AgentKind.CORE_AGENT
 
 
 @pytest.mark.asyncio
@@ -708,6 +727,63 @@ async def test_dispatch_request_emits_success_text_and_execution_trace_context(
 
 
 @pytest.mark.asyncio
+async def test_dispatch_request_emits_workflow_trace_children_as_action_trace(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workflow_children = [
+        {
+            "kind": "output",
+            "text": "TRACE_CHILD_DONE",
+            "channel": "stdout",
+        }
+    ]
+    pyfetch = AsyncMock(
+        side_effect=[
+            _FakeResponse(json_data={"requestId": "req-123"}),
+            _FakeResponse(
+                json_data={
+                    "status": "success",
+                    "completedAt": "2026-05-08T00:00:00+00:00",
+                    "response": {
+                        "text": "TRACE_PARENT_CHILD_DONE",
+                        "workflowTrace": {
+                            "status": "success",
+                            "runtime": "python",
+                            "children": workflow_children,
+                        },
+                    },
+                    "activeInputRequest": None,
+                }
+            ),
+        ]
+    )
+    narada_pkg, _ = _import_pyodide_narada(monkeypatch, pyfetch=pyfetch)
+    emitted_events: list[str] = []
+    monkeypatch.setattr(
+        sys.modules["narada._trace"],
+        "_narada_emit_trace_event",
+        emitted_events.append,
+        raising=False,
+    )
+
+    env = narada_pkg.RemoteBrowserEnvironment(
+        browser_window_id="browser-window-123",
+        cloud_browser_session_id="session-123",
+        api_key="test-api-key",
+    )
+    response = await env._dispatch_request(
+        prompt="run child workflow",
+        agent="/$USER/childWorkflow",
+    )
+
+    assert response["status"] == "success"
+    assert len(emitted_events) == 1
+    parsed_event = json.loads(emitted_events[0])
+    assert parsed_event["text"] == "TRACE_PARENT_CHILD_DONE"
+    assert parsed_event["action_trace"] == workflow_children
+
+
+@pytest.mark.asyncio
 async def test_dispatch_request_preserves_current_file_variable_shape(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -817,6 +893,7 @@ async def test_cloud_browser_downloads_return_presigned_urls(
             file_name="report.pdf",
             size=42,
             download_url="https://example.com/report.pdf",
+            source_key="downloads/session-123/report.pdf",
         )
     ]
     first_call, second_call = pyfetch.await_args_list
@@ -859,6 +936,7 @@ async def test_lambda_environment_downloads_return_presigned_urls(
             file_name="report.pdf",
             size=42,
             download_url="https://example.com/report.pdf",
+            source_key="downloads/session-123/report.pdf",
         )
     ]
     first_call, second_call = pyfetch.await_args_list

--- a/packages/narada/src/narada/__init__.py
+++ b/packages/narada/src/narada/__init__.py
@@ -17,7 +17,7 @@ from narada_core.models import (
     ResponseContent,
 )
 
-from narada.agent import Agent
+from narada.agent import Agent, LocalBrowserWindow
 from narada.config import BrowserConfig, ProxyConfig
 from narada.environment import (
     BaseBrowserEnvironment,
@@ -25,12 +25,17 @@ from narada.environment import (
     CloudBrowserEnvironment,
     Environment,
     LambdaEnvironment,
+    Narada,
     RemoteBrowserEnvironment,
     SessionDownloadItem,
 )
 from narada.tracing import TraceSession, trace
 from narada.utils import download_file, render_html
 from narada.version import __version__
+
+Agent.PRODUCTIVITY = AgentKind.PRODUCTIVITY  # type: ignore[attr-defined]
+Agent.OPERATOR = AgentKind.OPERATOR  # type: ignore[attr-defined]
+Agent.CORE_AGENT = AgentKind.CORE_AGENT  # type: ignore[attr-defined]
 
 __all__ = [
     "__version__",
@@ -47,6 +52,8 @@ __all__ = [
     "Environment",
     "File",
     "LambdaEnvironment",
+    "LocalBrowserWindow",
+    "Narada",
     "NaradaError",
     "NaradaExtensionMissingError",
     "NaradaExtensionUnauthenticatedError",

--- a/packages/narada/src/narada/agent.py
+++ b/packages/narada/src/narada/agent.py
@@ -59,6 +59,7 @@ from pydantic import BaseModel
 
 from narada.environment import (
     BaseBrowserEnvironment,
+    BrowserEnvironment,
     Environment,
     InputRequiredCallback,
 )
@@ -593,6 +594,70 @@ class Agent(Generic[_StructuredOutput]):
         return await self._browser_environment()._run_extension_action(
             GetScreenshotRequest(),
             GetScreenshotResponse,
+            timeout=timeout,
+        )
+
+
+class LocalBrowserWindow(Agent[Any]):
+    """Backward-compatible browser-window helper for existing APA Python code."""
+
+    def __init__(self) -> None:
+        super().__init__(environment=BrowserEnvironment(), kind=AgentKind.OPERATOR)
+
+    async def agent(
+        self,
+        *,
+        prompt: str,
+        agent: AgentKind | str = AgentKind.OPERATOR,
+        reasoning: ReasoningEffort | None = None,
+        clear_chat: bool | None = None,
+        generate_gif: bool | None = None,
+        output_schema: type[BaseModel] | None = None,
+        previous_request_id: str | None = None,
+        chat_history: list[RemoteDispatchChatHistoryItem] | None = None,
+        additional_context: dict[str, str] | None = None,
+        attachment: File | IO[Any] | None = None,
+        time_zone: str = "America/Los_Angeles",
+        user_resource_credentials: UserResourceCredentials | None = None,
+        mcp_servers: list[McpServer] | None = None,
+        secret_variables: dict[str, str] | None = None,
+        input_variables: Mapping[str, Any] | None = None,
+        variables: Mapping[str, Any] | None = None,
+        callback_url: str | None = None,
+        callback_secret: str | None = None,
+        callback_headers: Mapping[str, Any] | None = None,
+        on_input_required: InputRequiredCallback | None = None,
+        critic: CriticConfig | None = None,
+        trace: bool = False,
+        timeout: int = 1000,
+    ) -> AgentResponse:
+        if variables is not None and input_variables is not None:
+            raise ValueError("Pass either `variables` or `input_variables`, not both.")
+
+        scoped_agent = Agent(environment=self.environment, kind=agent)
+        return await scoped_agent.run(
+            prompt,
+            reasoning=reasoning,
+            clear_chat=clear_chat,
+            generate_gif=generate_gif,
+            output_schema=output_schema,
+            previous_request_id=previous_request_id,
+            chat_history=chat_history,
+            additional_context=additional_context,
+            attachment=attachment,
+            time_zone=time_zone,
+            user_resource_credentials=user_resource_credentials,
+            mcp_servers=mcp_servers,
+            secret_variables=secret_variables,
+            input_variables=input_variables
+            if input_variables is not None
+            else variables,
+            callback_url=callback_url,
+            callback_secret=callback_secret,
+            callback_headers=callback_headers,
+            on_input_required=on_input_required,
+            critic=critic,
+            trace=trace,
             timeout=timeout,
         )
 

--- a/packages/narada/src/narada/browser_workbench.py
+++ b/packages/narada/src/narada/browser_workbench.py
@@ -18,6 +18,7 @@ from pathlib import Path
 from typing import Any
 from urllib.parse import urlsplit, urlunsplit
 
+import aiohttp
 from narada_core.actions.models import (
     BrowserActionResponse,
     BrowserClickNrdRequest,
@@ -36,7 +37,11 @@ from narada_core.actions.models import (
 )
 
 from narada.config import BrowserConfig
-from narada.environment import BrowserEnvironment, RemoteBrowserEnvironment
+from narada.environment import (
+    BrowserEnvironment,
+    CloudBrowserEnvironment,
+    RemoteBrowserEnvironment,
+)
 from narada.workbench import (
     _default_out_dir,
     _redact_sensitive_text,
@@ -476,8 +481,12 @@ def _remote_env(
     browser_window_id = record.get("browserWindowId")
     if not isinstance(browser_window_id, str) or not browser_window_id:
         raise ValueError("Browser environment record has no browserWindowId")
+    cloud_browser_session_id = record.get("cloudBrowserSessionId")
     return RemoteBrowserEnvironment(
         browser_window_id=browser_window_id,
+        cloud_browser_session_id=cloud_browser_session_id
+        if isinstance(cloud_browser_session_id, str)
+        else None,
         auth_headers=default_auth_headers(),
         base_url=base_url or record.get("apiBaseUrl") or default_api_base_url(),
     )
@@ -489,12 +498,49 @@ def _write_env(root: Path, env_id: str, record: dict[str, Any]) -> dict[str, Any
     return _artifact(root, path, "browser-environment", sensitive=False)
 
 
+def _env_command_ids(
+    env_id: str, record: dict[str, Any], extra: dict[str, Any] | None = None
+) -> dict[str, Any]:
+    ids = {
+        "envId": env_id,
+        "browserWindowId": record.get("browserWindowId"),
+    }
+    cloud_session_id = record.get("cloudBrowserSessionId")
+    if isinstance(cloud_session_id, str) and cloud_session_id:
+        ids["cloudBrowserSessionId"] = cloud_session_id
+    if extra:
+        ids.update(extra)
+    return ids
+
+
 def _write_env_lifecycle_snapshot(
     root: Path, env_id: str, status: str, record: dict[str, Any]
 ) -> dict[str, Any]:
     path = root / "browser" / "environments" / f"{_safe_slug(env_id)}-{status}.json"
     _write_json(path, record)
     return _artifact(root, path, "browser-environment", sensitive=False)
+
+
+def _append_cloud_session_lifecycle(
+    root: Path, record: dict[str, Any], row: dict[str, Any]
+) -> dict[str, Any] | None:
+    session_id = record.get("cloudBrowserSessionId")
+    if not isinstance(session_id, str) or not session_id:
+        return None
+    session_dir = root / "browser" / "cloud-sessions" / _safe_slug(session_id)
+    path = session_dir / "status.jsonl"
+    payload = {
+        "schemaVersion": 1,
+        "cloudBrowserSessionId": session_id,
+        "envId": record.get("id"),
+        **row,
+    }
+    _append_jsonl(path, payload)
+    event_path = session_dir / "events" / f"{uuid.uuid4().hex}.json"
+    _write_json(event_path, payload)
+    return _artifact(
+        root, event_path, "cloud-browser-session-lifecycle-event", sensitive=False
+    )
 
 
 def _snapshot_dir(root: Path, snapshot_id: str) -> Path:
@@ -646,6 +692,81 @@ def _decode_base64_content(value: str) -> bytes:
     return base64.b64decode(content, validate=False)
 
 
+async def _download_to_file(url: str, destination: Path) -> int:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    temp_destination = destination.with_suffix(f"{destination.suffix}.tmp")
+    byte_count = 0
+    async with aiohttp.ClientSession() as session:
+        async with session.get(url, timeout=aiohttp.ClientTimeout(total=60)) as resp:
+            resp.raise_for_status()
+            with temp_destination.open("wb") as output:
+                async for chunk in resp.content.iter_chunked(1024 * 1024):
+                    output.write(chunk)
+                    byte_count += len(chunk)
+    temp_destination.replace(destination)
+    return byte_count
+
+
+async def _materialize_cloud_browser_downloads(
+    *,
+    root: Path,
+    env_id: str,
+    record: dict[str, Any],
+    command_id: str,
+    env: RemoteBrowserEnvironment,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]], list[str]]:
+    downloads = await env.get_downloaded_files()
+    download_dir = root / "downloads" / command_id
+    artifacts: list[dict[str, Any]] = []
+    rows: list[dict[str, Any]] = []
+    warnings: list[str] = []
+    for index, item in enumerate(downloads):
+        destination = (
+            download_dir / f"{index:03d}-{_safe_slug(item.file_name or 'download')}"
+        )
+        try:
+            byte_size = await _download_to_file(item.download_url, destination)
+        except Exception as exc:
+            rows.append(
+                {
+                    "source": "cloud-browser-replay",
+                    "envId": env_id,
+                    "cloudBrowserSessionId": record.get("cloudBrowserSessionId"),
+                    "fileName": item.file_name,
+                    "sourceS3Key": item.source_key,
+                    "size": item.size,
+                    "downloadStatus": "failed",
+                    "error": _redact_sensitive_text(str(exc)),
+                    "redactedDownloadUrl": _redact_url(item.download_url),
+                }
+            )
+            warnings.append("cloud_download_fetch_failed")
+            continue
+        artifact = _artifact(root, destination, "cloud-browser-download")
+        artifact["sensitive"] = True
+        artifacts.append(artifact)
+        rows.append(
+            {
+                "source": "cloud-browser-replay",
+                "envId": env_id,
+                "cloudBrowserSessionId": record.get("cloudBrowserSessionId"),
+                "fileName": item.file_name,
+                "sourceS3Key": item.source_key,
+                "size": item.size,
+                "path": artifact["path"],
+                "sha256": artifact["sha256"],
+                "byteSize": byte_size,
+                "downloadStatus": "downloaded",
+                "redactedDownloadUrl": _redact_url(item.download_url),
+            }
+        )
+    if not downloads:
+        warnings.append("cloud_download_capture_empty")
+    elif not artifacts:
+        warnings.append("cloud_download_bytes_not_materialized")
+    return artifacts, rows, warnings
+
+
 async def env_open(
     *,
     name: str,
@@ -659,16 +780,37 @@ async def env_open(
     profile_directory: str | None = None,
     attach_to_existing: bool = False,
     browser_window_id: str | None = None,
+    cloud_browser_session_id: str | None = None,
+    session_name: str | None = None,
+    session_timeout: int | None = None,
+    dev_app_origin_override: str | None = None,
+    dev_extension_s3_bucket: str | None = None,
+    dev_extension_s3_key: str | None = None,
 ) -> BrowserWorkbenchCommandResult:
-    if kind != "local":
-        raise ValueError("M4 supports only --kind local")
+    if kind not in {"local", "cloud"}:
+        raise ValueError("M5 supports --kind local or --kind cloud")
+    if kind == "local" and cloud_browser_session_id is not None:
+        raise ValueError("--cloud-browser-session-id requires --kind cloud")
+    if kind == "local" and any(
+        (dev_app_origin_override, dev_extension_s3_bucket, dev_extension_s3_key)
+    ):
+        raise ValueError("Cloud Browser dev overrides require --kind cloud")
+    if bool(dev_extension_s3_bucket) != bool(dev_extension_s3_key):
+        raise ValueError(
+            "--dev-extension-s3-bucket and --dev-extension-s3-key must be provided together"
+        )
     root = _browser_root(proof_root, f"browser-env-{name}")
     if (root / "commands.jsonl").exists():
         _add_manifest_taint(root, "proof_root_preexisting")
     api_base_url = base_url or default_api_base_url()
     if browser_window_id is not None:
+        if kind == "cloud" and not cloud_browser_session_id:
+            raise ValueError(
+                "--kind cloud adoption requires --cloud-browser-session-id"
+            )
         remote = RemoteBrowserEnvironment(
             browser_window_id=browser_window_id,
+            cloud_browser_session_id=cloud_browser_session_id,
             auth_headers=default_auth_headers(),
             base_url=api_base_url,
         )
@@ -681,6 +823,7 @@ async def env_open(
             "kind": kind,
             "status": "open",
             "browserWindowId": browser_window_id,
+            "cloudBrowserSessionId": cloud_browser_session_id,
             "browserProcessId": None,
             "apiBaseUrl": api_base_url,
             "apiBaseUrlOrigin": _origin(api_base_url),
@@ -691,16 +834,85 @@ async def env_open(
             "extensionId": extension_id,
             "attachToExisting": True,
             "adoptedBrowserWindow": True,
+            "ownership": "adopted",
+            "sessionName": session_name,
+            "sessionTimeout": session_timeout,
             "verifiedCurrentUrl": current_url,
         }
         artifact = _write_env(root, name, record)
+        cloud_artifact = _append_cloud_session_lifecycle(
+            root,
+            record,
+            {
+                "status": "open",
+                "ownership": "adopted",
+                "event": "env.open",
+            },
+        )
+        artifacts = [artifact, *([cloud_artifact] if cloud_artifact else [])]
         return _finish_command(
             root,
             command="env.open",
             status="passed",
             payload={"environment": record},
-            artifacts=[artifact],
-            ids={"envId": name, "browserWindowId": browser_window_id},
+            artifacts=artifacts,
+            ids=_env_command_ids(name, record),
+            inputs={"kind": kind, "apiBaseUrlOrigin": record["apiBaseUrlOrigin"]},
+        )
+
+    if kind == "cloud":
+        env = CloudBrowserEnvironment(
+            auth_headers=default_auth_headers(),
+            base_url=api_base_url,
+            config=BrowserConfig(interactive=False),
+            session_name=session_name,
+            session_timeout=session_timeout,
+            dev_app_origin_override=dev_app_origin_override,
+            dev_extension_s3_bucket=dev_extension_s3_bucket,
+            dev_extension_s3_key=dev_extension_s3_key,
+        )
+        await env.start()
+        record = {
+            "schemaVersion": 1,
+            "id": name,
+            "kind": kind,
+            "status": "open",
+            "browserWindowId": env.browser_window_id,
+            "cloudBrowserSessionId": env.cloud_browser_session_id,
+            "browserProcessId": None,
+            "apiBaseUrl": api_base_url,
+            "apiBaseUrlOrigin": _origin(api_base_url),
+            "initializationUrlOrigin": _origin(
+                env._initialization_url or env._config.initialization_url
+            ),
+            "devAppOriginOverride": dev_app_origin_override,
+            "devExtensionS3Bucket": dev_extension_s3_bucket,
+            "devExtensionS3Key": dev_extension_s3_key,
+            "sessionName": session_name,
+            "sessionTimeout": session_timeout,
+            "ownership": "sdk-created",
+            "attachToExisting": False,
+            "adoptedBrowserWindow": False,
+        }
+        artifact = _write_env(root, name, record)
+        cloud_artifact = _append_cloud_session_lifecycle(
+            root,
+            record,
+            {
+                "status": "open",
+                "ownership": "sdk-created",
+                "event": "env.open",
+            },
+        )
+        await env._stop_playwright()
+        artifacts = [artifact, *([cloud_artifact] if cloud_artifact else [])]
+        return _finish_command(
+            root,
+            command="env.open",
+            status="passed",
+            payload={"environment": record},
+            artifacts=artifacts,
+            ids=_env_command_ids(name, record),
             inputs={"kind": kind, "apiBaseUrlOrigin": record["apiBaseUrlOrigin"]},
         )
 
@@ -750,7 +962,7 @@ async def env_open(
         status="passed",
         payload={"environment": record},
         artifacts=[artifact],
-        ids={"envId": name, "browserWindowId": env.browser_window_id},
+        ids=_env_command_ids(name, record),
         inputs={"kind": kind, "apiBaseUrlOrigin": record["apiBaseUrlOrigin"]},
     )
 
@@ -770,7 +982,12 @@ async def env_status(
         response = await env._run_extension_action(GetUrlRequest(), GetUrlResponse)
         url = response.url
     except Exception as exc:
-        warnings.append(_redact_sensitive_text(str(exc)))
+        message = str(exc)
+        warnings.append(
+            _redact_sensitive_text(
+                f"{type(exc).__name__}: {message if message else '<empty>'}"
+            )
+        )
     payload = {"environment": record, "currentUrl": url}
     return _finish_command(
         root,
@@ -778,7 +995,7 @@ async def env_status(
         status="passed" if url is not None else "needs_review",
         payload=payload,
         warnings=warnings,
-        ids={"envId": env_id, "browserWindowId": record.get("browserWindowId")},
+        ids=_env_command_ids(env_id, record),
     )
 
 
@@ -792,10 +1009,13 @@ async def env_close(
     root = _browser_root(proof_root, f"browser-env-{env_id}")
     record = _load_env(root, env_id)
     is_adopted = record.get("adoptedBrowserWindow") is True
+    is_cloud = isinstance(record.get("cloudBrowserSessionId"), str)
     is_sdk_created_local = (
-        record.get("ownership") == "sdk-created"
+        not is_cloud
+        and record.get("ownership") == "sdk-created"
         and record.get("attachToExisting") is not True
     )
+    ownership = record.get("ownership")
     warnings: list[str] = []
     if is_adopted and not close_adopted:
         record = {
@@ -803,7 +1023,11 @@ async def env_close(
             "status": "detached",
             "closeBehavior": "adopted_browser_not_closed",
         }
-        warnings.append("adopted_browser_not_closed")
+        warnings.append(
+            "adopted_cloud_browser_not_stopped"
+            if is_cloud
+            else "adopted_browser_not_closed"
+        )
     else:
         env = _remote_env(record, base_url=base_url)
         try:
@@ -842,6 +1066,16 @@ async def env_close(
     artifact = _write_env_lifecycle_snapshot(
         root, env_id, str(record["status"]), record
     )
+    cloud_artifact = _append_cloud_session_lifecycle(
+        root,
+        record,
+        {
+            "status": record["status"],
+            "ownership": ownership,
+            "event": "env.close",
+            "closeBehavior": record.get("closeBehavior"),
+        },
+    )
     _write_json(
         root / "cleanup" / "status.json",
         {
@@ -851,6 +1085,8 @@ async def env_close(
             "localBrowserProcessStatus": record.get("localBrowserProcessStatus"),
             "localBrowserProcessIdentity": record.get("localBrowserProcessIdentity"),
             "localBrowserCdpPortStatus": record.get("localBrowserCdpPortStatus"),
+            "cloudBrowserSessionId": record.get("cloudBrowserSessionId"),
+            "cloudBrowserOwnership": ownership,
             **(
                 {"error": record["closeError"]}
                 if record.get("closeError") is not None
@@ -858,14 +1094,15 @@ async def env_close(
             ),
         },
     )
+    artifacts = [artifact, *([cloud_artifact] if cloud_artifact else [])]
     return _finish_command(
         root,
         command="env.close",
         status="failed" if record["status"] == "close_failed" else "passed",
         payload={"environment": record},
-        artifacts=[artifact],
+        artifacts=artifacts,
         warnings=warnings,
-        ids={"envId": env_id, "browserWindowId": record.get("browserWindowId")},
+        ids=_env_command_ids(env_id, record),
     )
 
 
@@ -895,7 +1132,7 @@ async def browser_goto(
         command="browser.goto",
         status="passed",
         payload=action_row,
-        ids={"envId": env_id, "browserWindowId": record.get("browserWindowId")},
+        ids=_env_command_ids(env_id, record),
         inputs={"url": url},
     )
 
@@ -935,7 +1172,7 @@ async def browser_snapshot(
         },
         artifacts=artifacts,
         warnings=warnings,
-        ids={"envId": env_id, "snapshotId": snapshot.snapshot_id},
+        ids=_env_command_ids(env_id, record, {"snapshotId": snapshot.snapshot_id}),
     )
 
 
@@ -1083,12 +1320,15 @@ async def browser_nrd_action(
         payload=payload,
         artifacts=artifacts,
         warnings=warnings,
-        ids={
-            "envId": env_id,
-            "snapshotId": snapshot_id,
-            "dataNrd": data_nrd,
-            "postSnapshotId": payload.get("postSnapshotId"),
-        },
+        ids=_env_command_ids(
+            env_id,
+            record,
+            {
+                "snapshotId": snapshot_id,
+                "dataNrd": data_nrd,
+                "postSnapshotId": payload.get("postSnapshotId"),
+            },
+        ),
     )
 
 
@@ -1143,7 +1383,7 @@ async def browser_screenshot(
             status="needs_review",
             payload=row,
             warnings=["browser_screenshot_capture_failed"],
-            ids={"envId": env_id},
+            ids=_env_command_ids(env_id, record),
         )
     data = _decode_base64_content(screenshot.base64_content)
     path = root / "browser" / "screenshots" / f"{uuid.uuid4().hex}.png"
@@ -1164,7 +1404,7 @@ async def browser_screenshot(
         status="passed",
         payload=row,
         artifacts=[artifact],
-        ids={"envId": env_id},
+        ids=_env_command_ids(env_id, record),
     )
 
 
@@ -1177,13 +1417,44 @@ async def browser_downloads(
     root = _browser_root(proof_root, f"browser-{env_id}")
     record = _load_env(root, env_id)
     env = _remote_env(record, base_url=base_url)
+    command_id = f"cmd_{uuid.uuid4().hex}"
+    if record.get("cloudBrowserSessionId"):
+        (
+            download_artifacts,
+            downloaded_rows,
+            warnings,
+        ) = await _materialize_cloud_browser_downloads(
+            root=root,
+            env_id=env_id,
+            record=record,
+            command_id=command_id,
+            env=env,
+        )
+        row = {
+            "envId": env_id,
+            "source": "cloud-browser-replay",
+            "cloudBrowserSessionId": record.get("cloudBrowserSessionId"),
+            "downloads": downloaded_rows,
+            "captureSupported": True,
+        }
+        _append_jsonl(root / "downloads.jsonl", row)
+        return _finish_command(
+            root,
+            command="browser.downloads",
+            status="passed" if download_artifacts and not warnings else "needs_review",
+            payload=row,
+            artifacts=download_artifacts,
+            warnings=warnings,
+            command_id=command_id,
+            ids=_env_command_ids(env_id, record),
+        )
+
     started_after = _proof_root_started_after(root)
     response = await env._run_extension_action(
         BrowserDownloadsRequest(started_after=started_after),
         BrowserDownloadsResponse,
         timeout=30,
     )
-    command_id = f"cmd_{uuid.uuid4().hex}"
     download_artifacts: list[dict[str, Any]] = []
     sanitized_downloads: list[dict[str, Any]] = []
     download_dir = root / "downloads" / command_id
@@ -1255,5 +1526,5 @@ async def browser_downloads(
         artifacts=download_artifacts,
         warnings=warnings,
         command_id=command_id,
-        ids={"envId": env_id},
+        ids=_env_command_ids(env_id, record),
     )

--- a/packages/narada/src/narada/cli.py
+++ b/packages/narada/src/narada/cli.py
@@ -230,6 +230,12 @@ async def _env_open(args: argparse.Namespace) -> int:
         profile_directory=args.profile_directory,
         attach_to_existing=args.attach_to_existing,
         browser_window_id=args.browser_window_id,
+        cloud_browser_session_id=args.cloud_browser_session_id,
+        session_name=args.session_name,
+        session_timeout=args.session_timeout,
+        dev_app_origin_override=args.dev_app_origin_override,
+        dev_extension_s3_bucket=args.dev_extension_s3_bucket,
+        dev_extension_s3_key=args.dev_extension_s3_key,
     )
     _print({**result.payload, "commandId": result.command_id}, as_json=args.json)
     return 0 if result.status == "passed" else 1
@@ -398,6 +404,12 @@ def build_parser() -> argparse.ArgumentParser:
     env_open_parser.add_argument("--profile-directory")
     env_open_parser.add_argument("--attach-to-existing", action="store_true")
     env_open_parser.add_argument("--browser-window-id")
+    env_open_parser.add_argument("--cloud-browser-session-id")
+    env_open_parser.add_argument("--session-name")
+    env_open_parser.add_argument("--session-timeout", type=int)
+    env_open_parser.add_argument("--dev-app-origin-override")
+    env_open_parser.add_argument("--dev-extension-s3-bucket")
+    env_open_parser.add_argument("--dev-extension-s3-key")
     env_open_parser.add_argument("--json", action="store_true")
     env_open_parser.set_defaults(handler=lambda args: asyncio.run(_env_open(args)))
 

--- a/packages/narada/src/narada/environment.py
+++ b/packages/narada/src/narada/environment.py
@@ -172,6 +172,7 @@ class SessionDownloadItem:
     file_name: str
     size: int
     download_url: str
+    source_key: str | None = None
 
 
 @dataclass
@@ -1470,14 +1471,33 @@ class CloudBrowserEnvironment(BaseBrowserEnvironment):
         session_timeout: int | None = None,
         api_key: str | None = None,
         auth_headers: dict[str, str] | None = None,
+        base_url: str | None = None,
+        dev_app_origin_override: str | None = None,
+        dev_extension_s3_bucket: str | None = None,
+        dev_extension_s3_key: str | None = None,
     ) -> None:
         super().__init__(
             api_key=api_key,
             auth_headers=auth_headers,
+            base_url=base_url,
         )
         self._config = config or BrowserConfig()
         self._session_name = session_name
         self._session_timeout = session_timeout
+        dev_overrides = (
+            dev_app_origin_override,
+            dev_extension_s3_bucket,
+            dev_extension_s3_key,
+        )
+        if any(dev_overrides) and not all(dev_overrides):
+            raise ValueError(
+                "dev Cloud Browser overrides require app origin, extension S3 bucket, "
+                "and extension S3 key"
+            )
+        self._dev_app_origin_override = dev_app_origin_override
+        self._dev_extension_s3_bucket = dev_extension_s3_bucket
+        self._dev_extension_s3_key = dev_extension_s3_key
+        self._initialization_url: str | None = None
         self._session_id: str | None = None
         self._context: BrowserContext | None = None
         self._playwright_context_manager: PlaywrightContextManager | None = None
@@ -1505,8 +1525,8 @@ class CloudBrowserEnvironment(BaseBrowserEnvironment):
 
         Calls ``POST /cloud-browser/create-cloud-browser-session``, then connects local
         Playwright over CDP, opens ``login_url``, and waits for
-        ``#narada-browser-window-id`` (extension install retries apply). ``config`` controls
-        interactive prompts and related behavior.
+        ``#narada-browser-window-id`` (extension install/sign-in retries apply).
+        ``config`` controls interactive prompts and related behavior.
         """
         self._playwright_context_manager = async_playwright()
         self._playwright = await self._playwright_context_manager.__aenter__()
@@ -1516,7 +1536,26 @@ class CloudBrowserEnvironment(BaseBrowserEnvironment):
             "session_name": self._session_name,
             "session_timeout": self._session_timeout,
         }
-        endpoint_url = f"{self._base_url}/cloud-browser/create-cloud-browser-session"
+        has_dev_overrides = any(
+            (
+                self._dev_app_origin_override,
+                self._dev_extension_s3_bucket,
+                self._dev_extension_s3_key,
+            )
+        )
+        if has_dev_overrides:
+            request_body.update(
+                {
+                    "app_origin_override": self._dev_app_origin_override,
+                    "extension_s3_bucket": self._dev_extension_s3_bucket,
+                    "extension_s3_key": self._dev_extension_s3_key,
+                }
+            )
+        endpoint_url = (
+            f"{self._base_url}/cloud-browser/dev/create-cloud-browser-session"
+            if has_dev_overrides
+            else f"{self._base_url}/cloud-browser/create-cloud-browser-session"
+        )
 
         async with aiohttp.ClientSession() as session:
             async with session.post(
@@ -1548,8 +1587,8 @@ class CloudBrowserEnvironment(BaseBrowserEnvironment):
         session_id = response_data["session_id"]
         login_url = response_data["login_url"]
         cdp_auth_headers = response_data["cdp_auth_headers"]
+        self._initialization_url = login_url
 
-        # Connect to browser via CDP with authentication headers and log the user in.
         try:
             await self._initialize_cloud_browser_window(
                 cdp_websocket_url=cdp_websocket_url,
@@ -1558,7 +1597,6 @@ class CloudBrowserEnvironment(BaseBrowserEnvironment):
                 cdp_auth_headers=cdp_auth_headers,
             )
         except Exception:
-            # Clean up the session if CDP connection fails
             try:
                 async with aiohttp.ClientSession() as cleanup_session:
                     async with cleanup_session.post(
@@ -1582,7 +1620,6 @@ class CloudBrowserEnvironment(BaseBrowserEnvironment):
                 logging.warning(
                     "Error cleaning up session %s: %s", session_id, cleanup_error
                 )
-            # Re-raise the original connection error
             raise
 
     async def _stop_playwright(self) -> None:
@@ -1628,7 +1665,7 @@ class CloudBrowserEnvironment(BaseBrowserEnvironment):
     ) -> None:
         assert self._playwright is not None
 
-        # Connect to browser via CDP with authentication headers
+        # Connect to browser via CDP with authentication headers.
         browser = await self._playwright.chromium.connect_over_cdp(
             cdp_websocket_url, headers=cdp_auth_headers
         )
@@ -1656,6 +1693,14 @@ class CloudBrowserEnvironment(BaseBrowserEnvironment):
                     raise
                 logging.info("Waiting for Narada extension to be installed...")
                 await asyncio.sleep(1)
+            except NaradaExtensionUnauthenticatedError:
+                if attempt == max_attempts - 1:
+                    raise
+                logging.info("Waiting for Narada extension to sign in...")
+                await asyncio.sleep(1)
+                await initialization_page.goto(
+                    login_url, timeout=15_000, wait_until="domcontentloaded"
+                )
             except NaradaTimeoutError:
                 if attempt == max_attempts - 1:
                     raise
@@ -1667,10 +1712,89 @@ class CloudBrowserEnvironment(BaseBrowserEnvironment):
 
         self._browser_window_id = browser_window_id
         self._session_id = session_id
-        self._context = context
+
+        # The initialization page only proves that the extension is installed,
+        # signed in, and can report a browser window id. Browser workbench
+        # commands are handled by the side-panel app, so we must also prove that
+        # page is mounted before releasing local Playwright control.
+        side_panel_page = await self._find_or_reconnect_cloud_side_panel_page(
+            browser=browser,
+            cdp_websocket_url=cdp_websocket_url,
+            cdp_auth_headers=cdp_auth_headers,
+            browser_window_id=browser_window_id,
+        )
+        self._context = side_panel_page.context
 
         if self._config.interactive:
             self._print_success_message(browser_window_id)
+
+    @staticmethod
+    def _is_side_panel_page_url(url: str, *, browser_window_id: str) -> bool:
+        parsed_url = urlsplit(url)
+        if parsed_url.scheme != "chrome-extension":
+            return False
+        if parsed_url.path != "/sidepanel.html":
+            return False
+        query = dict(parse_qsl(parsed_url.query, keep_blank_values=True))
+        if "browserWindowId" not in query:
+            return True
+        return query.get("browserWindowId") == browser_window_id
+
+    async def _wait_for_cloud_side_panel_page(
+        self,
+        context: BrowserContext,
+        *,
+        browser_window_id: str,
+        timeout_ms: int,
+    ) -> Page:
+        deadline = time.monotonic() + timeout_ms / 1000
+        while time.monotonic() < deadline:
+            side_panel_page = next(
+                (
+                    page
+                    for page in context.pages
+                    if isinstance(page.url, str)
+                    if self._is_side_panel_page_url(
+                        page.url, browser_window_id=browser_window_id
+                    )
+                ),
+                None,
+            )
+            if side_panel_page is not None:
+                return side_panel_page
+            await asyncio.sleep(0.25)
+
+        visible_urls = [page.url for page in context.pages]
+        raise NaradaTimeoutError(
+            "Timed out waiting for Narada Cloud Browser side panel "
+            f"for browser window {browser_window_id!r}. Visible page URLs: {visible_urls!r}"
+        )
+
+    async def _find_or_reconnect_cloud_side_panel_page(
+        self,
+        *,
+        browser: Browser,
+        cdp_websocket_url: str,
+        cdp_auth_headers: dict[str, str],
+        browser_window_id: str,
+    ) -> Page:
+        context = browser.contexts[0]
+        try:
+            return await self._wait_for_cloud_side_panel_page(
+                context, browser_window_id=browser_window_id, timeout_ms=2_000
+            )
+        except NaradaTimeoutError:
+            # Mirrors the existing local-browser attach flow: Chrome side panels
+            # are not always visible to an already-established CDP connection.
+            await browser.close()
+
+        browser = await self._playwright.chromium.connect_over_cdp(
+            cdp_websocket_url, headers=cdp_auth_headers
+        )
+        context = browser.contexts[0]
+        return await self._wait_for_cloud_side_panel_page(
+            context, browser_window_id=browser_window_id, timeout_ms=15_000
+        )
 
     @override
     async def _close_impl(self, *, timeout: int | None = None) -> None:
@@ -1705,6 +1829,51 @@ class CloudBrowserEnvironment(BaseBrowserEnvironment):
             f"browser_window_id={self.browser_window_id}"
             ")"
         )
+
+
+class Narada(CloudBrowserEnvironment):
+    """Backward-compatible SDK facade.
+
+    New CPython code should prefer explicit environment classes such as
+    ``BrowserEnvironment`` and ``CloudBrowserEnvironment``. Some existing
+    integrations still use ``async with Narada(...)`` as a lightweight client
+    wrapper around the SDK browser initialization helpers. Entering the context
+    prepares local Playwright only; it intentionally does not create a cloud
+    session because those callers may own session lifecycle themselves.
+    """
+
+    async def __aenter__(self) -> Narada:
+        if self._playwright_context_manager is None:
+            self._playwright_context_manager = async_playwright()
+            self._playwright = await self._playwright_context_manager.__aenter__()
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: object | None,
+    ) -> None:
+        await self._stop_playwright()
+
+    async def _initialize_cloud_browser_window(
+        self,
+        *,
+        config: BrowserConfig | None = None,
+        cdp_websocket_url: str,
+        session_id: str,
+        login_url: str,
+        cdp_auth_headers: dict[str, str],
+    ) -> Narada:
+        if config is not None:
+            self._config = config
+        await super()._initialize_cloud_browser_window(
+            cdp_websocket_url=cdp_websocket_url,
+            session_id=session_id,
+            login_url=login_url,
+            cdp_auth_headers=cdp_auth_headers,
+        )
+        return self
 
 
 class LambdaEnvironment(Environment):
@@ -1859,6 +2028,7 @@ async def _get_cloud_browser_downloads(
             file_name=item["file_name"],
             size=item["size"],
             download_url=presigned_urls[i],
+            source_key=item.get("key"),
         )
         for i, item in enumerate(files)
     ]
@@ -1871,25 +2041,19 @@ async def _stop_cloud_browser_session(
     session_id: str,
     timeout: int | None = None,
 ) -> None:
-    try:
-        async with aiohttp.ClientSession() as session:
-            async with session.post(
-                f"{base_url}/cloud-browser/stop-cloud-browser-session",
-                headers=auth_headers,
-                json={"session_id": session_id},
-                timeout=aiohttp.ClientTimeout(total=timeout or 40),
-            ) as resp:
-                if resp.ok:
-                    response_data = await resp.json()
-                    if not response_data.get("success"):
-                        logger.warning(
-                            "Failed to stop session: %s",
-                            response_data.get("message"),
-                        )
-                else:
-                    logger.warning("Failed to stop session: %s", resp.status)
-    except Exception as e:
-        logger.warning("Error calling stop session endpoint: %s", e)
+    async with aiohttp.ClientSession() as session:
+        async with session.post(
+            f"{base_url}/cloud-browser/stop-cloud-browser-session",
+            headers=auth_headers,
+            json={"session_id": session_id},
+            timeout=aiohttp.ClientTimeout(total=timeout or 40),
+        ) as resp:
+            if not resp.ok:
+                raise RuntimeError(f"Failed to stop session: HTTP {resp.status}")
+            response_data = await resp.json()
+            if not response_data.get("success"):
+                message = response_data.get("message") or "unknown error"
+                raise RuntimeError(f"Failed to stop session: {message}")
 
 
 def create_side_panel_url(config: BrowserConfig, browser_window_id: str) -> str:

--- a/packages/narada/src/narada/workbench.py
+++ b/packages/narada/src/narada/workbench.py
@@ -796,6 +796,7 @@ def score_proof_root(proof_root: str | Path, *, write: bool = True) -> dict[str,
     failures: list[dict[str, Any]] = []
     taints: list[dict[str, Any]] = []
     warnings: list[dict[str, Any]] = []
+    needs_review = False
 
     manifest_path = root / "manifest.json"
     manifest_kind = "trace"
@@ -1071,6 +1072,17 @@ def score_proof_root(proof_root: str | Path, *, write: bool = True) -> dict[str,
                 }
             )
     browser_artifact_rows: list[dict[str, Any]] = []
+    browser_evidence_roles = {
+        "browser-download",
+        "browser-screenshot",
+        "browser-snapshot-elements",
+        "browser-snapshot-frames",
+        "browser-snapshot-html",
+        "browser-snapshot-summary",
+        "browser-snapshot-visible-text",
+        "cloud-browser-download",
+    }
+    materialized_browser_evidence_count = 0
     if browser_index_path.exists():
         browser_artifact_rows = _load_jsonl(browser_index_path)
         for row in browser_artifact_rows:
@@ -1102,6 +1114,11 @@ def score_proof_root(proof_root: str | Path, *, write: bool = True) -> dict[str,
                         "path": local_path_value,
                     }
                 )
+            if row.get("role") in browser_evidence_roles:
+                materialized_browser_evidence_count += 1
+    if is_browser_workbench_root and materialized_browser_evidence_count == 0:
+        needs_review = True
+        warnings.append({"code": "browser_workbench_no_materialized_evidence"})
 
     redaction_report = _write_redaction_report(root) if write else _scan_redaction(root)
     for finding in redaction_report["findings"]:
@@ -1123,7 +1140,6 @@ def score_proof_root(proof_root: str | Path, *, write: bool = True) -> dict[str,
     commands_path = root / "commands.jsonl"
     if commands_path.exists():
         command_rows = _load_jsonl(commands_path)
-        needs_review = False
         if not command_rows:
             failures.append({"code": "empty_command_ledger"})
         materialize_commands = [
@@ -1328,9 +1344,6 @@ def score_proof_root(proof_root: str | Path, *, write: bool = True) -> dict[str,
                                 "path": relative_path,
                             }
                         )
-    else:
-        needs_review = False
-
     cleanup_path = root / "cleanup" / "status.json"
     if cleanup_path.exists():
         cleanup = _load_json(cleanup_path)

--- a/packages/narada/tests/test_browser_workbench.py
+++ b/packages/narada/tests/test_browser_workbench.py
@@ -19,6 +19,7 @@ from narada.browser_workbench import (
     env_open,
 )
 from narada.cli import main
+from narada.environment import SessionDownloadItem
 from narada.workbench import score_proof_root, verify_proof_root
 from narada_core.actions.models import (
     BrowserActionResponse,
@@ -98,12 +99,16 @@ def _write_env_record(
 
 class _FakeRemoteEnvironment:
     calls: list[Any] = []
+    instances: list["_FakeRemoteEnvironment"] = []
     fail_screenshot: bool = False
+    fail_close: bool = False
     download_path: Path | None = None
     stale_download_path: Path | None = None
+    cloud_downloads: list[SessionDownloadItem] = []
 
     def __init__(self, **kwargs: Any) -> None:
         self.kwargs = kwargs
+        self.__class__.instances.append(self)
 
     async def _run_extension_action(
         self, request: Any, response_model: Any = None, **kwargs: Any
@@ -172,6 +177,14 @@ class _FakeRemoteEnvironment:
     async def close(self, *, timeout: int | None = None) -> None:
         del timeout
         self.__class__.calls.append("close")
+        if self.__class__.fail_close:
+            raise RuntimeError(
+                "stop failed with signed URL https://example.test/?X-Amz-Signature=secret"
+            )
+
+    async def get_downloaded_files(self) -> list[SessionDownloadItem]:
+        self.__class__.calls.append("get_downloaded_files")
+        return self.__class__.cloud_downloads
 
 
 class _FakeLocalEnvironment:
@@ -190,12 +203,41 @@ class _FakeLocalEnvironment:
         return None
 
 
+class _FakeCloudEnvironment:
+    instances: list["_FakeCloudEnvironment"] = []
+
+    def __init__(self, **kwargs: Any) -> None:
+        self.kwargs = kwargs
+        self.browser_window_id = "cloud-window-1"
+        self._session_id = "cloud-session-1"
+        self._config = kwargs["config"]
+        self._initialization_url = (
+            kwargs.get("dev_app_origin_override") or "https://dev-app.narada.ai"
+        ) + "/initialize?customToken=test"
+        self.stopped_playwright = False
+        self.__class__.instances.append(self)
+
+    @property
+    def cloud_browser_session_id(self) -> str:
+        return self._session_id
+
+    async def start(self) -> None:
+        return None
+
+    async def _stop_playwright(self) -> None:
+        self.stopped_playwright = True
+
+
 @pytest.fixture(autouse=True)
 def reset_fake_remote_environment() -> None:
     _FakeRemoteEnvironment.calls = []
+    _FakeRemoteEnvironment.instances = []
     _FakeRemoteEnvironment.download_path = None
     _FakeRemoteEnvironment.stale_download_path = None
+    _FakeRemoteEnvironment.cloud_downloads = []
+    _FakeRemoteEnvironment.fail_close = False
     _FakeLocalEnvironment.instances = []
+    _FakeCloudEnvironment.instances = []
 
 
 @pytest.mark.asyncio
@@ -349,6 +391,221 @@ async def test_browser_downloads_filters_stale_profile_downloads(
 
 
 @pytest.mark.asyncio
+async def test_browser_downloads_materializes_cloud_replay_bytes(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(
+        browser_module, "RemoteBrowserEnvironment", _FakeRemoteEnvironment
+    )
+
+    async def fake_download_to_file(url: str, destination: Path) -> int:
+        assert url == "https://signed.example/download.txt?X-Amz-Signature=secret"
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_bytes(b"cloud download bytes")
+        return len(b"cloud download bytes")
+
+    monkeypatch.setattr(browser_module, "_download_to_file", fake_download_to_file)
+    proof_root = tmp_path / "proof"
+    _write_env_record(
+        proof_root,
+        env_id="cloud-dev",
+        browser_window_id="cloud-window-1",
+        extra={
+            "kind": "cloud",
+            "cloudBrowserSessionId": "cloud-session-1",
+            "ownership": "sdk-created",
+        },
+    )
+    _FakeRemoteEnvironment.cloud_downloads = [
+        SessionDownloadItem(
+            file_name="cloud-download.txt",
+            size=20,
+            download_url="https://signed.example/download.txt?X-Amz-Signature=secret",
+            source_key="cloud-browser/session/download.txt",
+        )
+    ]
+
+    result = await browser_downloads(env_id="cloud-dev", proof_root=proof_root)
+
+    assert result.status == "passed"
+    download = result.payload["downloads"][0]
+    assert download["source"] == "cloud-browser-replay"
+    assert download["sourceS3Key"] == "cloud-browser/session/download.txt"
+    assert download["redactedDownloadUrl"] == "https://signed.example/download.txt"
+    assert (proof_root / download["path"]).read_bytes() == b"cloud download bytes"
+    assert download["sha256"] == hashlib.sha256(b"cloud download bytes").hexdigest()
+    root_text = "\n".join(
+        path.read_text(encoding="utf-8", errors="ignore")
+        for path in proof_root.rglob("*")
+        if path.is_file() and path.suffix not in {".png"}
+    )
+    assert "X-Amz-Signature=secret" not in root_text
+    assert score_proof_root(proof_root)["status"] == "passed"
+    assert verify_proof_root(proof_root)["verified"] is True
+
+
+@pytest.mark.asyncio
+async def test_browser_downloads_cloud_without_materialized_bytes_needs_review(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(
+        browser_module, "RemoteBrowserEnvironment", _FakeRemoteEnvironment
+    )
+
+    async def fake_download_to_file(url: str, destination: Path) -> int:
+        del url
+        del destination
+        raise RuntimeError("signed URL expired")
+
+    monkeypatch.setattr(browser_module, "_download_to_file", fake_download_to_file)
+    proof_root = tmp_path / "proof"
+    _write_env_record(
+        proof_root,
+        env_id="cloud-dev",
+        browser_window_id="cloud-window-1",
+        extra={
+            "kind": "cloud",
+            "cloudBrowserSessionId": "cloud-session-1",
+            "ownership": "sdk-created",
+        },
+    )
+    _FakeRemoteEnvironment.cloud_downloads = [
+        SessionDownloadItem(
+            file_name="cloud-download.txt",
+            size=20,
+            download_url="https://signed.example/download.txt?X-Amz-Signature=secret",
+            source_key="cloud-browser/session/download.txt",
+        )
+    ]
+
+    result = await browser_downloads(env_id="cloud-dev", proof_root=proof_root)
+
+    assert result.status == "needs_review"
+    assert result.payload["downloads"][0]["downloadStatus"] == "failed"
+    assert "X-Amz-Signature=secret" not in json.dumps(result.payload)
+    score = score_proof_root(proof_root)
+    assert score["status"] == "needs_review"
+    assert any(
+        warning.get("command") == "browser.downloads"
+        and warning.get("warning") == "cloud_download_fetch_failed"
+        for warning in score["warnings"]
+    )
+
+
+@pytest.mark.asyncio
+async def test_browser_downloads_cloud_partial_materialization_needs_review(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(
+        browser_module, "RemoteBrowserEnvironment", _FakeRemoteEnvironment
+    )
+
+    async def fake_download_to_file(url: str, destination: Path) -> int:
+        if "missing" in url:
+            raise RuntimeError("signed URL expired")
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_bytes(b"cloud download bytes")
+        return len(b"cloud download bytes")
+
+    monkeypatch.setattr(browser_module, "_download_to_file", fake_download_to_file)
+    proof_root = tmp_path / "proof"
+    _write_env_record(
+        proof_root,
+        env_id="cloud-dev",
+        browser_window_id="cloud-window-1",
+        extra={
+            "kind": "cloud",
+            "cloudBrowserSessionId": "cloud-session-1",
+            "ownership": "sdk-created",
+        },
+    )
+    _FakeRemoteEnvironment.cloud_downloads = [
+        SessionDownloadItem(
+            file_name="cloud-download.txt",
+            size=20,
+            download_url="https://signed.example/download.txt?X-Amz-Signature=secret",
+            source_key="cloud-browser/session/download.txt",
+        ),
+        SessionDownloadItem(
+            file_name="missing.txt",
+            size=20,
+            download_url="https://signed.example/missing.txt?X-Amz-Signature=secret",
+            source_key="cloud-browser/session/missing.txt",
+        ),
+    ]
+
+    result = await browser_downloads(env_id="cloud-dev", proof_root=proof_root)
+
+    assert result.status == "needs_review"
+    assert [row["downloadStatus"] for row in result.payload["downloads"]] == [
+        "downloaded",
+        "failed",
+    ]
+    score = score_proof_root(proof_root)
+    assert score["status"] == "needs_review"
+
+
+@pytest.mark.asyncio
+async def test_browser_downloads_cloud_duplicate_names_do_not_overwrite(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(
+        browser_module, "RemoteBrowserEnvironment", _FakeRemoteEnvironment
+    )
+
+    async def fake_download_to_file(url: str, destination: Path) -> int:
+        content = url.encode("utf-8")
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_bytes(content)
+        return len(content)
+
+    monkeypatch.setattr(browser_module, "_download_to_file", fake_download_to_file)
+    proof_root = tmp_path / "proof"
+    _write_env_record(
+        proof_root,
+        env_id="cloud-dev",
+        browser_window_id="cloud-window-1",
+        extra={
+            "kind": "cloud",
+            "cloudBrowserSessionId": "cloud-session-1",
+            "ownership": "sdk-created",
+        },
+    )
+    _FakeRemoteEnvironment.cloud_downloads = [
+        SessionDownloadItem(
+            file_name="duplicate.txt",
+            size=20,
+            download_url="https://signed.example/one.txt",
+            source_key="cloud-browser/session/one.txt",
+        ),
+        SessionDownloadItem(
+            file_name="duplicate.txt",
+            size=20,
+            download_url="https://signed.example/two.txt",
+            source_key="cloud-browser/session/two.txt",
+        ),
+    ]
+
+    result = await browser_downloads(env_id="cloud-dev", proof_root=proof_root)
+
+    assert result.status == "passed"
+    paths = [row["path"] for row in result.payload["downloads"]]
+    assert paths[0].endswith("/000-duplicate.txt")
+    assert paths[1].endswith("/001-duplicate.txt")
+    assert paths[0] != paths[1]
+    assert (proof_root / paths[0]).read_text(encoding="utf-8") == (
+        "https://signed.example/one.txt"
+    )
+    assert (proof_root / paths[1]).read_text(encoding="utf-8") == (
+        "https://signed.example/two.txt"
+    )
+
+
+@pytest.mark.asyncio
 async def test_env_open_and_close_write_cleanup_status(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -385,8 +642,13 @@ async def test_env_open_and_close_write_cleanup_status(
     assert cleanup["localBrowserProcessStatus"] == "already_exited"
     assert cleanup["localBrowserCdpPortStatus"] == "closed"
     assert (tmp_path / "browser" / "environments" / "dev-closed.json").exists()
-    assert score_proof_root(tmp_path)["status"] == "passed"
-    assert verify_proof_root(tmp_path)["verified"] is True
+    score = score_proof_root(tmp_path)
+    assert score["status"] == "needs_review"
+    assert any(
+        warning["code"] == "browser_workbench_no_materialized_evidence"
+        for warning in score["warnings"]
+    )
+    assert verify_proof_root(tmp_path)["verified"] is False
 
 
 @pytest.mark.asyncio
@@ -413,6 +675,187 @@ async def test_env_open_can_adopt_existing_browser_window_id(
         "https://fixture.test/current"
     )
     assert _FakeLocalEnvironment.instances == []
+
+
+@pytest.mark.asyncio
+async def test_env_open_can_create_cloud_browser_environment(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(
+        browser_module, "CloudBrowserEnvironment", _FakeCloudEnvironment
+    )
+
+    opened = await env_open(
+        name="cloud-dev",
+        kind="cloud",
+        proof_root=tmp_path,
+        base_url="https://api.test/fast/v2",
+        session_name="m5-cloud-test",
+        session_timeout=900,
+    )
+
+    record = opened.payload["environment"]
+    assert record["kind"] == "cloud"
+    assert record["ownership"] == "sdk-created"
+    assert record["browserWindowId"] == "cloud-window-1"
+    assert record["cloudBrowserSessionId"] == "cloud-session-1"
+    assert record["sessionName"] == "m5-cloud-test"
+    assert record["sessionTimeout"] == 900
+    assert _FakeCloudEnvironment.instances[0].kwargs["base_url"] == (
+        "https://api.test/fast/v2"
+    )
+    assert record["initializationUrlOrigin"] == "https://dev-app.narada.ai"
+    assert _FakeCloudEnvironment.instances[0].stopped_playwright is True
+    lifecycle = (
+        tmp_path / "browser" / "cloud-sessions" / "cloud-session-1" / "status.jsonl"
+    )
+    assert lifecycle.exists()
+    assert (
+        json.loads(lifecycle.read_text(encoding="utf-8").splitlines()[0])["ownership"]
+        == "sdk-created"
+    )
+    score = score_proof_root(tmp_path)
+    assert score["status"] == "needs_review"
+    assert any(
+        warning["code"] == "cleanup_status_not_terminal"
+        for warning in score["warnings"]
+    )
+
+
+@pytest.mark.asyncio
+async def test_cloud_env_open_then_close_keeps_lifecycle_artifacts_immutable(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(
+        browser_module, "CloudBrowserEnvironment", _FakeCloudEnvironment
+    )
+    monkeypatch.setattr(
+        browser_module, "RemoteBrowserEnvironment", _FakeRemoteEnvironment
+    )
+
+    await env_open(name="cloud-dev", kind="cloud", proof_root=tmp_path)
+    await env_close(env_id="cloud-dev", proof_root=tmp_path)
+
+    lifecycle = (
+        tmp_path / "browser" / "cloud-sessions" / "cloud-session-1" / "status.jsonl"
+    )
+    event_files = sorted(
+        (tmp_path / "browser" / "cloud-sessions" / "cloud-session-1" / "events").glob(
+            "*.json"
+        )
+    )
+    assert [
+        json.loads(line)["event"] for line in lifecycle.read_text().splitlines()
+    ] == [
+        "env.open",
+        "env.close",
+    ]
+    assert len(event_files) == 2
+    score = score_proof_root(tmp_path)
+    assert score["status"] == "needs_review"
+    assert any(
+        warning["code"] == "browser_workbench_no_materialized_evidence"
+        for warning in score["warnings"]
+    )
+    assert verify_proof_root(tmp_path)["verified"] is False
+
+
+@pytest.mark.asyncio
+async def test_env_open_cloud_forwards_dev_branch_overrides(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(
+        browser_module, "CloudBrowserEnvironment", _FakeCloudEnvironment
+    )
+
+    opened = await env_open(
+        name="cloud-dev",
+        kind="cloud",
+        proof_root=tmp_path,
+        base_url="https://api.test/fast/v2",
+        dev_app_origin_override="https://branch.example.test",
+        dev_extension_s3_bucket="narada-chrome-extension-test-builds",
+        dev_extension_s3_key="proof/m5-extension.zip",
+    )
+
+    record = opened.payload["environment"]
+    instance = _FakeCloudEnvironment.instances[0]
+    assert instance.kwargs["dev_app_origin_override"] == "https://branch.example.test"
+    assert (
+        instance.kwargs["dev_extension_s3_bucket"]
+        == "narada-chrome-extension-test-builds"
+    )
+    assert instance.kwargs["dev_extension_s3_key"] == "proof/m5-extension.zip"
+    assert record["initializationUrlOrigin"] == "https://branch.example.test"
+    assert record["devAppOriginOverride"] == "https://branch.example.test"
+    assert record["devExtensionS3Bucket"] == "narada-chrome-extension-test-builds"
+    assert record["devExtensionS3Key"] == "proof/m5-extension.zip"
+
+
+@pytest.mark.asyncio
+async def test_env_open_dev_cloud_overrides_require_cloud_kind(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="dev overrides require --kind cloud"):
+        await env_open(
+            name="dev",
+            kind="local",
+            proof_root=tmp_path,
+            dev_app_origin_override="https://branch.example.test",
+        )
+
+
+@pytest.mark.asyncio
+async def test_env_open_dev_extension_override_requires_bucket_and_key(
+    tmp_path: Path,
+) -> None:
+    with pytest.raises(ValueError, match="must be provided together"):
+        await env_open(
+            name="cloud-dev",
+            kind="cloud",
+            proof_root=tmp_path,
+            dev_extension_s3_bucket="narada-chrome-extension-test-builds",
+        )
+
+
+@pytest.mark.asyncio
+async def test_env_open_can_adopt_cloud_browser_session(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(
+        browser_module, "RemoteBrowserEnvironment", _FakeRemoteEnvironment
+    )
+
+    opened = await env_open(
+        name="cloud-dev",
+        kind="cloud",
+        proof_root=tmp_path,
+        browser_window_id="cloud-window-adopted",
+        cloud_browser_session_id="cloud-session-adopted",
+        base_url="https://api.test/fast/v2",
+    )
+
+    record = opened.payload["environment"]
+    assert record["kind"] == "cloud"
+    assert record["ownership"] == "adopted"
+    assert record["browserWindowId"] == "cloud-window-adopted"
+    assert record["cloudBrowserSessionId"] == "cloud-session-adopted"
+    assert _FakeRemoteEnvironment.instances[0].kwargs["cloud_browser_session_id"] == (
+        "cloud-session-adopted"
+    )
+
+
+@pytest.mark.asyncio
+async def test_env_open_cloud_adoption_requires_session_id(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="cloud adoption requires"):
+        await env_open(
+            name="cloud-dev",
+            kind="cloud",
+            proof_root=tmp_path,
+            browser_window_id="cloud-window-adopted",
+        )
 
 
 @pytest.mark.asyncio
@@ -660,6 +1103,125 @@ async def test_env_close_fails_if_sdk_created_local_cdp_port_stays_open(
     assert any(taint["code"] == "cleanup_failed" for taint in score["taints"])
 
 
+@pytest.mark.asyncio
+async def test_env_close_stops_sdk_created_cloud_session(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(
+        browser_module, "RemoteBrowserEnvironment", _FakeRemoteEnvironment
+    )
+    _write_env_record(
+        tmp_path,
+        env_id="cloud-dev",
+        browser_window_id="cloud-window-1",
+        extra={
+            "kind": "cloud",
+            "cloudBrowserSessionId": "cloud-session-1",
+            "ownership": "sdk-created",
+        },
+    )
+
+    closed = await env_close(env_id="cloud-dev", proof_root=tmp_path)
+
+    assert closed.status == "passed"
+    assert closed.payload["environment"]["status"] == "closed"
+    assert "close" in _FakeRemoteEnvironment.calls
+    cleanup = json.loads((tmp_path / "cleanup" / "status.json").read_text())
+    assert cleanup["cloudBrowserSessionId"] == "cloud-session-1"
+    assert cleanup["cloudBrowserOwnership"] == "sdk-created"
+    lifecycle = (
+        tmp_path / "browser" / "cloud-sessions" / "cloud-session-1" / "status.jsonl"
+    )
+    assert any(
+        json.loads(line)["status"] == "closed"
+        for line in lifecycle.read_text(encoding="utf-8").splitlines()
+    )
+    score = score_proof_root(tmp_path)
+    assert score["status"] == "needs_review"
+    assert any(
+        warning["code"] == "browser_workbench_no_materialized_evidence"
+        for warning in score["warnings"]
+    )
+    assert verify_proof_root(tmp_path)["verified"] is False
+
+
+@pytest.mark.asyncio
+async def test_env_close_failure_records_failed_cleanup(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(
+        browser_module, "RemoteBrowserEnvironment", _FakeRemoteEnvironment
+    )
+    _FakeRemoteEnvironment.fail_close = True
+    _write_env_record(
+        tmp_path,
+        env_id="cloud-dev",
+        browser_window_id="cloud-window-1",
+        extra={
+            "kind": "cloud",
+            "cloudBrowserSessionId": "cloud-session-1",
+            "ownership": "sdk-created",
+        },
+    )
+
+    closed = await env_close(env_id="cloud-dev", proof_root=tmp_path)
+
+    assert closed.status == "failed"
+    assert closed.payload["environment"]["status"] == "close_failed"
+    cleanup = json.loads((tmp_path / "cleanup" / "status.json").read_text())
+    assert cleanup["status"] == "failed"
+    assert "X-Amz-Signature=secret" not in cleanup["error"]
+    score = score_proof_root(tmp_path)
+    assert score["status"] == "tainted"
+    assert any(taint["code"] == "cleanup_failed" for taint in score["taints"])
+
+
+@pytest.mark.asyncio
+async def test_env_close_detaches_adopted_cloud_session_by_default(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(
+        browser_module, "RemoteBrowserEnvironment", _FakeRemoteEnvironment
+    )
+    _write_env_record(
+        tmp_path,
+        env_id="cloud-dev",
+        browser_window_id="cloud-window-adopted",
+        extra={
+            "kind": "cloud",
+            "cloudBrowserSessionId": "cloud-session-adopted",
+            "ownership": "adopted",
+            "adoptedBrowserWindow": True,
+        },
+    )
+
+    closed = await env_close(env_id="cloud-dev", proof_root=tmp_path)
+
+    assert closed.status == "passed"
+    assert closed.payload["environment"]["status"] == "detached"
+    assert "close" not in _FakeRemoteEnvironment.calls
+    command_rows = [
+        json.loads(line)
+        for line in (tmp_path / "commands.jsonl")
+        .read_text(encoding="utf-8")
+        .splitlines()
+    ]
+    assert any(
+        row.get("command") == "env.close"
+        and "adopted_cloud_browser_not_stopped" in row.get("warnings", [])
+        for row in command_rows
+    )
+    score = score_proof_root(tmp_path)
+    assert score["status"] == "needs_review"
+    assert any(
+        warning["code"] == "browser_workbench_no_materialized_evidence"
+        for warning in score["warnings"]
+    )
+
+
 def test_cli_browser_find_requires_proof_root() -> None:
     with pytest.raises(SystemExit) as exc_info:
         main(["workbench", "browser", "find", "dev", "--snapshot-id", "snap"])
@@ -892,6 +1454,30 @@ async def test_browser_workbench_open_cleanup_status_is_review_gated(
 
 
 @pytest.mark.asyncio
+async def test_browser_workbench_metadata_only_root_cannot_verify_clean(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(browser_module, "BrowserEnvironment", _FakeLocalEnvironment)
+    monkeypatch.setattr(
+        browser_module, "RemoteBrowserEnvironment", _FakeRemoteEnvironment
+    )
+
+    await env_open(name="dev", kind="local", proof_root=tmp_path)
+    await env_close(env_id="dev", proof_root=tmp_path)
+
+    score = score_proof_root(tmp_path)
+    verified = verify_proof_root(tmp_path)
+
+    assert score["status"] == "needs_review"
+    assert verified["verified"] is False
+    assert any(
+        warning["code"] == "browser_workbench_no_materialized_evidence"
+        for warning in score["warnings"]
+    )
+
+
+@pytest.mark.asyncio
 async def test_browser_workbench_score_verify_do_not_amplify_warning_codes(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -905,6 +1491,7 @@ async def test_browser_workbench_score_verify_do_not_amplify_warning_codes(
     record["adoptedBrowserWindow"] = True
     env_path.write_text(json.dumps(record), encoding="utf-8")
 
+    await browser_snapshot(env_id="dev", proof_root=tmp_path)
     await env_close(env_id="dev", proof_root=tmp_path)
     browser_module.append_command(
         tmp_path,

--- a/packages/narada/tests/test_client.py
+++ b/packages/narada/tests/test_client.py
@@ -125,8 +125,19 @@ async def test_cloud_browser_initialization_uses_domcontentloaded_navigation(
     async def wait_for_browser_window_id(*args: object, **kwargs: object) -> str:
         return "window-123"
 
+    async def wait_for_cloud_side_panel_page(
+        *args: object, **kwargs: object
+    ) -> _FakePage:
+        side_panel_page = _FakePage()
+        side_panel_page.url = "chrome-extension://dev-extension/sidepanel.html"
+        side_panel_page.context = _FakeContext(side_panel_page)
+        return side_panel_page
+
     monkeypatch.setattr(
         env, "_wait_for_cloud_browser_window_id", wait_for_browser_window_id
+    )
+    monkeypatch.setattr(
+        env, "_wait_for_cloud_side_panel_page", wait_for_cloud_side_panel_page
     )
 
     await env._initialize_cloud_browser_window(

--- a/packages/narada/tests/test_cloud_browser.py
+++ b/packages/narada/tests/test_cloud_browser.py
@@ -7,10 +7,13 @@ from narada import (
     Agent,
     CloudBrowserEnvironment,
     LambdaEnvironment,
+    LocalBrowserWindow,
+    Narada,
     RemoteBrowserEnvironment,
 )
 from narada.config import BrowserConfig
-from narada_core.errors import NaradaTimeoutError
+from narada_core.errors import NaradaExtensionUnauthenticatedError, NaradaTimeoutError
+from narada_core.models import AgentKind
 
 
 class _FakeResponse:
@@ -75,16 +78,132 @@ class _RemoteDispatchFakeClientSession:
         raise AssertionError(f"Unexpected GET URL: {url}")
 
 
-def _build_cloud_environment_with_page(page: AsyncMock) -> CloudBrowserEnvironment:
+class _FakePlaywrightContextManager:
+    def __init__(self) -> None:
+        self.entered = False
+        self.exited = False
+
+    async def __aenter__(self):
+        self.entered = True
+        return SimpleNamespace()
+
+    async def __aexit__(self, *args):
+        self.exited = True
+        return None
+
+
+def _build_cloud_environment_with_page(
+    page: AsyncMock, *, browser_window_id: str = "browser-window-123"
+) -> CloudBrowserEnvironment:
     env = CloudBrowserEnvironment(
         auth_headers={"x-api-key": "test-key"},
         config=BrowserConfig(interactive=False),
     )
-    browser = SimpleNamespace(contexts=[SimpleNamespace(pages=[page])])
+    side_panel_page = AsyncMock()
+    side_panel_page.url = (
+        "chrome-extension://dev-extension/sidepanel.html"
+        f"?browserWindowId={browser_window_id}"
+    )
+    browser = SimpleNamespace(
+        contexts=[SimpleNamespace(pages=[page, side_panel_page])],
+        close=AsyncMock(),
+    )
     env._playwright = SimpleNamespace(
         chromium=SimpleNamespace(connect_over_cdp=AsyncMock(return_value=browser))
     )
     return env
+
+
+def test_cloud_browser_side_panel_url_matcher_accepts_queryless_cloud_url() -> None:
+    assert CloudBrowserEnvironment._is_side_panel_page_url(
+        "chrome-extension://dev-extension/sidepanel.html",
+        browser_window_id="browser-window-123",
+    )
+
+    assert CloudBrowserEnvironment._is_side_panel_page_url(
+        "chrome-extension://dev-extension/sidepanel.html?browserWindowId=browser-window-123",
+        browser_window_id="browser-window-123",
+    )
+
+    assert not CloudBrowserEnvironment._is_side_panel_page_url(
+        "chrome-extension://dev-extension/sidepanel.html?browserWindowId=other-window",
+        browser_window_id="browser-window-123",
+    )
+
+
+def test_local_browser_window_legacy_import_surface(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("NARADA_API_KEY", "test-key")
+
+    window = LocalBrowserWindow()
+
+    assert isinstance(window, Agent)
+    assert window.kind is AgentKind.OPERATOR
+    assert Agent.OPERATOR is AgentKind.OPERATOR
+    assert Agent.PRODUCTIVITY is AgentKind.PRODUCTIVITY
+    assert Agent.CORE_AGENT is AgentKind.CORE_AGENT
+
+
+@pytest.mark.asyncio
+async def test_narada_facade_context_prepares_playwright_without_starting_session(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import narada.environment as environment_module
+
+    fake_context_manager = _FakePlaywrightContextManager()
+    monkeypatch.setattr(
+        environment_module,
+        "async_playwright",
+        lambda: fake_context_manager,
+    )
+
+    narada = Narada(auth_headers={"x-api-key": "test-key"})
+
+    async with narada as client:
+        assert client is narada
+        assert fake_context_manager.entered
+        assert narada._playwright is not None
+        assert narada._session_id is None
+        assert not narada._initialized
+
+    assert fake_context_manager.exited
+    assert narada._playwright is None
+
+
+@pytest.mark.asyncio
+async def test_narada_facade_accepts_legacy_cloud_initializer_config_keyword(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    page = AsyncMock()
+    narada = Narada(auth_headers={"x-api-key": "test-key"})
+    side_panel_page = AsyncMock()
+    side_panel_page.url = "chrome-extension://dev-extension/sidepanel.html"
+    browser = SimpleNamespace(
+        contexts=[SimpleNamespace(pages=[page, side_panel_page])],
+        close=AsyncMock(),
+    )
+    narada._playwright = SimpleNamespace(
+        chromium=SimpleNamespace(connect_over_cdp=AsyncMock(return_value=browser))
+    )
+    wait_for_browser_window_id = AsyncMock(return_value="browser-window-123")
+    monkeypatch.setattr(
+        narada, "_wait_for_cloud_browser_window_id", wait_for_browser_window_id
+    )
+    config = BrowserConfig(interactive=False)
+
+    window = await narada._initialize_cloud_browser_window(
+        config=config,
+        cdp_websocket_url="wss://agentcore.example.test/session-123",
+        session_id="session-123",
+        login_url="https://app.narada.ai/initialize?customToken=test-token",
+        cdp_auth_headers={"Authorization": "signed-cdp"},
+    )
+
+    assert window is narada
+    assert narada._config is config
+    assert narada.browser_window_id == "browser-window-123"
+    assert narada.cloud_browser_session_id == "session-123"
 
 
 @pytest.mark.asyncio
@@ -276,6 +395,81 @@ async def test_lambda_environment_uses_backend_initialization(
 
 
 @pytest.mark.asyncio
+async def test_cloud_browser_environment_dev_overrides_use_dev_create_route(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import narada.environment as environment_module
+
+    fake_session = _FakeClientSession(
+        {
+            "cdp_websocket_url": "wss://agentcore.example.test/session-123",
+            "session_id": "session-123",
+            "session_name": "branch-session",
+            "login_url": "https://branch.example.test/initialize?customToken=test",
+            "cdp_auth_headers": {"Authorization": "signed-cdp"},
+        }
+    )
+    monkeypatch.setattr(
+        environment_module.aiohttp, "ClientSession", lambda: fake_session
+    )
+    monkeypatch.setattr(
+        environment_module,
+        "async_playwright",
+        lambda: _FakePlaywrightContextManager(),
+    )
+
+    env = CloudBrowserEnvironment(
+        auth_headers={"x-api-key": "test-key"},
+        base_url="https://api.test/fast/v2",
+        session_name="branch-session",
+        session_timeout=300,
+        dev_app_origin_override="https://branch.example.test",
+        dev_extension_s3_bucket="narada-chrome-extension-test-builds",
+        dev_extension_s3_key="proof/m5-extension.zip",
+    )
+
+    async def _initialize_window(**kwargs):
+        env._session_id = kwargs["session_id"]
+        env._browser_window_id = "browser-window-123"
+
+    initialize_window = AsyncMock(side_effect=_initialize_window)
+    monkeypatch.setattr(env, "_initialize_cloud_browser_window", initialize_window)
+
+    await env.start()
+
+    assert env.cloud_browser_session_id == "session-123"
+    assert env._initialization_url == (
+        "https://branch.example.test/initialize?customToken=test"
+    )
+    assert len(fake_session.posts) == 1
+    post = fake_session.posts[0]
+    assert post["url"].endswith("/cloud-browser/dev/create-cloud-browser-session")
+    assert post["headers"] == {"x-api-key": "test-key"}
+    assert post["json"] == {
+        "require_extension": True,
+        "session_name": "branch-session",
+        "session_timeout": 300,
+        "app_origin_override": "https://branch.example.test",
+        "extension_s3_bucket": "narada-chrome-extension-test-builds",
+        "extension_s3_key": "proof/m5-extension.zip",
+    }
+    initialize_window.assert_awaited_once_with(
+        cdp_websocket_url="wss://agentcore.example.test/session-123",
+        session_id="session-123",
+        login_url="https://branch.example.test/initialize?customToken=test",
+        cdp_auth_headers={"Authorization": "signed-cdp"},
+    )
+
+
+def test_cloud_browser_environment_rejects_partial_dev_overrides() -> None:
+    with pytest.raises(ValueError, match="dev Cloud Browser overrides require"):
+        CloudBrowserEnvironment(
+            dev_app_origin_override="https://branch.example.test",
+            dev_extension_s3_bucket="narada-chrome-extension-test-builds",
+        )
+
+
+@pytest.mark.asyncio
 async def test_lambda_environment_exposes_downloaded_files(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -340,6 +534,61 @@ async def test_cloud_browser_environment_uses_domcontentloaded_for_login_navigat
 
 
 @pytest.mark.asyncio
+async def test_cloud_browser_environment_reconnects_to_find_side_panel(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    page = AsyncMock()
+    side_panel_page = AsyncMock()
+    side_panel_page.url = (
+        "chrome-extension://dev-extension/sidepanel.html"
+        "?browserWindowId=browser-window-123"
+    )
+    second_context = SimpleNamespace(pages=[page, side_panel_page])
+    side_panel_page.context = second_context
+    first_browser = SimpleNamespace(
+        contexts=[SimpleNamespace(pages=[page])],
+        close=AsyncMock(),
+    )
+    second_browser = SimpleNamespace(
+        contexts=[second_context],
+        close=AsyncMock(),
+    )
+    env = CloudBrowserEnvironment(
+        auth_headers={"x-api-key": "test-key"},
+        config=BrowserConfig(interactive=False),
+    )
+    connect_over_cdp = AsyncMock(side_effect=[first_browser, second_browser])
+    env._playwright = SimpleNamespace(
+        chromium=SimpleNamespace(connect_over_cdp=connect_over_cdp)
+    )
+
+    wait_for_browser_window_id = AsyncMock(return_value="browser-window-123")
+    monkeypatch.setattr(
+        env, "_wait_for_cloud_browser_window_id", wait_for_browser_window_id
+    )
+    wait_for_side_panel = AsyncMock(
+        side_effect=[
+            NaradaTimeoutError("side panel not visible on first CDP connection"),
+            side_panel_page,
+        ]
+    )
+    monkeypatch.setattr(env, "_wait_for_cloud_side_panel_page", wait_for_side_panel)
+
+    await env._initialize_cloud_browser_window(
+        cdp_websocket_url="wss://agentcore.example.test/session-123",
+        session_id="session-123",
+        login_url="https://app.narada.ai/initialize?customToken=test-token",
+        cdp_auth_headers={"Authorization": "signed-cdp"},
+    )
+
+    assert connect_over_cdp.await_count == 2
+    first_browser.close.assert_awaited_once()
+    assert wait_for_side_panel.await_count == 2
+    assert env.browser_window_id == "browser-window-123"
+    assert env._context is second_context
+
+
+@pytest.mark.asyncio
 async def test_cloud_browser_environment_uses_domcontentloaded_for_retry_navigation(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -349,6 +598,48 @@ async def test_cloud_browser_environment_uses_domcontentloaded_for_retry_navigat
     wait_for_browser_window_id = AsyncMock(
         side_effect=[
             NaradaTimeoutError("Timed out waiting for browser window ID"),
+            "browser-window-123",
+        ]
+    )
+    monkeypatch.setattr(
+        env, "_wait_for_cloud_browser_window_id", wait_for_browser_window_id
+    )
+
+    await env._initialize_cloud_browser_window(
+        cdp_websocket_url="wss://agentcore.example.test/session-123",
+        session_id="session-123",
+        login_url="https://app.narada.ai/chat?customToken=test-token",
+        cdp_auth_headers={"Authorization": "signed-cdp"},
+    )
+
+    assert page.goto.await_args_list == [
+        call(
+            "https://app.narada.ai/chat?customToken=test-token",
+            timeout=15_000,
+            wait_until="domcontentloaded",
+        ),
+        call(
+            "https://app.narada.ai/chat?customToken=test-token",
+            timeout=15_000,
+            wait_until="domcontentloaded",
+        ),
+    ]
+    assert wait_for_browser_window_id.await_count == 2
+    assert env.browser_window_id == "browser-window-123"
+
+
+@pytest.mark.asyncio
+async def test_cloud_browser_environment_retries_extension_sign_in_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    page = AsyncMock()
+    env = _build_cloud_environment_with_page(page)
+
+    wait_for_browser_window_id = AsyncMock(
+        side_effect=[
+            NaradaExtensionUnauthenticatedError(
+                "Sign in to the Narada extension first"
+            ),
             "browser-window-123",
         ]
     )


### PR DESCRIPTION
## Summary
- Extend the workbench environment model with `env open --kind cloud` plus Cloud Browser adoption and cleanup semantics.
- Keep the M4 browser command family unchanged for cloud sessions: `goto`, `snapshot`, `find`, `selectors`, `click-nrd`, `fill-nrd`, `select-nrd`, `diff`, `screenshot`, and `downloads`.
- Materialize Cloud Browser downloads into the local proof root without persisting signed URLs.
- Harden scoring/verification so SDK-created cloud sessions need terminal cleanup and env-only roots cannot verify clean.

## Validation
- `cd /Users/erenerdogan/ZenRep/narada-python-sdk && uv run ruff check packages/narada packages/narada-core packages/narada-pyodide`
- `cd /Users/erenerdogan/ZenRep/narada-python-sdk && uvx ruff@latest format --check --diff packages/narada packages/narada-core packages/narada-pyodide`
- `cd /Users/erenerdogan/ZenRep/narada-python-sdk && uv run pytest packages/narada/tests packages/narada-pyodide/tests/test_cloud_browser.py`
- Result: `155 passed`.

## Live proof
- SDK CLI Cloud Browser proof root: `/tmp/narada-workbench-runs/m5-cloud-browser-cli-final-20260609T134247Z`
- SDK command outputs: `/tmp/narada-m5-cli-outputs-final-20260609T134247Z`
- Harness product-path Cloud Browser proof root: `/tmp/narada-e2e-runs/20260610T001710Z-cloudbrowserproductpath-bb578174374f412eb87ebb4549ca06fb`
- Final `score` and `verify` passed cleanly for the SDK proof root.
- Final harness proof was clean and Cloud Browser cleanup was `terminated`.

## Codex sibling refs
- caddie: NaradaAI/caddie#6611
- caddie prior trace/lifecycle work: NaradaAI/caddie#6601, NaradaAI/caddie#6603
- narada-python-sdk prior workbench stack: NaradaAI/narada-python-sdk#146, NaradaAI/narada-python-sdk#147, NaradaAI/narada-python-sdk#148
- frontend: branch:codex/agent-maker-m5-cloud-browser-parity
- architecture-docs: branch:codex/agent-maker-m5-docs

## Notes
- Cloud Browser session/window ids are provenance/control metadata only, not task-success evidence.
- The Narada E2E harness was used only as a DEV product-path backstop; the primary surface under test here is the SDK CLI.
