### PR TITLE
Volodymyr/three retries for initialization

### DIFF
--- a/packages/narada/pyproject.toml
+++ b/packages/narada/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "narada"
-version = "0.2.2"
+version = "0.2.3a"
 description = "Python client SDK for Narada"
 license = "Apache-2.0"
 readme = "README.md"

--- a/packages/narada/src/narada/environment.py
+++ b/packages/narada/src/narada/environment.py
@@ -74,6 +74,7 @@ from playwright.async_api import TimeoutError as PlaywrightTimeoutError
 from playwright.async_api._context_manager import PlaywrightContextManager
 from pydantic import BaseModel, ValidationError
 from rich.console import Console
+import random
 
 from narada.config import BrowserConfig, ProxyConfig
 from narada.utils import assert_never, assert_not_none
@@ -1523,41 +1524,49 @@ class CloudBrowserEnvironment(BaseBrowserEnvironment):
         login_url = response_data["login_url"]
         cdp_auth_headers = response_data["cdp_auth_headers"]
 
-        # Connect to browser via CDP with authentication headers and log the user in.
-        try:
-            await self._initialize_cloud_browser_window(
-                cdp_websocket_url=cdp_websocket_url,
-                session_id=session_id,
-                login_url=login_url,
-                cdp_auth_headers=cdp_auth_headers,
-            )
-        except Exception:
-            # Clean up the session if CDP connection fails
+        max_attempts = 3
+        for attempt in range(max_attempts):
             try:
-                async with aiohttp.ClientSession() as cleanup_session:
-                    async with cleanup_session.post(
-                        f"{self._base_url}/cloud-browser/stop-cloud-browser-session",
-                        headers=self._auth_headers,
-                        json={"session_id": session_id, "status": "failed"},
-                        timeout=aiohttp.ClientTimeout(total=10),
-                    ) as resp:
-                        if resp.ok:
-                            logging.info(
-                                "Cleaned up session %s after CDP connection failure",
-                                session_id,
-                            )
-                        else:
-                            logging.warning(
-                                "Failed to cleanup session %s: %s",
-                                session_id,
-                                resp.status,
-                            )
-            except Exception as cleanup_error:
-                logging.warning(
-                    "Error cleaning up session %s: %s", session_id, cleanup_error
+                # Connect to browser via CDP with authentication headers and log the user in.
+                # Due to unknown network issues, sometimes initialization fails
+                await self._initialize_cloud_browser_window(
+                    cdp_websocket_url=cdp_websocket_url,
+                    session_id=session_id,
+                    login_url=login_url,
+                    cdp_auth_headers=cdp_auth_headers,
                 )
-            # Re-raise the original connection error
-            raise
+            except Exception:
+                # Retry if max attempts hasn't been reached yet
+                if attempt < max_attempts - 1:
+                    retry_backoff_with_jitter = random.uniform(1, 4)
+                    await asyncio.sleep(retry_backoff_seconds[attempt])
+                    continue
+                # Clean up the session if CDP connection fails after multiple attempts
+                try:
+                    async with aiohttp.ClientSession() as cleanup_session:
+                        async with cleanup_session.post(
+                            f"{self._base_url}/cloud-browser/stop-cloud-browser-session",
+                            headers=self._auth_headers,
+                            json={"session_id": session_id, "status": "failed"},
+                            timeout=aiohttp.ClientTimeout(total=10),
+                        ) as resp:
+                            if resp.ok:
+                                logging.info(
+                                    "Cleaned up session %s after CDP connection failure",
+                                    session_id,
+                                )
+                            else:
+                                logging.warning(
+                                    "Failed to cleanup session %s: %s",
+                                    session_id,
+                                    resp.status,
+                                )
+                except Exception as cleanup_error:
+                    logging.warning(
+                        "Error cleaning up session %s: %s after %s retries", session_id, cleanup_error, max_attempts
+                    )
+                # Re-raise the original connection error
+                raise
 
     async def _start_playwright(self) -> None:
         self._playwright_context_manager = async_playwright()

--- a/packages/narada/src/narada/environment.py
+++ b/packages/narada/src/narada/environment.py
@@ -1478,14 +1478,31 @@ class CloudBrowserEnvironment(BaseBrowserEnvironment):
 
     async def _initialize(self) -> None:
         """Create a cloud browser session and initialize the browser extension.
+        Retry up to 3 times on error.
 
         Calls ``POST /cloud-browser/create-cloud-browser-session``, then connects local
         Playwright over CDP, opens ``login_url``, and waits for
         ``#narada-browser-window-id`` (extension install retries apply). ``config`` controls
         interactive prompts and related behavior.
         """
-        await self._start_playwright()
+        max_attempts = 3
+        for attempt in range(max_attempts):
+            try:
+                await self._initialize_once()
+                return
+            except Exception as error:
+                await self._cleanup_failed_initialization_attempt()
+                if (
+                    attempt == max_attempts - 1
+                    or self._is_non_retryable_initialization_error(error)
+                ):
+                    raise
 
+                retry_backoff_with_jitter = attempt * 2 + 2 + random.uniform(0, 1)
+                await asyncio.sleep(retry_backoff_with_jitter)
+
+    async def _initialize_once(self) -> None:
+        await self._start_playwright()
         request_body = {
             "require_extension": True,
             "session_name": self._session_name,
@@ -1504,81 +1521,63 @@ class CloudBrowserEnvironment(BaseBrowserEnvironment):
             ) as resp:
                 if not resp.ok:
                     error_text = await resp.text()
-                    if resp.status == HTTPStatus.FORBIDDEN:
-                        error = ApiErrorPayload.from_error_text(error_text)
-                        err = RuntimeError(
-                            f"Failed to create cloud browser session: {resp.status} {error_text}\n"
-                            f"Endpoint URL: {endpoint_url}"
-                        )
-                        err.status_code = resp.status  # type: ignore[attr-defined]
-                        err.detail = error.detail  # type: ignore[attr-defined]
-                        raise err
-                    raise RuntimeError(
+                    err = RuntimeError(
                         f"Failed to create cloud browser session: {resp.status} {error_text}\n"
                         f"Endpoint URL: {endpoint_url}"
                     )
+                    err.status_code = resp.status  # type: ignore[attr-defined]
+                    if resp.status == HTTPStatus.FORBIDDEN:
+                        error = ApiErrorPayload.from_error_text(error_text)
+                        err.detail = error.detail  # type: ignore[attr-defined]
+                    raise err
                 response_data = await resp.json()
 
         cdp_websocket_url = response_data["cdp_websocket_url"]
         session_id = response_data["session_id"]
         login_url = response_data["login_url"]
         cdp_auth_headers = response_data["cdp_auth_headers"]
+        self._session_id = session_id
 
-        max_attempts = 3
-        for attempt in range(max_attempts):
+        # Connect to browser via CDP with authentication headers and log the user in.
+        await self._initialize_cloud_browser_window(
+            cdp_websocket_url=cdp_websocket_url,
+            session_id=session_id,
+            login_url=login_url,
+            cdp_auth_headers=cdp_auth_headers,
+        )
+
+    @staticmethod
+    def _is_non_retryable_initialization_error(error: Exception) -> bool:
+        status_code = getattr(error, "status_code", None)
+        return isinstance(status_code, int) and 400 <= status_code < 500
+
+    async def _cleanup_failed_initialization_attempt(self) -> None:
+        if self._session_id is not None:
             try:
-                # Connect to browser via CDP with authentication headers and log the user in.
-                # Due to unknown network issues, sometimes initialization fails
-                await self._initialize_cloud_browser_window(
-                    cdp_websocket_url=cdp_websocket_url,
-                    session_id=session_id,
-                    login_url=login_url,
-                    cdp_auth_headers=cdp_auth_headers,
+                await _stop_cloud_browser_session(
+                    base_url=self._base_url,
+                    auth_headers=self._auth_headers,
+                    session_id=self._session_id,
+                    status="failed",
+                    timeout=10,
                 )
-                break
             except Exception:
-                # Retry if max attempts hasn't been reached yet
-                if attempt < max_attempts - 1:
-                    retry_backoff_with_jitter = attempt * 2 + 2 + random.uniform(0, 1)
-                    await asyncio.sleep(retry_backoff_with_jitter)
-                    continue
-                # Clean up the session if CDP connection fails after multiple attempts
-                try:
-                    async with aiohttp.ClientSession() as cleanup_session:
-                        async with cleanup_session.post(
-                            f"{self._base_url}/cloud-browser/stop-cloud-browser-session",
-                            headers=self._auth_headers,
-                            json={"session_id": session_id, "status": "failed"},
-                            timeout=aiohttp.ClientTimeout(total=10),
-                        ) as resp:
-                            if resp.ok:
-                                logging.info(
-                                    "Cleaned up session %s after CDP connection failure",
-                                    session_id,
-                                )
-                            else:
-                                logging.warning(
-                                    "Failed to cleanup session %s: %s",
-                                    session_id,
-                                    resp.status,
-                                )
-                except Exception as cleanup_error:
-                    logging.error(
-                        "Error cleaning up session %s (%s): %s after %s init attempts",
-                        session_id,
-                        self._session_name,
-                        cleanup_error,
-                        max_attempts,
-                    )
-                try:
-                    await self._stop_playwright()
-                except Exception as playwright_cleanup_error:
-                    logging.warning(
-                        "Error stopping Playwright after failed cloud browser initialization: %s",
-                        playwright_cleanup_error,
-                    )
-                # Re-raise the original connection error
-                raise
+                logger.exception(
+                    "Error cleaning up session %s (%s) after failed initialization",
+                    self._session_id,
+                    self._session_name,
+                )
+
+        try:
+            await self._stop_playwright()
+        except Exception:
+            logger.exception(
+                "Error stopping Playwright after failed cloud browser initialization"
+            )
+        finally:
+            self._session_id = None
+            self._browser_window_id = None
+            self._context = None
 
     async def _start_playwright(self) -> None:
         self._playwright_context_manager = async_playwright()
@@ -1895,6 +1894,7 @@ async def _stop_cloud_browser_session(
     base_url: str,
     auth_headers: dict[str, str],
     session_id: str,
+    status: Literal["complete", "terminated", "failed", "timed_out"] = "complete",
     timeout: int | None = None,
 ) -> None:
     try:
@@ -1902,7 +1902,7 @@ async def _stop_cloud_browser_session(
             async with session.post(
                 f"{base_url}/cloud-browser/stop-cloud-browser-session",
                 headers=auth_headers,
-                json={"session_id": session_id},
+                json={"session_id": session_id, "status": status},
                 timeout=aiohttp.ClientTimeout(total=timeout or 40),
             ) as resp:
                 if resp.ok:

--- a/packages/narada/src/narada/environment.py
+++ b/packages/narada/src/narada/environment.py
@@ -6,6 +6,7 @@ import json
 import logging
 import mimetypes
 import os
+import random
 import subprocess
 import sys
 import time
@@ -74,7 +75,6 @@ from playwright.async_api import TimeoutError as PlaywrightTimeoutError
 from playwright.async_api._context_manager import PlaywrightContextManager
 from pydantic import BaseModel, ValidationError
 from rich.console import Console
-import random
 
 from narada.config import BrowserConfig, ProxyConfig
 from narada.utils import assert_never, assert_not_none
@@ -1564,7 +1564,10 @@ class CloudBrowserEnvironment(BaseBrowserEnvironment):
                                 )
                 except Exception as cleanup_error:
                     logging.error(
-                        "Error cleaning up session %s: %s after %s retries", session_id, cleanup_error, max_attempts
+                        "Error cleaning up session %s: %s after %s retries",
+                        session_id,
+                        cleanup_error,
+                        max_attempts,
                     )
                 try:
                     await self._stop_playwright()

--- a/packages/narada/src/narada/environment.py
+++ b/packages/narada/src/narada/environment.py
@@ -1525,6 +1525,7 @@ class CloudBrowserEnvironment(BaseBrowserEnvironment):
         cdp_auth_headers = response_data["cdp_auth_headers"]
 
         max_attempts = 3
+        retry_base_backoff_seconds = (2.0, 4.0, 0.0)  # no wait after last attempt
         for attempt in range(max_attempts):
             try:
                 # Connect to browser via CDP with authentication headers and log the user in.
@@ -1535,12 +1536,12 @@ class CloudBrowserEnvironment(BaseBrowserEnvironment):
                     login_url=login_url,
                     cdp_auth_headers=cdp_auth_headers,
                 )
-                break  # stop retrying if an error wast raised
+                break
             except Exception:
                 # Retry if max attempts hasn't been reached yet
                 if attempt < max_attempts - 1:
-                    retry_backoff_with_jitter = random.uniform(1, 4)
-                    await asyncio.sleep(retry_backoff_with_jitter)
+                    sleep_time = retry_base_backoff_seconds[attempt] + random.uniform(0, 1)  # add jitter
+                    await asyncio.sleep(sleep_time)
                     continue
                 # Clean up the session if CDP connection fails after multiple attempts
                 try:

--- a/packages/narada/src/narada/environment.py
+++ b/packages/narada/src/narada/environment.py
@@ -1563,8 +1563,15 @@ class CloudBrowserEnvironment(BaseBrowserEnvironment):
                                     resp.status,
                                 )
                 except Exception as cleanup_error:
-                    logging.warning(
+                    logging.error(
                         "Error cleaning up session %s: %s after %s retries", session_id, cleanup_error, max_attempts
+                    )
+                try:
+                    await self._stop_playwright()
+                except Exception as playwright_cleanup_error:
+                    logging.warning(
+                        "Error stopping Playwright after failed cloud browser initialization: %s",
+                        playwright_cleanup_error,
                     )
                 # Re-raise the original connection error
                 raise

--- a/packages/narada/src/narada/environment.py
+++ b/packages/narada/src/narada/environment.py
@@ -1498,7 +1498,7 @@ class CloudBrowserEnvironment(BaseBrowserEnvironment):
                 ):
                     raise
 
-                retry_backoff_with_jitter = attempt * 2 + 2 + random.uniform(0, 1)
+                retry_backoff_with_jitter = 2 ** (attempt + 1) + random.uniform(0, 1)
                 await asyncio.sleep(retry_backoff_with_jitter)
 
     async def _initialize_once(self) -> None:

--- a/packages/narada/src/narada/environment.py
+++ b/packages/narada/src/narada/environment.py
@@ -1525,7 +1525,6 @@ class CloudBrowserEnvironment(BaseBrowserEnvironment):
         cdp_auth_headers = response_data["cdp_auth_headers"]
 
         max_attempts = 3
-        retry_base_backoff_seconds = (2.0, 4.0, 0.0)  # no wait after last attempt
         for attempt in range(max_attempts):
             try:
                 # Connect to browser via CDP with authentication headers and log the user in.
@@ -1540,8 +1539,8 @@ class CloudBrowserEnvironment(BaseBrowserEnvironment):
             except Exception:
                 # Retry if max attempts hasn't been reached yet
                 if attempt < max_attempts - 1:
-                    sleep_time = retry_base_backoff_seconds[attempt] + random.uniform(0, 1)  # add jitter
-                    await asyncio.sleep(sleep_time)
+                    retry_backoff_with_jitter = attempt * 2 + 2 + random.uniform(0, 1)
+                    await asyncio.sleep(retry_backoff_with_jitter)
                     continue
                 # Clean up the session if CDP connection fails after multiple attempts
                 try:

--- a/packages/narada/src/narada/environment.py
+++ b/packages/narada/src/narada/environment.py
@@ -1564,8 +1564,9 @@ class CloudBrowserEnvironment(BaseBrowserEnvironment):
                                 )
                 except Exception as cleanup_error:
                     logging.error(
-                        "Error cleaning up session %s: %s after %s retries",
+                        "Error cleaning up session %s (%s): %s after %s init attempts",
                         session_id,
+                        self._session_name,
                         cleanup_error,
                         max_attempts,
                     )

