### PR TITLE
[codex] Add cloud browser session initializer

### DIFF
--- a/packages/narada/src/narada/__init__.py
+++ b/packages/narada/src/narada/__init__.py
@@ -27,6 +27,7 @@ from narada.environment import (
     LambdaEnvironment,
     RemoteBrowserEnvironment,
     SessionDownloadItem,
+    initialize_existing_cloud_browser_session,
 )
 from narada.utils import download_file, render_html
 from narada.version import __version__
@@ -45,6 +46,7 @@ __all__ = [
     "download_file",
     "Environment",
     "File",
+    "initialize_existing_cloud_browser_session",
     "LambdaEnvironment",
     "NaradaError",
     "NaradaExtensionMissingError",

--- a/packages/narada/src/narada/environment.py
+++ b/packages/narada/src/narada/environment.py
@@ -1374,15 +1374,19 @@ class RemoteBrowserEnvironment(BaseBrowserEnvironment):
         *,
         browser_window_id: str,
         cloud_browser_session_id: str | None = None,
+        stop_cloud_browser_session_on_close: bool = True,
         api_key: str | None = None,
         auth_headers: dict[str, str] | None = None,
+        base_url: str | None = None,
     ) -> None:
         super().__init__(
             api_key=api_key,
             auth_headers=auth_headers,
+            base_url=base_url,
             browser_window_id=browser_window_id,
         )
         self._cloud_browser_session_id = cloud_browser_session_id
+        self._stop_cloud_browser_session_on_close = stop_cloud_browser_session_on_close
 
     @property
     def _validates_sdk_config(self) -> bool:
@@ -1396,13 +1400,16 @@ class RemoteBrowserEnvironment(BaseBrowserEnvironment):
     async def _close_impl(self, *, timeout: int | None = None) -> None:
         """Closes the remote browser environment.
 
-        If this window is backed by a cloud browser session, this also stops the cloud
+        If this window is backed by an SDK-owned cloud browser session, this also stops the cloud
         session.
         """
         if self._cloud_browser_session_id is None:
             return await self._run_extension_action(
                 CloseWindowRequest(), timeout=timeout
             )
+
+        if not self._stop_cloud_browser_session_on_close:
+            return
 
         await _stop_cloud_browser_session(
             base_url=self._base_url,
@@ -1442,10 +1449,12 @@ class CloudBrowserEnvironment(BaseBrowserEnvironment):
         session_timeout: int | None = None,
         api_key: str | None = None,
         auth_headers: dict[str, str] | None = None,
+        base_url: str | None = None,
     ) -> None:
         super().__init__(
             api_key=api_key,
             auth_headers=auth_headers,
+            base_url=base_url,
         )
         self._config = config or BrowserConfig()
         self._session_name = session_name
@@ -1597,6 +1606,7 @@ class CloudBrowserEnvironment(BaseBrowserEnvironment):
         session_id: str,
         login_url: str,
         cdp_auth_headers: dict[str, str],
+        expected_browser_window_id: str | None = None,
     ) -> None:
         assert self._playwright is not None
 
@@ -1608,6 +1618,17 @@ class CloudBrowserEnvironment(BaseBrowserEnvironment):
         # Navigate to login URL (provided by backend with custom token)
         context = browser.contexts[0]
         initialization_page = context.pages[0]
+        if expected_browser_window_id is not None:
+            await context.add_init_script(
+                script=(
+                    "(() => {\n"
+                    f"  const expectedBrowserWindowId = {json.dumps(expected_browser_window_id)};\n"
+                    "  try {\n"
+                    "    sessionStorage.setItem('naradaBrowserWindowId', expectedBrowserWindowId);\n"
+                    "  } catch (_error) {}\n"
+                    "})();"
+                )
+            )
         await initialization_page.goto(
             login_url, timeout=15_000, wait_until="domcontentloaded"
         )
@@ -1628,7 +1649,7 @@ class CloudBrowserEnvironment(BaseBrowserEnvironment):
                     raise
                 logging.info("Waiting for Narada extension to be installed...")
                 await asyncio.sleep(1)
-            except NaradaTimeoutError:
+            except (NaradaTimeoutError, NaradaExtensionUnauthenticatedError):
                 if attempt == max_attempts - 1:
                     raise
                 # If browser window ID is not found, reload the page and try again
