### PR TITLE
[Narada Code 7] Request execution trace capture explicitly

### DIFF
--- a/packages/narada-pyodide/src/narada/agent.py
+++ b/packages/narada-pyodide/src/narada/agent.py
@@ -244,6 +244,7 @@ class Agent(Generic[_StructuredOutput]):
         callback_headers: Mapping[str, Any] | None = None,
         on_input_required: InputRequiredCallback | None = None,
         critic_context: dict[str, Any] | None = None,
+        capture_execution_trace: bool | None = None,
         timeout: int = 1000,
     ) -> Response:
         dispatch_agent = self.kind if agent is None else agent
@@ -272,6 +273,7 @@ class Agent(Generic[_StructuredOutput]):
                 callback_headers=callback_headers,
                 on_input_required=on_input_required,
                 critic_context=critic_context,
+                capture_execution_trace=capture_execution_trace,
                 timeout=timeout,
             )
         else:
@@ -308,6 +310,7 @@ class Agent(Generic[_StructuredOutput]):
                 callback_headers=callback_headers,
                 on_input_required=on_input_required,
                 critic_context=critic_context,
+                capture_execution_trace=capture_execution_trace,
                 timeout=timeout,
             )
         return remote_dispatch_response

--- a/packages/narada-pyodide/src/narada/environment.py
+++ b/packages/narada-pyodide/src/narada/environment.py
@@ -447,6 +447,7 @@ class Environment(ABC):
         callback_secret: str | None = None,
         callback_headers: dict[str, Any] | None = None,
         on_input_required: InputRequiredCallback | None = None,
+        capture_execution_trace: bool | None = None,
         timeout: int = 1000,
     ) -> Response[None]: ...
 
@@ -473,6 +474,7 @@ class Environment(ABC):
         callback_secret: str | None = None,
         callback_headers: dict[str, Any] | None = None,
         on_input_required: InputRequiredCallback | None = None,
+        capture_execution_trace: bool | None = None,
         timeout: int = 1000,
     ) -> Response[_StructuredOutput]: ...
 
@@ -499,6 +501,7 @@ class Environment(ABC):
         callback_secret: str | None = None,
         callback_headers: dict[str, Any] | None = None,
         on_input_required: InputRequiredCallback | None = None,
+        capture_execution_trace: bool | None = None,
         timeout: int = 1000,
     ) -> Response[None]: ...
 
@@ -525,6 +528,7 @@ class Environment(ABC):
         callback_secret: str | None = None,
         callback_headers: dict[str, Any] | None = None,
         on_input_required: InputRequiredCallback | None = None,
+        capture_execution_trace: bool | None = None,
         timeout: int = 1000,
     ) -> Response[_StructuredOutput]: ...
 
@@ -551,6 +555,7 @@ class Environment(ABC):
         callback_secret: str | None = None,
         callback_headers: dict[str, Any] | None = None,
         on_input_required: InputRequiredCallback | None = None,
