### PR TITLE
Support test mode in environment SDK

### DIFF
--- a/packages/narada-pyodide/src/narada/agent.py
+++ b/packages/narada-pyodide/src/narada/agent.py
@@ -105,6 +105,7 @@ class Agent(Generic[_StructuredOutput]):
         callback_headers: Mapping[str, Any] | None = None,
         on_input_required: InputRequiredCallback | None = None,
         critic: CriticConfig | None = None,
+        test: bool = False,
         timeout: int = 1000,
     ) -> AgentResponse[dict[str, Any]]: ...
 
@@ -131,6 +132,7 @@ class Agent(Generic[_StructuredOutput]):
         callback_headers: Mapping[str, Any] | None = None,
         on_input_required: InputRequiredCallback | None = None,
         critic: CriticConfig | None = None,
+        test: bool = False,
         timeout: int = 1000,
     ) -> AgentResponse[_StructuredOutput]: ...
 
@@ -156,6 +158,7 @@ class Agent(Generic[_StructuredOutput]):
         callback_headers: Mapping[str, Any] | None = None,
         on_input_required: InputRequiredCallback | None = None,
         critic: CriticConfig | None = None,
+        test: bool = False,
         timeout: int = 1000,
     ) -> AgentResponse:
         """Invokes an agent in the bound Narada environment."""
@@ -178,6 +181,7 @@ class Agent(Generic[_StructuredOutput]):
             callback_headers=callback_headers,
             on_input_required=on_input_required,
             reasoning=reasoning,
+            test=test,
             timeout=timeout,
         )
         response_content = remote_dispatch_response["response"]
@@ -248,6 +252,7 @@ class Agent(Generic[_StructuredOutput]):
         callback_headers: Mapping[str, Any] | None = None,
         on_input_required: InputRequiredCallback | None = None,
         critic_context: dict[str, Any] | None = None,
+        test: bool = False,
         timeout: int = 1000,
     ) -> Response:
         dispatch_agent = self.kind if agent is None else agent
@@ -276,6 +281,7 @@ class Agent(Generic[_StructuredOutput]):
                 callback_headers=callback_headers,
                 on_input_required=on_input_required,
                 critic_context=critic_context,
+                test=test,
                 timeout=timeout,
             )
         else:
@@ -312,6 +318,7 @@ class Agent(Generic[_StructuredOutput]):
                 callback_headers=callback_headers,
                 on_input_required=on_input_required,
                 critic_context=critic_context,
+                test=test,
                 timeout=timeout,
             )
         return remote_dispatch_response

--- a/packages/narada-pyodide/src/narada/environment.py
+++ b/packages/narada-pyodide/src/narada/environment.py
@@ -573,9 +573,12 @@ class Environment(ABC):
 
         headers = await self._get_auth_headers()
 
-        agent_prefix = (
-            agent.prompt_prefix() if isinstance(agent, AgentKind) else f"{agent} "
-        )
+        if isinstance(agent, AgentKind):
+            agent_prefix = (
+                "" if prompt.lstrip().startswith("/") else agent.prompt_prefix()
+            )
+        else:
+            agent_prefix = f"{agent} "
         body: dict[str, Any] = {
             "prompt": agent_prefix + prompt,
             "timeZone": time_zone,

--- a/packages/narada-pyodide/src/narada/environment.py
+++ b/packages/narada-pyodide/src/narada/environment.py
@@ -438,6 +438,7 @@ class Environment(ABC):
         callback_secret: str | None = None,
         callback_headers: dict[str, Any] | None = None,
         on_input_required: InputRequiredCallback | None = None,
+        test: bool = False,
         timeout: int = 1000,
     ) -> Response[None]: ...
 
@@ -464,6 +465,7 @@ class Environment(ABC):
         callback_secret: str | None = None,
         callback_headers: dict[str, Any] | None = None,
         on_input_required: InputRequiredCallback | None = None,
+        test: bool = False,
         timeout: int = 1000,
     ) -> Response[_StructuredOutput]: ...
 
@@ -490,6 +492,7 @@ class Environment(ABC):
         callback_secret: str | None = None,
         callback_headers: dict[str, Any] | None = None,
         on_input_required: InputRequiredCallback | None = None,
+        test: bool = False,
         timeout: int = 1000,
     ) -> Response[None]: ...
 
@@ -516,6 +519,7 @@ class Environment(ABC):
         callback_secret: str | None = None,
         callback_headers: dict[str, Any] | None = None,
         on_input_required: InputRequiredCallback | None = None,
+        test: bool = False,
         timeout: int = 1000,
     ) -> Response[_StructuredOutput]: ...
 
@@ -542,6 +546,7 @@ class Environment(ABC):
         callback_secret: str | None = None,
         callback_headers: dict[str, Any] | None = None,
         on_input_required: InputRequiredCallback | None = None,
