### PR TITLE
Add save_pdf_file SDK action

### DIFF
--- a/packages/narada-core/src/narada_core/actions/models.py
+++ b/packages/narada-core/src/narada_core/actions/models.py
@@ -393,6 +393,17 @@ class GetSimplifiedHtmlResponse(BaseModel):
     html: str
 
 
+class GetFileRequest(BaseModel):
+    name: Literal["get_file"] = "get_file"
+
+
+class GetFileResponse(BaseModel):
+    base64_content: str = Field(exclude=True)
+    name: str
+    mime_type: str
+    timestamp: str
+
+
 class GetScreenshotRequest(BaseModel):
     name: Literal["get_screenshot"] = "get_screenshot"
 
@@ -489,6 +500,7 @@ type ExtensionActionRequest = (
     | AgenticSelectorRequest
     | CloseWindowRequest
     | ExecuteJavaScriptOnPageRequest
+    | GetFileRequest
     | GetFullHtmlRequest
     | GetScreenshotRequest
     | GetSimplifiedHtmlRequest

--- a/packages/narada-core/src/narada_core/actions/models.py
+++ b/packages/narada-core/src/narada_core/actions/models.py
@@ -393,11 +393,11 @@ class GetSimplifiedHtmlResponse(BaseModel):
     html: str
 
 
-class GetFileRequest(BaseModel):
-    name: Literal["get_file"] = "get_file"
+class SavePdfFileRequest(BaseModel):
+    name: Literal["save_pdf_file"] = "save_pdf_file"
 
 
-class GetFileResponse(BaseModel):
+class SavePdfFileResponse(BaseModel):
     base64_content: str = Field(exclude=True)
     name: str
     mime_type: str
@@ -500,7 +500,7 @@ type ExtensionActionRequest = (
     | AgenticSelectorRequest
     | CloseWindowRequest
     | ExecuteJavaScriptOnPageRequest
-    | GetFileRequest
+    | SavePdfFileRequest
     | GetFullHtmlRequest
     | GetScreenshotRequest
     | GetSimplifiedHtmlRequest

--- a/packages/narada-pyodide/src/narada/agent.py
+++ b/packages/narada-pyodide/src/narada/agent.py
@@ -18,6 +18,8 @@ from narada_core.actions.models import (
     CriticResult,
     ExecuteJavaScriptOnPageRequest,
     ExecuteJavaScriptOnPageResponse,
+    GetFileRequest,
+    GetFileResponse,
     GetFullHtmlRequest,
     GetFullHtmlResponse,
     GetScreenshotRequest,
@@ -28,9 +30,9 @@ from narada_core.actions.models import (
     GetUrlResponse,
     GoToUrlRequest,
     JsonValue,
-    PrintMessageRequest,
     PressKeyEventItem,
     PressKeyRequest,
+    PrintMessageRequest,
     PromptForUserInputRequest,
     PromptForUserInputResponse,
     PromptForUserInputVariable,
@@ -594,6 +596,14 @@ class Agent(Generic[_StructuredOutput]):
         return await self._browser_environment()._run_extension_action(
             GetSimplifiedHtmlRequest(),
             GetSimplifiedHtmlResponse,
+            timeout=timeout,
+        )
+
+    async def get_file(self, *, timeout: int | None = None) -> GetFileResponse:
+        """Gets the PDF file displayed in the current browser page."""
+        return await self._browser_environment()._run_extension_action(
+            GetFileRequest(),
+            GetFileResponse,
             timeout=timeout,
         )
 

--- a/packages/narada-pyodide/src/narada/agent.py
+++ b/packages/narada-pyodide/src/narada/agent.py
@@ -18,8 +18,6 @@ from narada_core.actions.models import (
     CriticResult,
     ExecuteJavaScriptOnPageRequest,
     ExecuteJavaScriptOnPageResponse,
-    GetFileRequest,
-    GetFileResponse,
     GetFullHtmlRequest,
     GetFullHtmlResponse,
     GetScreenshotRequest,
@@ -41,6 +39,8 @@ from narada_core.actions.models import (
     ReadGoogleSheetRequest,
     ReadGoogleSheetResponse,
     RecordedClick,
+    SavePdfFileRequest,
+    SavePdfFileResponse,
     UserApprovalRequest,
     UserApprovalResponse,
     WaitForElementRequest,
@@ -599,11 +599,11 @@ class Agent(Generic[_StructuredOutput]):
             timeout=timeout,
         )
 
-    async def get_file(self, *, timeout: int | None = None) -> GetFileResponse:
-        """Gets the PDF file displayed in the current browser page."""
+    async def save_pdf_file(self, *, timeout: int | None = None) -> SavePdfFileResponse:
+        """Saves the PDF file displayed in the current browser page."""
         return await self._browser_environment()._run_extension_action(
-            GetFileRequest(),
-            GetFileResponse,
+            SavePdfFileRequest(),
+            SavePdfFileResponse,
             timeout=timeout,
         )
 

--- a/packages/narada/src/narada/agent.py
+++ b/packages/narada/src/narada/agent.py
@@ -18,8 +18,6 @@ from narada_core.actions.models import (
     CriticResult,
     ExecuteJavaScriptOnPageRequest,
     ExecuteJavaScriptOnPageResponse,
-    GetFileRequest,
-    GetFileResponse,
     GetFullHtmlRequest,
     GetFullHtmlResponse,
     GetScreenshotRequest,
@@ -41,6 +39,8 @@ from narada_core.actions.models import (
     ReadGoogleSheetRequest,
     ReadGoogleSheetResponse,
     RecordedClick,
+    SavePdfFileRequest,
+    SavePdfFileResponse,
     UserApprovalRequest,
     UserApprovalResponse,
     WaitForElementRequest,
@@ -586,11 +586,11 @@ class Agent(Generic[_StructuredOutput]):
             timeout=timeout,
         )
 
-    async def get_file(self, *, timeout: int | None = None) -> GetFileResponse:
-        """Gets the PDF file displayed in the current browser page."""
+    async def save_pdf_file(self, *, timeout: int | None = None) -> SavePdfFileResponse:
+        """Saves the PDF file displayed in the current browser page."""
         return await self._browser_environment()._run_extension_action(
-            GetFileRequest(),
-            GetFileResponse,
+            SavePdfFileRequest(),
+            SavePdfFileResponse,
             timeout=timeout,
         )
 

--- a/packages/narada/src/narada/agent.py
+++ b/packages/narada/src/narada/agent.py
@@ -18,6 +18,8 @@ from narada_core.actions.models import (
     CriticResult,
     ExecuteJavaScriptOnPageRequest,
     ExecuteJavaScriptOnPageResponse,
+    GetFileRequest,
+    GetFileResponse,
     GetFullHtmlRequest,
     GetFullHtmlResponse,
     GetScreenshotRequest,
@@ -28,9 +30,9 @@ from narada_core.actions.models import (
     GetUrlResponse,
     GoToUrlRequest,
     JsonValue,
-    PrintMessageRequest,
     PressKeyEventItem,
     PressKeyRequest,
+    PrintMessageRequest,
     PromptForUserInputRequest,
     PromptForUserInputResponse,
     PromptForUserInputVariable,
@@ -581,6 +583,14 @@ class Agent(Generic[_StructuredOutput]):
         return await self._browser_environment()._run_extension_action(
             GetSimplifiedHtmlRequest(),
             GetSimplifiedHtmlResponse,
+            timeout=timeout,
+        )
+
+    async def get_file(self, *, timeout: int | None = None) -> GetFileResponse:
+        """Gets the PDF file displayed in the current browser page."""
+        return await self._browser_environment()._run_extension_action(
+            GetFileRequest(),
+            GetFileResponse,
             timeout=timeout,
         )
 

--- a/packages/narada/tests/test_window_human_interaction.py
+++ b/packages/narada/tests/test_window_human_interaction.py
@@ -143,7 +143,7 @@ async def test_execute_javascript_on_page_dispatches_extension_action(
 
 
 @pytest.mark.asyncio
-async def test_get_file_dispatches_extension_action(
+async def test_save_pdf_file_dispatches_extension_action(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     fake_session = _FakeSession(
@@ -163,10 +163,10 @@ async def test_get_file_dispatches_extension_action(
         )
     )
 
-    result = await agent.get_file()
+    result = await agent.save_pdf_file()
 
     assert result.name == "invoice.pdf"
     assert result.mime_type == "application/pdf"
     assert result.base64_content == "JVBERi0xLjQ="
     assert "base64_content" not in result.model_dump()
-    assert fake_session.post_bodies[0]["action"] == {"name": "get_file"}
+    assert fake_session.post_bodies[0]["action"] == {"name": "save_pdf_file"}

--- a/packages/narada/tests/test_window_human_interaction.py
+++ b/packages/narada/tests/test_window_human_interaction.py
@@ -140,3 +140,33 @@ async def test_execute_javascript_on_page_dispatches_extension_action(
         "name": "execute_javascript_on_page",
         "code": "(() => ({ title: document.title, count: 3 }))()",
     }
+
+
+@pytest.mark.asyncio
+async def test_get_file_dispatches_extension_action(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_session = _FakeSession(
+        [
+            {
+                "status": "success",
+                "data": '{"base64_content":"JVBERi0xLjQ=","name":"invoice.pdf","mime_type":"application/pdf","timestamp":"2026-06-22T00:00:00.000Z"}',
+            }
+        ]
+    )
+    monkeypatch.setattr(
+        "narada.environment.aiohttp.ClientSession", lambda: fake_session
+    )
+    agent = Agent(
+        environment=RemoteBrowserEnvironment(
+            browser_window_id="bw-1", api_key="test-key"
+        )
+    )
+
+    result = await agent.get_file()
+
+    assert result.name == "invoice.pdf"
+    assert result.mime_type == "application/pdf"
+    assert result.base64_content == "JVBERi0xLjQ="
+    assert "base64_content" not in result.model_dump()
+    assert fake_session.post_bodies[0]["action"] == {"name": "get_file"}


### PR DESCRIPTION
Adds agent.save_pdf_file() and the save_pdf_file request/response models for the normal and Pyodide SDKs. The response exposes PDF bytes to callers but excludes base64_content from model dumps so traces do not persist full PDFs.\n\nValidation: uv run pytest packages/narada/tests/test_window_human_interaction.py::test_save_pdf_file_dispatches_extension_action; ruff check on touched files.