+        capture_execution_trace: bool | None = None,
         timeout: int = 1000,
     ) -> Response:
         """Low-level API for invoking an agent in the Narada extension side panel chat.
@@ -601,6 +606,8 @@ class Environment(ABC):
         execution_trace_context = _load_execution_trace_context_from_env()
         if execution_trace_context is not None:
             body["executionTraceContext"] = execution_trace_context
+        if capture_execution_trace or execution_trace_context is not None:
+            body["captureExecutionTrace"] = True
         cloud_browser_session_id = self.cloud_browser_session_id
         if cloud_browser_session_id is not None:
             body["cloudBrowserSessionId"] = cloud_browser_session_id

--- a/packages/narada-pyodide/tests/test_cloud_browser.py
+++ b/packages/narada-pyodide/tests/test_cloud_browser.py
@@ -1296,6 +1296,8 @@ async def test_local_browser_environment_dispatch_uses_latest_parent_run_ids(
         "parentSegmentId": "segment-local",
     }
     assert second_post["executionTraceContext"] == first_post["executionTraceContext"]
+    assert first_post["captureExecutionTrace"] is True
+    assert second_post["captureExecutionTrace"] is True
 
 
 @pytest.mark.asyncio

--- a/packages/narada/src/narada/agent.py
+++ b/packages/narada/src/narada/agent.py
@@ -161,6 +161,7 @@ class Agent(Generic[_StructuredOutput]):
         timeout: int = 1000,
     ) -> AgentResponse:
         """Invokes an agent in the bound Narada environment."""
+        active_trace_session = get_active_trace_session()
         remote_dispatch_response = await self._dispatch_request(
             prompt=prompt,
             clear_chat=clear_chat,
@@ -180,6 +181,7 @@ class Agent(Generic[_StructuredOutput]):
             callback_headers=callback_headers,
             on_input_required=on_input_required,
             reasoning=reasoning,
+            capture_execution_trace=trace or active_trace_session is not None,
             timeout=timeout,
         )
         response_content = remote_dispatch_response["response"]
@@ -218,7 +220,6 @@ class Agent(Generic[_StructuredOutput]):
             critic_result=critic_result,
             execution_trace_context=execution_trace_context,
         )
-        active_trace_session = get_active_trace_session()
         if trace and response.execution_trace_context is not None:
             materialized = await materialize_execution_trace_context(
                 response.execution_trace_context,
@@ -264,9 +265,15 @@ class Agent(Generic[_StructuredOutput]):
         callback_headers: Mapping[str, Any] | None = None,
         on_input_required: InputRequiredCallback | None = None,
         critic_context: dict[str, Any] | None = None,
+        capture_execution_trace: bool | None = None,
         timeout: int = 1000,
     ) -> Response:
         dispatch_agent = self.kind if agent is None else agent
+        capture_execution_trace = (
+            get_active_trace_session() is not None
+            if capture_execution_trace is None
+            else capture_execution_trace
+        )
         # Branch on `reasoning` so each call site binds a single, typed overload
         # of `_dispatch_request`. The validation also lives in `_dispatch_request`
         # itself (defense in depth + reachable when callers go straight to the
@@ -292,6 +299,7 @@ class Agent(Generic[_StructuredOutput]):
                 callback_headers=callback_headers,
                 on_input_required=on_input_required,
                 critic_context=critic_context,
+                capture_execution_trace=capture_execution_trace,
                 timeout=timeout,
             )
         else:
@@ -328,6 +336,7 @@ class Agent(Generic[_StructuredOutput]):
                 callback_headers=callback_headers,
                 on_input_required=on_input_required,
                 critic_context=critic_context,
+                capture_execution_trace=capture_execution_trace,
                 timeout=timeout,
             )
         return remote_dispatch_response

--- a/packages/narada/src/narada/cli.py
+++ b/packages/narada/src/narada/cli.py
@@ -31,6 +31,7 @@ from narada.studio import (
     studio_project_export,
     studio_resolve,
     studio_run,
+    studio_search,
     studio_sync_python_project,
     studio_upsert_python,
 )
@@ -138,6 +139,21 @@ async def _studio_list(args: argparse.Namespace) -> int:
 async def _studio_resolve(args: argparse.Namespace) -> int:
     result = await studio_resolve(
         path=args.path,
+        proof_root=args.proof_root,
+        client=_studio_client(args),
+    )
+    _print({**result.payload, "commandId": result.command_id}, as_json=args.json)
+    return 0 if result.status == "passed" else 1
+
+
+async def _studio_search(args: argparse.Namespace) -> int:
+    result = await studio_search(
+        query=args.query,
+        parent_path=args.parent_path,
+        content=args.content,
+        max_depth=args.max_depth,
+        max_items=args.max_items,
+        max_content_items=args.max_content_items,
         proof_root=args.proof_root,
         client=_studio_client(args),
     )
@@ -619,6 +635,20 @@ def build_parser() -> argparse.ArgumentParser:
     studio_resolve_parser.add_argument("--json", action="store_true")
     studio_resolve_parser.set_defaults(
         handler=lambda args: asyncio.run(_studio_resolve(args))
+    )
+
+    studio_search_parser = studio_subparsers.add_parser("search")
+    studio_search_parser.add_argument("--query", required=True)
+    studio_search_parser.add_argument("--parent-path", default="/")
+    studio_search_parser.add_argument("--content", action="store_true")
+    studio_search_parser.add_argument("--max-depth", type=int, default=3)
+    studio_search_parser.add_argument("--max-items", type=int, default=200)
+    studio_search_parser.add_argument("--max-content-items", type=int, default=25)
+    studio_search_parser.add_argument("--proof-root")
+    studio_search_parser.add_argument("--base-url")
+    studio_search_parser.add_argument("--json", action="store_true")
+    studio_search_parser.set_defaults(
+        handler=lambda args: asyncio.run(_studio_search(args))
     )
 
     studio_get_parser = studio_subparsers.add_parser("get")

--- a/packages/narada/src/narada/environment.py
+++ b/packages/narada/src/narada/environment.py
@@ -589,6 +589,7 @@ class Environment(ABC):
         callback_secret: str | None = None,
         callback_headers: Mapping[str, Any] | None = None,
         on_input_required: InputRequiredCallback | None = None,
+        capture_execution_trace: bool | None = None,
         timeout: int = 1000,
     ) -> Response[None]: ...
 
@@ -615,6 +616,7 @@ class Environment(ABC):
         callback_secret: str | None = None,
         callback_headers: Mapping[str, Any] | None = None,
         on_input_required: InputRequiredCallback | None = None,
+        capture_execution_trace: bool | None = None,
         timeout: int = 1000,
     ) -> Response[_StructuredOutput]: ...
 
@@ -641,6 +643,7 @@ class Environment(ABC):
         callback_secret: str | None = None,
         callback_headers: Mapping[str, Any] | None = None,
         on_input_required: InputRequiredCallback | None = None,
+        capture_execution_trace: bool | None = None,
         timeout: int = 1000,
     ) -> Response[None]: ...
 
@@ -667,6 +670,7 @@ class Environment(ABC):
         callback_secret: str | None = None,
         callback_headers: Mapping[str, Any] | None = None,
         on_input_required: InputRequiredCallback | None = None,
+        capture_execution_trace: bool | None = None,
         timeout: int = 1000,
     ) -> Response[_StructuredOutput]: ...
 
@@ -693,6 +697,7 @@ class Environment(ABC):
         callback_secret: str | None = None,
         callback_headers: Mapping[str, Any] | None = None,
         on_input_required: InputRequiredCallback | None = None,
+        capture_execution_trace: bool | None = None,
         timeout: int = 1000,
     ) -> Response:
         """Low-level API for invoking an agent in the Narada extension side panel chat.
@@ -724,6 +729,8 @@ class Environment(ABC):
         execution_trace_context = _load_execution_trace_context_from_env()
         if execution_trace_context is not None:
             body["executionTraceContext"] = execution_trace_context
+        if capture_execution_trace or execution_trace_context is not None:
+            body["captureExecutionTrace"] = True
         cloud_browser_session_id = self.cloud_browser_session_id
         if cloud_browser_session_id is not None:
             body["cloudBrowserSessionId"] = cloud_browser_session_id

--- a/packages/narada/src/narada/studio.py
+++ b/packages/narada/src/narada/studio.py
@@ -20,6 +20,7 @@ from narada.project_sync import (
     scan_project_package_findings,
     write_exported_project,
 )