+        test: bool = False,
         timeout: int = 1000,
     ) -> Response:
         """Low-level API for invoking an agent in the Narada extension side panel chat.
@@ -632,6 +637,8 @@ class Environment(ABC):
             body["callbackHeaders"] = callback_headers
         if reasoning is not None:
             body["reasoningMode"] = reasoning.value
+        if test:
+            body["test"] = True
 
         try:
             seen_input_ids: set[str] = set()

--- a/packages/narada-pyodide/tests/test_cloud_browser.py
+++ b/packages/narada-pyodide/tests/test_cloud_browser.py
@@ -477,6 +477,40 @@ async def test_agent_run_forwards_clear_chat(
 
 
 @pytest.mark.asyncio
+async def test_agent_run_forwards_test_mode(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pyfetch = AsyncMock(
+        side_effect=[
+            _FakeResponse(json_data={"requestId": "child-request-123"}),
+            _FakeResponse(
+                json_data={
+                    "status": "success",
+                    "response": {
+                        "text": "done",
+                        "output": {"type": "text", "content": "done"},
+                    },
+                    "completedAt": "2026-05-08T00:00:00+00:00",
+                    "usage": {"actions": 0, "credits": 0},
+                    "activeInputRequest": None,
+                }
+            ),
+        ]
+    )
+    narada_pkg, _ = _import_pyodide_narada(monkeypatch, pyfetch=pyfetch)
+
+    env = narada_pkg.RemoteBrowserEnvironment(
+        browser_window_id="browser-window-123",
+        cloud_browser_session_id="session-123",
+        api_key="test-api-key",
+    )
+    await narada_pkg.Agent(environment=env).run("automated eval", test=True)
+
+    payload = json.loads(pyfetch.await_args_list[0].kwargs["body"])
+    assert payload["test"] is True
+
+
+@pytest.mark.asyncio
 async def test_agent_run_exposes_workflow_trace_alias(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/packages/narada-pyodide/tests/test_cloud_browser.py
+++ b/packages/narada-pyodide/tests/test_cloud_browser.py
@@ -504,9 +504,12 @@ async def test_agent_run_forwards_test_mode(
         cloud_browser_session_id="session-123",
         api_key="test-api-key",
     )
-    await narada_pkg.Agent(environment=env).run("automated eval", test=True)
+    await narada_pkg.Agent(environment=env).run(
+        "/agentMaker repair workflow", test=True
+    )
 
     payload = json.loads(pyfetch.await_args_list[0].kwargs["body"])
+    assert payload["prompt"] == "/agentMaker repair workflow"
     assert payload["test"] is True
 
 

--- a/packages/narada/src/narada/agent.py
+++ b/packages/narada/src/narada/agent.py
@@ -103,6 +103,7 @@ class Agent(Generic[_StructuredOutput]):
         callback_headers: Mapping[str, Any] | None = None,
         on_input_required: InputRequiredCallback | None = None,
         critic: CriticConfig | None = None,
+        test: bool = False,
         timeout: int = 1000,
     ) -> AgentResponse[dict[str, Any]]: ...
 
@@ -129,6 +130,7 @@ class Agent(Generic[_StructuredOutput]):
         callback_headers: Mapping[str, Any] | None = None,
         on_input_required: InputRequiredCallback | None = None,
         critic: CriticConfig | None = None,
+        test: bool = False,
         timeout: int = 1000,
     ) -> AgentResponse[_StructuredOutput]: ...
 
@@ -154,6 +156,7 @@ class Agent(Generic[_StructuredOutput]):
         callback_headers: Mapping[str, Any] | None = None,
         on_input_required: InputRequiredCallback | None = None,
         critic: CriticConfig | None = None,
+        test: bool = False,
         timeout: int = 1000,
     ) -> AgentResponse:
         """Invokes an agent in the bound Narada environment."""
@@ -176,6 +179,7 @@ class Agent(Generic[_StructuredOutput]):
             callback_headers=callback_headers,
             on_input_required=on_input_required,
             reasoning=reasoning,
+            test=test,
             timeout=timeout,
         )
         response_content = remote_dispatch_response["response"]
@@ -240,6 +244,7 @@ class Agent(Generic[_StructuredOutput]):
         callback_headers: Mapping[str, Any] | None = None,
         on_input_required: InputRequiredCallback | None = None,
         critic_context: dict[str, Any] | None = None,
+        test: bool = False,
         timeout: int = 1000,
     ) -> Response:
         dispatch_agent = self.kind if agent is None else agent
@@ -268,6 +273,7 @@ class Agent(Generic[_StructuredOutput]):
                 callback_headers=callback_headers,
                 on_input_required=on_input_required,
                 critic_context=critic_context,
+                test=test,
                 timeout=timeout,
             )
         else:
@@ -304,6 +310,7 @@ class Agent(Generic[_StructuredOutput]):
                 callback_headers=callback_headers,
                 on_input_required=on_input_required,
                 critic_context=critic_context,
+                test=test,
                 timeout=timeout,
             )
         return remote_dispatch_response

--- a/packages/narada/src/narada/environment.py
+++ b/packages/narada/src/narada/environment.py
@@ -588,6 +588,7 @@ class Environment(ABC):
         callback_secret: str | None = None,
         callback_headers: Mapping[str, Any] | None = None,
         on_input_required: InputRequiredCallback | None = None,
+        test: bool = False,
         timeout: int = 1000,
     ) -> Response[None]: ...
 
@@ -614,6 +615,7 @@ class Environment(ABC):
         callback_secret: str | None = None,
         callback_headers: Mapping[str, Any] | None = None,
         on_input_required: InputRequiredCallback | None = None,
+        test: bool = False,
         timeout: int = 1000,
     ) -> Response[_StructuredOutput]: ...
 
@@ -640,6 +642,7 @@ class Environment(ABC):
         callback_secret: str | None = None,
         callback_headers: Mapping[str, Any] | None = None,
         on_input_required: InputRequiredCallback | None = None,
+        test: bool = False,
         timeout: int = 1000,
     ) -> Response[None]: ...
 
@@ -666,6 +669,7 @@ class Environment(ABC):
         callback_secret: str | None = None,
         callback_headers: Mapping[str, Any] | None = None,
         on_input_required: InputRequiredCallback | None = None,
+        test: bool = False,
         timeout: int = 1000,
     ) -> Response[_StructuredOutput]: ...
 
@@ -692,6 +696,7 @@ class Environment(ABC):
         callback_secret: str | None = None,
         callback_headers: Mapping[str, Any] | None = None,
         on_input_required: InputRequiredCallback | None = None,
+        test: bool = False,
         timeout: int = 1000,
     ) -> Response:
         """Low-level API for invoking an agent in the Narada extension side panel chat.