--- a/packages/narada/src/narada/environment.py
+++ b/packages/narada/src/narada/environment.py
@@ -1535,11 +1535,12 @@ class CloudBrowserEnvironment(BaseBrowserEnvironment):
                     login_url=login_url,
                     cdp_auth_headers=cdp_auth_headers,
                 )
+                break  # stop retrying if an error wast raised
             except Exception:
                 # Retry if max attempts hasn't been reached yet
                 if attempt < max_attempts - 1:
                     retry_backoff_with_jitter = random.uniform(1, 4)
-                    await asyncio.sleep(retry_backoff_seconds[attempt])
+                    await asyncio.sleep(retry_backoff_with_jitter)
                     continue
                 # Clean up the session if CDP connection fails after multiple attempts
                 try:

--- a/uv.lock
+++ b/uv.lock
@@ -312,7 +312,7 @@ wheels = [
 
 [[package]]
 name = "narada"
-version = "0.2.2"
+version = "0.2.3a"
 source = { editable = "packages/narada" }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
This PR refactors SDK-owned `CloudBrowserEnvironment` startup so retries now wrap the entire initialization attempt, including Playwright startup, cloud browser session creation, and CDP/browser-window initialization. Failed attempts clean up any created cloud session as `failed`, stop local Playwright, reset partial state, and retry with backoff plus jitter; non-retryable 4xx creation errors fail immediately after cleanup. It also extends the cloud-session stop helper to accept a status and adds focused tests for fresh-session retries, create failures, 4xx no-retry behavior, repeated cleanup, and cleanup errors preserving the original initialization failure.