@@ -1636,6 +1657,15 @@ class CloudBrowserEnvironment(BaseBrowserEnvironment):
                 await initialization_page.goto(
                     login_url, timeout=15_000, wait_until="domcontentloaded"
                 )
+
+        if (
+            expected_browser_window_id is not None
+            and browser_window_id != expected_browser_window_id
+        ):
+            raise RuntimeError(
+                "Initialized cloud session reported browserWindowId "
+                f"{browser_window_id!r}, expected {expected_browser_window_id!r}."
+            )
 
         self._browser_window_id = browser_window_id
         self._session_id = session_id
@@ -1770,6 +1800,53 @@ class LambdaEnvironment(Environment):
             auth_headers=self._auth_headers,
             session_id=self.session_id,
         )
+
+
+async def initialize_existing_cloud_browser_session(
+    *,
+    cdp_websocket_url: str,
+    session_id: str,
+    login_url: str,
+    cdp_auth_headers: dict[str, str],
+    config: BrowserConfig | None = None,
+    expected_browser_window_id: str | None = None,
+    api_key: str | None = None,
+    auth_headers: dict[str, str] | None = None,
+    base_url: str | None = None,
+) -> RemoteBrowserEnvironment:
+    """Initialize a backend-owned AgentCore Browser session.
+
+    This is for services that already created the cloud-browser session and need the SDK's
+    CDP/bootstrap flow only. The returned remote environment can dispatch through the initialized
+    browser window, but closing it does not stop the backend-owned cloud session.
+    """
+    cloud_env = CloudBrowserEnvironment(
+        api_key=api_key,
+        auth_headers=auth_headers,
+        base_url=base_url,
+        config=config,
+    )
+    try:
+        await cloud_env._validate_sdk_config()
+        cloud_env._playwright_context_manager = async_playwright()
+        cloud_env._playwright = await cloud_env._playwright_context_manager.__aenter__()
+        await cloud_env._initialize_cloud_browser_window(
+            cdp_websocket_url=cdp_websocket_url,
+            session_id=session_id,
+            login_url=login_url,
+            cdp_auth_headers=cdp_auth_headers,
+            expected_browser_window_id=expected_browser_window_id,
+        )
+        return RemoteBrowserEnvironment(
+            api_key=api_key,
+            auth_headers=auth_headers,
+            base_url=base_url,
+            browser_window_id=cloud_env.browser_window_id,
+            cloud_browser_session_id=session_id,
+            stop_cloud_browser_session_on_close=False,
+        )
+    finally:
+        await cloud_env._stop_playwright()
 
 
 async def _fetch_presigned_download_url(

--- a/packages/narada/tests/test_client.py
+++ b/packages/narada/tests/test_client.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+from unittest.mock import AsyncMock
+
 import narada.environment as environment_module
 import pytest
 from narada import CloudBrowserEnvironment, RemoteBrowserEnvironment
 from narada.config import BrowserConfig
+from narada.environment import initialize_existing_cloud_browser_session
 
 
 class _FakePage:
@@ -19,6 +22,10 @@ class _FakePage:
 class _FakeContext:
     def __init__(self, page: _FakePage) -> None:
         self.pages = [page]
+        self.init_scripts: list[str] = []
+
+    async def add_init_script(self, *, script: str) -> None:
+        self.init_scripts.append(script)
 
 
 class _FakeBrowser:
@@ -43,6 +50,18 @@ class _FakeChromium:
 class _FakePlaywright:
     def __init__(self, page: _FakePage) -> None:
         self.chromium = _FakeChromium(page)
+
+
+class _FakePlaywrightContextManager:
+    def __init__(self, playwright: _FakePlaywright) -> None:
+        self.playwright = playwright
+        self.exited = False
+
+    async def __aenter__(self) -> _FakePlaywright:
+        return self.playwright
+
+    async def __aexit__(self, *_args: object) -> None:
+        self.exited = True
 
 
 class _FakeRemoteDispatchPostResponse:
@@ -145,6 +164,94 @@ async def test_cloud_browser_initialization_uses_domcontentloaded_navigation(
             "wait_until": "domcontentloaded",
         }
     ]