@@ -768,6 +773,8 @@ class Environment(ABC):
             body["callbackHeaders"] = callback_headers
         if reasoning is not None:
             body["reasoningMode"] = reasoning.value
+        if test:
+            body["test"] = True
 
         try:
             seen_input_ids: set[str] = set()

--- a/packages/narada/src/narada/environment.py
+++ b/packages/narada/src/narada/environment.py
@@ -715,9 +715,12 @@ class Environment(ABC):
             )
         deadline = time.monotonic() + timeout
 
-        agent_prefix = (
-            agent.prompt_prefix() if isinstance(agent, AgentKind) else f"{agent} "
-        )
+        if isinstance(agent, AgentKind):
+            agent_prefix = (
+                "" if prompt.lstrip().startswith("/") else agent.prompt_prefix()
+            )
+        else:
+            agent_prefix = f"{agent} "
         body: dict[str, Any] = {
             "prompt": agent_prefix + prompt,
             "timeZone": time_zone,

--- a/packages/narada/tests/test_agent.py
+++ b/packages/narada/tests/test_agent.py
@@ -135,6 +135,7 @@ async def test_agent_run_forwards_test_mode(
     env = _CountingEnvironment()
     agent = Agent(environment=env)
 
-    await agent.run("automated eval", test=True)
+    await agent.run("/agentMaker repair workflow", test=True)
 
+    assert fake_session.dispatched_bodies[0]["prompt"] == "/agentMaker repair workflow"
     assert fake_session.dispatched_bodies[0]["test"] is True

--- a/packages/narada/tests/test_agent.py
+++ b/packages/narada/tests/test_agent.py
@@ -119,3 +119,22 @@ async def test_agent_run_forwards_clear_chat(
     await agent.run("fresh task", clear_chat=True)
 
     assert fake_session.dispatched_bodies[0]["clearChat"] is True
+
+
+@pytest.mark.asyncio
+async def test_agent_run_forwards_test_mode(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import narada.environment as environment_module
+
+    fake_session = _RemoteDispatchFakeClientSession()
+    monkeypatch.setattr(
+        environment_module.aiohttp, "ClientSession", lambda: fake_session
+    )
+
+    env = _CountingEnvironment()
+    agent = Agent(environment=env)
+
+    await agent.run("automated eval", test=True)
+
+    assert fake_session.dispatched_bodies[0]["test"] is True


### PR DESCRIPTION
# Changes

- Add `test` to the environment-based `Agent.run` and dispatch APIs.
- Forward test mode through both CPython and Pyodide clients.
- Add regression coverage for the remote-dispatch payload in both SDK variants.

# Testing

- GitHub Actions format, architecture freshness, and CodeQL checks.