+from narada.tracing import trace
 from narada.workbench import (
     _default_out_dir,
     _redact_sensitive_text,
@@ -32,7 +33,6 @@ from narada.workbench import (
     append_command,
     default_api_base_url,
     default_auth_headers,
-    materialize_execution_trace_context,
 )
 
 
@@ -1087,30 +1087,19 @@ async def studio_run(
         auth_headers=resolved_client.auth_headers,
         base_url=resolved_client.base_url,
     )
-    response = await Agent(environment=environment).run(prompt)
-    context = response.execution_trace_context
-    if context is None:
-        raise AgentStudioWorkbenchError(
-            "Agent run did not return executionTraceContext"
-        )
     root = (
         Path(proof_root)
         if proof_root is not None
         else _default_out_dir(f"studio-run-{item_id}")
     )
-    materialized = await materialize_execution_trace_context(
-        context,
-        out=root,
-        label=f"studio-run-{item_id}",
-        source_run={
-            "type": "remote-dispatch",
-            "authority": "agent-run-response",
-            "requestId": response.request_id,
-            "status": response.status,
-        },
-        auth_headers=resolved_client.auth_headers,
-        base_url=resolved_client.base_url,
-    )
+    async with trace(f"studio-run-{item_id}", out=root):
+        response = await Agent(environment=environment).run(prompt)
+    context = response.execution_trace_context
+    if context is None:
+        raise AgentStudioWorkbenchError(
+            "Agent run did not return executionTraceContext"
+        )
+    materialized_path = Path(response.execution_trace_path or root)
     run_report = {
         "schemaVersion": 1,
         "status": response.status,
@@ -1122,13 +1111,20 @@ async def studio_run(
         "structuredOutput": _jsonable_value(response.structured_output),
         "executionTraceContext": context,
     }
-    run_path = materialized.path / "agent-studio" / "run.json"
+    run_path = materialized_path / "agent-studio" / "run.json"
     _write_json(run_path, run_report)
     artifacts = [
-        _artifact_ref(materialized.path, run_path, "agent-studio-run"),
-        _write_remote_item_ref(materialized.path, item, "remote-item"),
+        _artifact_ref(materialized_path, run_path, "agent-studio-run"),
+        _write_remote_item_ref(materialized_path, item, "remote-item"),
     ]
-    materialization_report = getattr(materialized, "report", {})
+    materialization_report_path = (
+        materialized_path / "reports" / "materialization-report.json"
+    )
+    materialization_report: dict[str, Any] = {}
+    if materialization_report_path.exists():
+        materialization_report = json.loads(
+            materialization_report_path.read_text(encoding="utf-8")
+        )
     materialization_status = (
         str(materialization_report.get("status", "unknown"))
         if isinstance(materialization_report, dict)
@@ -1140,7 +1136,7 @@ async def studio_run(
     payload = {
         "schemaVersion": 1,
         "status": status,
-        "proofRoot": str(materialized.path),
+        "proofRoot": str(materialized_path),
         "requestId": response.request_id,
         "itemId": item_id,
         "slashPath": slash_path,
@@ -1158,7 +1154,7 @@ async def studio_run(
         },
     }
     command_id = _append_studio_command(
-        materialized.path,
+        materialized_path,
         command="studio.run",
         status=payload["status"],
         payload=payload,
@@ -1167,11 +1163,11 @@ async def studio_run(
         warnings=["requires-active-client"],
     )
     _update_manifest_hash(
-        materialized.path, "commandLedgerHash", materialized.path / "commands.jsonl"
+        materialized_path, "commandLedgerHash", materialized_path / "commands.jsonl"
     )
-    _refresh_redaction_report(materialized.path)
+    _refresh_redaction_report(materialized_path)
     return StudioCommandResult(
-        payload["status"], materialized.path, payload, command_id
+        payload["status"], materialized_path, payload, command_id
     )
 
 

--- a/packages/narada/src/narada/studio.py
+++ b/packages/narada/src/narada/studio.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import uuid
 from dataclasses import dataclass
+from difflib import SequenceMatcher
 from pathlib import Path
 from typing import Any, Callable
 from urllib.parse import urlencode, urlsplit, urlunsplit
@@ -34,6 +35,12 @@ from narada.workbench import (
     default_api_base_url,
     default_auth_headers,
 )
+
+_SEARCH_LIMIT_CAPS = {
+    "max_depth": 8,
+    "max_items": 1000,
+    "max_content_items": 100,
+}
 
 
 class AgentStudioWorkbenchError(RuntimeError):
@@ -212,6 +219,10 @@ def _list_item_summary(item: dict[str, Any]) -> dict[str, Any]:
     return summary
 
 
+def _is_folder_item(item: dict[str, Any]) -> bool:
+    return item.get("type") == "folder"
+
+
 def _item_code(item: dict[str, Any]) -> str:
     if item.get("type") != "file" or item.get("fileType") != "pythonAgent":
         raise AgentStudioWorkbenchError("Agent Studio item is not a Python agent file")
@@ -239,6 +250,13 @@ def _item_path(item: dict[str, Any]) -> str:
             "Agent Studio item did not contain parentPath/name"
         )
     return f"{parent_path}{name}"
+
+
+def _item_search_path(item: dict[str, Any]) -> str:
+    try:
+        return _item_path(item)
+    except AgentStudioWorkbenchError:
+        return ""
 
 
 def _jsonable_value(value: Any) -> Any:
@@ -284,6 +302,108 @@ def _local_code_and_hash(path: str | Path) -> tuple[str, str]:
 
 def _remote_code_hash(item: dict[str, Any]) -> str:
     return _sha256_json(_python_file_data(_item_code(item), _item_variables(item)))
+
+
+def _search_tokens(query: str) -> list[str]:
+    normalized = "".join(char.lower() if char.isalnum() else " " for char in query)
+    return [token for token in normalized.split() if token]
+
+
+def _text_similarity(query: str, value: str) -> int:
+    if not query or not value:
+        return 0
+    return int(SequenceMatcher(None, query.lower(), value.lower()).ratio() * 30)
+
+
+def _first_snippet(text: str, tokens: list[str], *, radius: int = 80) -> str | None:
+    lower = text.lower()
+    match_index = -1
+    for token in tokens:
+        match_index = lower.find(token)
+        if match_index >= 0:
+            break
+    if match_index < 0:
+        return None
+    start = max(0, match_index - radius)
+    end = min(len(text), match_index + radius)
+    prefix = "..." if start > 0 else ""
+    suffix = "..." if end < len(text) else ""
+    return _redact_sensitive_text(f"{prefix}{text[start:end]}{suffix}")
+
+
+def _score_metadata_match(
+    item: dict[str, Any], query: str, tokens: list[str]
+) -> tuple[int, list[str], list[dict[str, str]]]:
+    name = str(item.get("name") or "")
+    path = _item_search_path(item)
+    item_type = str(item.get("type") or "")
+    file_type = str(item.get("fileType") or item.get("targetFileType") or "")
+    fields = {
+        "name": name,
+        "path": path,
+        "type": item_type,
+        "fileType": file_type,
+    }
+    score = 0
+    matched_fields: set[str] = set()
+    snippets: list[dict[str, str]] = []
+    query_lower = query.lower()
+
+    for field, value in fields.items():
+        value_lower = value.lower()
+        if not value_lower:
+            continue
+        field_score = 0
+        if query_lower and query_lower in value_lower:
+            field_score += 80 if field == "name" else 60
+        for token in tokens:
+            if token in value_lower:
+                field_score += 20 if field == "name" else 12
+        similarity = _text_similarity(query, value)
+        if field in {"name", "path"} and similarity >= 18:
+            field_score += similarity
+        if field_score:
+            matched_fields.add(field)
+            snippet = _first_snippet(value, tokens)
+            if snippet is not None:
+                snippets.append({"field": field, "text": snippet})
+        score += field_score
+
+    return score, sorted(matched_fields), snippets
+
+
+def _score_content_match(
+    code: str, query: str, tokens: list[str]
+) -> tuple[int, list[dict[str, str]]]:
+    code_lower = code.lower()
+    query_lower = query.lower()
+    score = 0
+    if query_lower and query_lower in code_lower:
+        score += 50
+    for token in tokens:
+        if token in code_lower:
+            score += 12
+    snippet = _first_snippet(code, tokens, radius=100)
+    snippets = [{"field": "content", "text": snippet}] if snippet else []
+    return score, snippets
+
+
+def _redact_search_text(value: Any) -> Any:
+    if value is None:
+        return None
+    return _redact_sensitive_text(str(value))
+
+
+def _search_resolution_status(candidates: list[dict[str, Any]]) -> str:
+    if not candidates:
+        return "no_match"
+    if len(candidates) == 1:
+        return "single_candidate"
+    top_score = int(candidates[0].get("score") or 0)
+    second_score = int(candidates[1].get("score") or 0)
+    if second_score >= max(top_score - 10, int(top_score * 0.8)):
+        return "needs_user_choice"
+    return "single_candidate"
 
 
 def _studio_root(proof_root: str | Path | None, label: str) -> Path | None:
@@ -434,6 +554,179 @@ async def studio_list(
         payload=payload,
         client=resolved_client,
         artifacts=artifacts,
+    )
+    _refresh_redaction_report(root)
+    return StudioCommandResult("passed", root, payload, command_id)
+
+
+async def _collect_search_items(
+    client: AgentStudioWorkbenchClient,
+    *,
+    parent_path: str,
+    max_depth: int,
+    max_items: int,
+    warnings: list[str],
+) -> list[dict[str, Any]]:
+    normalized_parent_path = _normalize_parent_path(parent_path)
+    queue: list[tuple[str, int]] = [(normalized_parent_path, 0)]
+    visited_paths: set[str] = set()
+    items: list[dict[str, Any]] = []
+
+    while queue:
+        current_parent_path, depth = queue.pop(0)
+        if current_parent_path in visited_paths:
+            continue
+        visited_paths.add(current_parent_path)
+        if depth > max_depth:
+            warnings.append(f"max-depth-reached:{current_parent_path}")
+            continue
+        for item in await client.list_items(parent_path=current_parent_path):
+            items.append(item)
+            if len(items) >= max_items:
+                warnings.append("max-items-reached")
+                return items
+            if _is_folder_item(item) and depth < max_depth:
+                folder_path = _normalize_parent_path(_item_search_path(item))
+                if folder_path not in visited_paths:
+                    queue.append((folder_path, depth + 1))
+    return items
+
+
+async def studio_search(
+    *,
+    query: str,
+    parent_path: str = "/",
+    content: bool = False,
+    max_depth: int = 3,
+    max_items: int = 200,
+    max_content_items: int = 25,
+    proof_root: str | Path | None = None,
+    client: AgentStudioWorkbenchClient | None = None,
+) -> StudioCommandResult:
+    resolved_client = client or AgentStudioWorkbenchClient()
+    root = _studio_root(proof_root, "studio-search")
+    normalized_parent_path = _normalize_parent_path(parent_path)
+    warnings: list[str] = []
+    if max_depth < 0:
+        raise AgentStudioWorkbenchError("--max-depth must be non-negative")
+    if max_items < 1:
+        raise AgentStudioWorkbenchError("--max-items must be at least 1")
+    if max_content_items < 0:
+        raise AgentStudioWorkbenchError("--max-content-items must be non-negative")
+    if max_depth > _SEARCH_LIMIT_CAPS["max_depth"]:
+        warnings.append(f"max-depth-capped:{_SEARCH_LIMIT_CAPS['max_depth']}")
+        max_depth = _SEARCH_LIMIT_CAPS["max_depth"]
+    if max_items > _SEARCH_LIMIT_CAPS["max_items"]:
+        warnings.append(f"max-items-capped:{_SEARCH_LIMIT_CAPS['max_items']}")
+        max_items = _SEARCH_LIMIT_CAPS["max_items"]
+    if max_content_items > _SEARCH_LIMIT_CAPS["max_content_items"]:
+        warnings.append(
+            f"max-content-items-capped:{_SEARCH_LIMIT_CAPS['max_content_items']}"
+        )
+        max_content_items = _SEARCH_LIMIT_CAPS["max_content_items"]
+    tokens = _search_tokens(query)
+    if not tokens:
+        raise AgentStudioWorkbenchError("--query must contain searchable text")
+
+    items = await _collect_search_items(
+        resolved_client,
+        parent_path=normalized_parent_path,
+        max_depth=max_depth,
+        max_items=max_items,
+        warnings=warnings,
+    )
+    content_items_checked = 0
+    candidates: list[dict[str, Any]] = []
+    for item in items:
+        metadata_score, matched_fields, snippets = _score_metadata_match(
+            item, query, tokens
+        )
+        score = metadata_score
+        item_type = str(item.get("type") or "")
+        file_type = str(item.get("fileType") or item.get("targetFileType") or "")
+        item_id = str(item.get("id") or "")
+        if content and item_type == "file" and file_type == "pythonAgent" and item_id:
+            if content_items_checked >= max_content_items:
+                warnings.append("max-content-items-reached")
+            else:
+                content_items_checked += 1
+                try:
+                    full_item = await resolved_client.get_item(item_id=item_id)
+                    content_score, content_snippets = _score_content_match(
+                        _item_code(full_item), query, tokens
+                    )
+                    if content_score:
+                        score += content_score
+                        matched_fields = sorted({*matched_fields, "content"})
+                        snippets.extend(content_snippets)
+                except AgentStudioWorkbenchError as exc:
+                    warnings.append(f"content-unavailable:{item_id}:{exc.status}")
+        if score <= 0:
+            continue
+        candidates.append(
+            {
+                "itemId": item_id,
+                "name": _redact_search_text(item.get("name")),
+                "path": _redact_search_text(_item_search_path(item)),
+                "type": item_type,
+                "fileType": file_type or None,
+                "score": score,
+                "matchedFields": matched_fields,
+                "snippets": snippets[:3],
+                "ownerEmail": _redact_search_text(item.get("ownerEmail")),
+                "isShortcut": item_type.endswith("Shortcut"),
+            }
+        )
+
+    candidates.sort(
+        key=lambda candidate: (
+            int(candidate.get("score") or 0),
+            str(candidate.get("name") or "").lower(),
+        ),
+        reverse=True,
+    )
+    resolution_status = _search_resolution_status(candidates)
+    report = {
+        "schemaVersion": 1,
+        "status": "passed",
+        "query": _redact_search_text(query),
+        "resolutionStatus": resolution_status,
+        "candidates": candidates,
+        "warnings": sorted(set(warnings)),
+        "searchedItemCount": len(items),
+        "contentSearchEnabled": content,
+        "contentItemsChecked": content_items_checked,
+        "limits": {
+            "maxDepth": max_depth,
+            "maxItems": max_items,
+            "maxContentItems": max_content_items,
+        },
+    }
+    artifacts: list[dict[str, Any]] = []
+    if root is not None:
+        search_path = root / "agent-studio" / "search.json"
+        _write_json(search_path, report)
+        artifacts.append(_artifact_ref(root, search_path, "agent-studio-search"))
+    payload = {
+        **report,
+        "proofRoot": str(root) if root is not None else None,
+        "inputs": {
+            "query": _redact_search_text(query),
+            "parentPath": _redact_search_text(normalized_parent_path),
+            "content": content,
+            "maxDepth": max_depth,
+            "maxItems": max_items,
+            "maxContentItems": max_content_items,
+        },
+    }
+    command_id = _append_studio_command(
+        root,
+        command="studio.search",
+        status="passed",
+        payload=payload,
+        client=resolved_client,
+        artifacts=artifacts,
+        warnings=report["warnings"],
     )
     _refresh_redaction_report(root)
     return StudioCommandResult("passed", root, payload, command_id)

--- a/packages/narada/src/narada/workbench.py
+++ b/packages/narada/src/narada/workbench.py
@@ -32,6 +32,7 @@ _SIGNED_URL_PATTERNS = (
 )
 _SECRET_PATTERNS = (
     re.compile(r"Authorization:\s*Bearer\s+\S+", re.IGNORECASE),
+    re.compile(r"\bBearer\s+\S+", re.IGNORECASE),
     re.compile(r'"authorization"\s*:\s*"Bearer\s+[^"]+"', re.IGNORECASE),
     re.compile(r"\bcookie\s*:\s*[^\n\r]+", re.IGNORECASE),
     re.compile(r'"cookie"\s*:\s*"[^"]+"', re.IGNORECASE),

--- a/packages/narada/tests/test_agent.py
+++ b/packages/narada/tests/test_agent.py
@@ -102,6 +102,9 @@ async def test_agent_run_reruns_but_environment_initialization_is_cached(
         "/Operator first",
         "/Operator second",
     ]
+    assert all(
+        "captureExecutionTrace" not in body for body in fake_session.dispatched_bodies
+    )
 
 
 @pytest.mark.asyncio
@@ -231,6 +234,7 @@ async def test_trace_context_manager_materializes_registered_response(
     assert response.execution_trace_path == str(tmp_path / "proof")
     assert calls[0]["context"] == execution_trace_context
     assert calls[0]["out"] == tmp_path / "proof"
+    assert fake_session.dispatched_bodies[0]["captureExecutionTrace"] is True
 
 
 @pytest.mark.asyncio
@@ -293,6 +297,7 @@ async def test_agent_run_trace_true_materializes_single_response(
     assert response.execution_trace_path == str(tmp_path / "proof")
     assert calls[0]["context"] == execution_trace_context
     assert calls[0]["label"].startswith("agent-run-req-")
+    assert fake_session.dispatched_bodies[0]["captureExecutionTrace"] is True
 
 
 @pytest.mark.asyncio
@@ -371,3 +376,4 @@ async def test_agent_run_trace_true_inside_trace_context_materializes_once(
     assert tr.path is None
     assert len(agent_calls) == 1
     assert context_calls == []
+    assert fake_session.dispatched_bodies[0]["captureExecutionTrace"] is True

--- a/packages/narada/tests/test_cloud_browser.py
+++ b/packages/narada/tests/test_cloud_browser.py
@@ -334,6 +334,7 @@ async def test_dispatch_request_includes_execution_trace_context(
     assert response["status"] == "success"
     assert fake_session.dispatched_body is not None
     assert fake_session.dispatched_body["executionTraceContext"] == trace_context
+    assert fake_session.dispatched_body["captureExecutionTrace"] is True
 
 
 @pytest.mark.asyncio

--- a/packages/narada/tests/test_studio_workbench.py
+++ b/packages/narada/tests/test_studio_workbench.py
@@ -16,6 +16,7 @@ from narada.studio import (
     studio_export,
     studio_list,
     studio_run,
+    studio_search,
     studio_upsert_python,
 )
 from narada.workbench import _sha256_json, append_command
@@ -33,6 +34,23 @@ def _python_item(*, code: str = "print('remote')") -> dict[str, Any]:
         "parentPath": "/",
         "fileType": "pythonAgent",
         "fileData": {"code": code, "variables": []},
+        "sharedWithEmails": [],
+        "requestedAccessByEmails": [],
+        "isPublic": False,
+        "createdAt": "2026-06-09T00:00:00Z",
+        "updatedAt": "2026-06-09T00:00:00Z",
+    }
+
+
+def _folder_item(*, item_id: str, name: str, parent_path: str = "/") -> dict[str, Any]:
+    return {
+        "id": item_id,
+        "type": "folder",
+        "ownerEmail": "user@example.com",
+        "ownerUid": "user_1",
+        "ownerName": "User One",
+        "name": name,
+        "parentPath": parent_path,
         "sharedWithEmails": [],
         "requestedAccessByEmails": [],
         "isPublic": False,
@@ -60,6 +78,7 @@ class _FakeResponse:
 
 class _FakeStudioSession:
     existing_item: dict[str, Any] | None = _python_item()
+    search_items: list[dict[str, Any]] | None = None
     calls: list[tuple[str, str, dict[str, Any]]] = []
 
     def __init__(self) -> None:
@@ -75,6 +94,18 @@ class _FakeStudioSession:
         self.calls.append(("GET", url, kwargs))
         parsed = urlsplit(url)
         if parsed.path.endswith("/agent-studio/items") and parsed.query:
+            query = parse_qs(parsed.query)
+            parent_path = query.get("parentPath", ["/"])[0]
+            if self.__class__.search_items is not None:
+                return _FakeResponse(
+                    payload={
+                        "items": [
+                            item
+                            for item in self.__class__.search_items
+                            if item.get("parentPath") == parent_path
+                        ]
+                    }
+                )
             return _FakeResponse(
                 payload={"items": [self.existing_item] if self.existing_item else []}
             )
@@ -89,6 +120,12 @@ class _FakeStudioSession:
             if self.existing_item is None:
                 return _FakeResponse(status=404, payload={"detail": "not found"})
             return _FakeResponse(payload={"item": self.existing_item})
+        if "/agent-studio/items/" in parsed.path and self.__class__.search_items:
+            item_id = parsed.path.rsplit("/", 1)[-1]
+            for item in self.__class__.search_items:
+                if item.get("id") == item_id:
+                    return _FakeResponse(payload={"item": item})
+            return _FakeResponse(status=404, payload={"detail": "not found"})
         return _FakeResponse(status=500, payload={"detail": f"unexpected GET {url}"})
 
     def post(self, url: str, **kwargs: Any) -> _FakeResponse:
@@ -112,6 +149,7 @@ class _FakeStudioSession:
 @pytest.fixture(autouse=True)
 def reset_fake_studio_session() -> None:
     _FakeStudioSession.existing_item = _python_item()
+    _FakeStudioSession.search_items = None
     _FakeStudioSession.calls = []
 
 
@@ -140,6 +178,170 @@ async def test_studio_list_writes_optional_proof_artifacts(tmp_path: Path) -> No
     command_row = json.loads((tmp_path / "commands.jsonl").read_text().splitlines()[0])
     assert command_row["inputs"]["apiBaseUrlOrigin"] == "https://api.example.test"
     assert command_row["inputs"]["authMode"] == "api-key"
+
+
+@pytest.mark.asyncio
+async def test_studio_search_fuzzy_matches_nested_title_and_writes_proof(
+    tmp_path: Path,
+) -> None:
+    _FakeStudioSession.search_items = [
+        _folder_item(item_id="folder_1", name="JLR", parent_path="/"),
+        {
+            **_python_item(code="print('mercedes workflow')"),
+            "id": "item_mercedes",
+            "name": "Mercedes Benchmark",
+            "parentPath": "/JLR/",
+        },
+        {
+            **_python_item(code="print('other')"),
+            "id": "item_other",
+            "name": "Polestar Smoke",
+            "parentPath": "/",
+        },
+    ]
+
+    result = await studio_search(
+        query="JLR mercedes",
+        parent_path="/",
+        proof_root=tmp_path,
+        client=_client(),
+    )
+
+    assert result.status == "passed"
+    assert result.payload["resolutionStatus"] == "single_candidate"
+    assert result.payload["candidates"][0]["itemId"] == "item_mercedes"
+    assert "fileData" not in json.dumps(result.payload["candidates"])
+    search_report = json.loads(
+        (tmp_path / "agent-studio" / "search.json").read_text(encoding="utf-8")
+    )
+    assert search_report["query"] == "JLR mercedes"
+    command_row = json.loads((tmp_path / "commands.jsonl").read_text().splitlines()[0])
+    assert command_row["command"] == "studio.search"
+
+
+@pytest.mark.asyncio
+async def test_studio_search_content_is_opt_in_and_redacted() -> None:
+    _FakeStudioSession.search_items = [
+        {
+            **_python_item(
+                code='{"authorization": "Bearer should-not-leak"}\n# washer jets evidence\n'
+            ),
+            "id": "item_washer",
+            "name": "Maintenance Workflow",
+        }
+    ]
+
+    metadata_only = await studio_search(
+        query="washer jets",
+        parent_path="/",
+        content=False,
+        client=_client(),
+    )
+    content_result = await studio_search(
+        query="washer jets",
+        parent_path="/",
+        content=True,
+        client=_client(),
+    )
+
+    assert metadata_only.payload["candidates"] == []
+    candidate = content_result.payload["candidates"][0]
+    assert candidate["matchedFields"] == ["content"]
+    assert "Bearer should-not-leak" not in json.dumps(candidate["snippets"])
+
+
+@pytest.mark.asyncio
+async def test_studio_search_marks_close_candidates_for_user_choice() -> None:
+    _FakeStudioSession.search_items = [
+        {
+            **_python_item(code="print('a')"),
+            "id": "item_a",
+            "name": "Invoice Follow Up North",
+        },
+        {
+            **_python_item(code="print('b')"),
+            "id": "item_b",
+            "name": "Invoice Follow Up South",
+        },
+    ]
+
+    result = await studio_search(
+        query="invoice follow up",
+        parent_path="/",
+        client=_client(),
+    )
+
+    assert result.status == "passed"
+    assert result.payload["resolutionStatus"] == "needs_user_choice"
+    assert [candidate["itemId"] for candidate in result.payload["candidates"]] == [
+        "item_b",
+        "item_a",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_studio_search_redacts_persisted_query_and_metadata(
+    tmp_path: Path,
+) -> None:
+    _FakeStudioSession.search_items = [
+        {
+            **_python_item(code="print('secret title smoke')"),
+            "id": "item_secret",
+            "name": "Authorization: Bearer should-not-leak",
+            "parentPath": "/Authorization: Bearer should-not-leak/",
+            "ownerEmail": "token: should-not-leak",
+        }
+    ]
+
+    result = await studio_search(
+        query="Authorization: Bearer should-not-leak",
+        parent_path="/Authorization: Bearer should-not-leak",
+        proof_root=tmp_path,
+        client=_client(),
+    )
+
+    serialized_payload = json.dumps(result.payload)
+    search_report = json.loads(
+        (tmp_path / "agent-studio" / "search.json").read_text(encoding="utf-8")
+    )
+    command_row = json.loads((tmp_path / "commands.jsonl").read_text().splitlines()[0])
+    serialized_artifacts = json.dumps({"report": search_report, "command": command_row})
+
+    assert "should-not-leak" not in serialized_payload
+    assert "should-not-leak" not in serialized_artifacts
+    assert "[REDACTED_SECRET]" in serialized_payload
+    assert "[REDACTED_SECRET]" in serialized_artifacts
+
+
+@pytest.mark.asyncio
+async def test_studio_search_clamps_excessive_limits() -> None:
+    _FakeStudioSession.search_items = [
+        {
+            **_python_item(code="print('a')"),
+            "id": "item_a",
+            "name": "Invoice Follow Up North",
+        }
+    ]
+
+    result = await studio_search(
+        query="invoice",
+        parent_path="/",
+        max_depth=999,
+        max_items=9999,
+        max_content_items=999,
+        client=_client(),
+    )
+
+    assert result.payload["limits"] == {
+        "maxDepth": 8,
+        "maxItems": 1000,
+        "maxContentItems": 100,
+    }
+    assert result.payload["warnings"] == [
+        "max-content-items-capped:100",
+        "max-depth-capped:8",
+        "max-items-capped:1000",
+    ]
 
 
 @pytest.mark.asyncio

--- a/packages/narada/tests/test_studio_workbench.py
+++ b/packages/narada/tests/test_studio_workbench.py
@@ -328,6 +328,63 @@ async def test_studio_delete_rejects_update_command_provenance(tmp_path: Path) -
 
 
 @pytest.mark.asyncio
+async def test_studio_run_requests_trace_capture_through_real_agent(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FakeEnvironment:
+        instances: list["FakeEnvironment"] = []
+
+        def __init__(self, **kwargs: Any) -> None:
+            self._auth_headers = kwargs["auth_headers"]
+            self._base_url = kwargs["base_url"]
+            self.dispatch_kwargs: dict[str, Any] | None = None
+            self.__class__.instances.append(self)
+
+        async def _dispatch_request(self, **kwargs: Any) -> dict[str, Any]:
+            self.dispatch_kwargs = kwargs
+            return {
+                "requestId": "req_1",
+                "status": "success",
+                "response": {
+                    "text": "ok",
+                    "output": {"type": "text", "content": "ok"},
+                    "executionTraceContext": {
+                        "executionTraceS3Key": "trace/index.json"
+                    },
+                },
+                "usage": {"actions": 0, "credits": 0},
+            }
+
+    materialize_calls: list[dict[str, Any]] = []
+
+    async def fake_materialize_execution_trace_context(*_: Any, **kwargs: Any) -> Any:
+        materialize_calls.append(kwargs)
+        root = Path(kwargs["out"])
+        root.mkdir(parents=True, exist_ok=True)
+        return SimpleNamespace(path=root)
+
+    monkeypatch.setattr("narada.studio.Environment", FakeEnvironment)
+    monkeypatch.setattr(
+        "narada.tracing.materialize_execution_trace_context",
+        fake_materialize_execution_trace_context,
+    )
+
+    result = await studio_run(
+        item_id="item_1",
+        proof_root=tmp_path,
+        client=_client(),
+    )
+
+    assert result.status == "passed"
+    fake_environment = FakeEnvironment.instances[0]
+    assert fake_environment.dispatch_kwargs is not None
+    assert fake_environment.dispatch_kwargs["capture_execution_trace"] is True
+    assert len(materialize_calls) == 1
+    assert materialize_calls[0]["out"] == tmp_path
+
+
+@pytest.mark.asyncio
 async def test_studio_run_writes_jsonable_response_output(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -338,7 +395,11 @@ async def test_studio_run_writes_jsonable_response_output(
 
         async def run(self, prompt: str) -> AgentResponse[dict[str, Any]]:
             assert prompt == "/user@example.com/Smoke"
-            return AgentResponse(
+            from narada.tracing import get_active_trace_session
+
+            active_trace_session = get_active_trace_session()
+            assert active_trace_session is not None
+            response = AgentResponse(
                 request_id="req_1",
                 status="success",
                 text="ok",
@@ -347,6 +408,12 @@ async def test_studio_run_writes_jsonable_response_output(
                 usage=AgentUsage(actions=0, credits=0),
                 execution_trace_context={"executionTraceS3Key": "trace/index.json"},
             )
+            active_trace_session.register_response(
+                response,
+                auth_headers={},
+                base_url="http://test.local/fast/v2",
+            )
+            return response
 
     async def fake_materialize_execution_trace_context(*_: Any, **kwargs: Any) -> Any:
         root = Path(kwargs["out"])
@@ -355,7 +422,7 @@ async def test_studio_run_writes_jsonable_response_output(
 
     monkeypatch.setattr("narada.studio.Agent", FakeAgent)
     monkeypatch.setattr(
-        "narada.studio.materialize_execution_trace_context",
+        "narada.tracing.materialize_execution_trace_context",
         fake_materialize_execution_trace_context,
     )
 
@@ -382,7 +449,11 @@ async def test_studio_run_propagates_materializer_taint(
 
         async def run(self, prompt: str) -> AgentResponse[dict[str, Any]]:
             assert prompt == "/user@example.com/Smoke"
-            return AgentResponse(
+            from narada.tracing import get_active_trace_session
+
+            active_trace_session = get_active_trace_session()
+            assert active_trace_session is not None
+            response = AgentResponse(
                 request_id="req_1",
                 status="success",
                 text="ok",
@@ -391,15 +462,24 @@ async def test_studio_run_propagates_materializer_taint(
                 usage=AgentUsage(actions=0, credits=0),
                 execution_trace_context={"executionTraceS3Key": "trace/index.json"},
             )
+            active_trace_session.register_response(
+                response,
+                auth_headers={},
+                base_url="http://test.local/fast/v2",
+            )
+            return response
 
     async def fake_materialize_execution_trace_context(*_: Any, **kwargs: Any) -> Any:
         root = Path(kwargs["out"])
         root.mkdir(parents=True, exist_ok=True)
+        report_path = root / "reports" / "materialization-report.json"
+        report_path.parent.mkdir(parents=True, exist_ok=True)
+        report_path.write_text(json.dumps({"status": "tainted"}), encoding="utf-8")
         return SimpleNamespace(path=root, report={"status": "tainted"})
 
     monkeypatch.setattr("narada.studio.Agent", FakeAgent)
     monkeypatch.setattr(
-        "narada.studio.materialize_execution_trace_context",
+        "narada.tracing.materialize_execution_trace_context",
         fake_materialize_execution_trace_context,
     )
 


### PR DESCRIPTION
## Summary

Updates CPython and Pyodide SDK remote-dispatch request construction so execution trace capture is requested only for:

- `Agent.run(trace=True)`
- an active `async with trace(...)` session
- inherited `NARADA_EXECUTION_TRACE_CONTEXT` propagation

Normal `Agent.run(...)` remains backward-compatible and does not send `captureExecutionTrace`.

## Why

SDK trace materialization is opt-in, so the SDK should not trigger frontend trace capture unless the caller wants a materializable trace proof root or is continuing a parent trace.

## Validation

- `uv run ruff check packages/narada packages/narada-core packages/narada-pyodide`
- `uvx ruff@latest format --check --diff packages/narada packages/narada-core packages/narada-pyodide`
- `uv run pytest packages/narada/tests packages/narada-pyodide/tests/test_cloud_browser.py`
- Result: 174 passed.

## Live proof

- Signed-in DEV stack: `/tmp/narada-e2e-runs/20260610T025557Z-stack-m7-trace-optin-20260609195557`
- Untraced SDK request returned no `executionTraceContext`: `20260610030031-7U9njSw6UDbJZobLXxafC`
- Traced SDK request returned context and materialized cleanly: `/tmp/narada-workbench-runs/m7-trace-optin-traced-20260610T0300Z`
- `score` and `verify` passed on the materialized proof root.
- Nested traced Python APA harness backstop passed: `/tmp/narada-e2e-runs/20260610T031228Z-executiontrace-1c4df2245561486084520929489cab30`

## M7 skill dogfood note

The local `narada-agent-maker` skill package was created and installed, and a first Codex dogfood used it correctly for CLI discovery, scaffolding, authority/validation planning, and positive/negative local validation. I stopped the dogfood before Agent Studio sync/run because the child Codex inspected and printed a plaintext SDK-key artifact. The secret was revoked/deleted/redacted, the skill was patched to forbid reading/printing/copying plaintext key artifacts, and a clean full dogfood rerun remains the next M7 acceptance gate.

## Codex sibling refs

- caddie: `branch:codex/agent-maker-trace-opt-in`
- frontend: `branch:codex/agent-maker-trace-opt-in`
- architecture-docs: `branch:codex/agent-maker-trace-opt-in-docs`