+
+
+@pytest.mark.asyncio
+async def test_cloud_browser_initialization_can_preseed_browser_window_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    page = _FakePage()
+    env = CloudBrowserEnvironment(
+        config=BrowserConfig(interactive=False),
+        auth_headers={"x-test": "true"},
+    )
+    fake_playwright = _FakePlaywright(page)
+    env._playwright = fake_playwright
+
+    async def wait_for_browser_window_id(*args: object, **kwargs: object) -> str:
+        return "expected-window-123"
+
+    monkeypatch.setattr(
+        env, "_wait_for_cloud_browser_window_id", wait_for_browser_window_id
+    )
+
+    await env._initialize_cloud_browser_window(
+        cdp_websocket_url="wss://example.test/cdp",
+        session_id="session-123",
+        login_url="https://example.test/initialize",
+        cdp_auth_headers={"authorization": "Bearer test"},
+        expected_browser_window_id="expected-window-123",
+    )
+
+    context = fake_playwright.chromium.browser.contexts[0]
+    assert len(context.init_scripts) == 1
+    assert "expected-window-123" in context.init_scripts[0]
+    assert "naradaBrowserWindowId" in context.init_scripts[0]
+    assert env.browser_window_id == "expected-window-123"
+    assert env.cloud_browser_session_id == "session-123"
+
+
+@pytest.mark.asyncio
+async def test_initialize_existing_cloud_browser_session_returns_non_owning_remote_environment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    page = _FakePage()
+    manager = _FakePlaywrightContextManager(_FakePlaywright(page))
+    monkeypatch.setattr(environment_module, "async_playwright", lambda: manager)
+
+    async def validate_sdk_config(self: CloudBrowserEnvironment) -> None:
+        return None
+
+    async def wait_for_browser_window_id(*args: object, **kwargs: object) -> str:
+        return "expected-window-123"
+
+    monkeypatch.setattr(
+        CloudBrowserEnvironment, "_validate_sdk_config", validate_sdk_config
+    )
+    monkeypatch.setattr(
+        CloudBrowserEnvironment,
+        "_wait_for_cloud_browser_window_id",
+        wait_for_browser_window_id,
+    )
+
+    env = await initialize_existing_cloud_browser_session(
+        cdp_websocket_url="wss://example.test/cdp",
+        session_id="session-123",
+        login_url="https://example.test/initialize",
+        cdp_auth_headers={"authorization": "Bearer test"},
+        config=BrowserConfig(interactive=False),
+        expected_browser_window_id="expected-window-123",
+        auth_headers={"x-test": "true"},
+        base_url="https://api.example.test/fast/v2",
+    )
+
+    assert manager.exited is True
+    assert isinstance(env, RemoteBrowserEnvironment)
+    assert env.browser_window_id == "expected-window-123"
+    assert env.cloud_browser_session_id == "session-123"
+    assert env._base_url == "https://api.example.test/fast/v2"
+
+    stop_cloud_browser_session = AsyncMock()
+    run_extension_action = AsyncMock()
+    monkeypatch.setattr(
+        environment_module, "_stop_cloud_browser_session", stop_cloud_browser_session
+    )
+    monkeypatch.setattr(env, "_run_extension_action", run_extension_action)
+
+    await env.close()
+
+    stop_cloud_browser_session.assert_not_awaited()
+    run_extension_action.assert_not_awaited()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Adds a public SDK helper for initializing an existing backend-owned Cloud Browser session, including expected browser-window seeding and non-owning close semantics.

## Why

The caddie Cloud Browser service needs SDK-owned initialization logic for sessions it creates server-side, without duplicating SDK internals or accidentally stopping sessions it does not own.

## Validation

- `uv run ruff format --check --diff packages/narada/src/narada/__init__.py packages/narada/src/narada/environment.py packages/narada/tests/test_client.py`
- `uv run pytest packages/narada/tests/test_client.py packages/narada/tests/test_input_variables.py -q`

## Codex sibling refs

- caddie: https://github.com/NaradaAI/caddie/pull/6623
- frontend: https://github.com/NaradaAI/frontend/pull/1836
- architecture-docs: https://github.com/NaradaAI/architecture-docs/pull/31
