### PR TITLE
Use DOM observer for browser window ID wait

### DIFF
--- a/packages/narada/pyproject.toml
+++ b/packages/narada/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "narada"
-version = "0.2.3"
+version = "0.2.4a1"
 description = "Python client SDK for Narada"
 license = "Apache-2.0"
 readme = "README.md"

--- a/packages/narada/src/narada/environment.py
+++ b/packages/narada/src/narada/environment.py
@@ -162,7 +162,6 @@ def _build_browser_window_id_observer_script() -> str:
             version: 3,
             result: null,
             observer: null,
-            intervalId: null,
             resolved: false,
             disposed: false,
             resolve: null,
@@ -175,10 +174,6 @@ def _build_browser_window_id_observer_script() -> str:
             if (state.observer !== null) {
               state.observer.disconnect();
               state.observer = null;
-            }
-            if (state.intervalId !== null) {
-              clearInterval(state.intervalId);
-              state.intervalId = null;
             }
           }
 
@@ -263,7 +258,6 @@ def _build_browser_window_id_observer_script() -> str:
               subtree: true,
               characterData: true,
             });
-            state.intervalId = window.setInterval(finishIfReady, 50);
           }
 
           if (document.documentElement !== null) {

--- a/packages/narada/src/narada/environment.py
+++ b/packages/narada/src/narada/environment.py
@@ -96,6 +96,7 @@ _EXTENSION_MISSING_INDICATOR_SELECTOR = "#narada-extension-missing"
 _EXTENSION_UNAUTHENTICATED_INDICATOR_SELECTOR = "#narada-extension-unauthenticated"
 _INITIALIZATION_ERROR_INDICATOR_SELECTOR = "#narada-initialization-error"
 _BROWSER_WINDOW_ID_OBSERVER_KEY = "narada.sdk.browserWindowIdObserver"
+_BROWSER_WINDOW_ID_OBSERVER_LEGACY_GLOBAL = "__naradaBrowserWindowIdObserver"
 
 
 type _BrowserInitializationResultType = Literal[
@@ -140,15 +141,20 @@ def _build_browser_window_id_observer_script() -> str:
 
           const targets = __TARGETS__;
           const globalSymbol = Symbol.for(__GLOBAL_KEY__);
+          const legacyGlobalKey = __LEGACY_GLOBAL_KEY__;
+          const legacyState = window[legacyGlobalKey];
+          if (legacyState !== undefined) {
+            cleanupPreviousState(legacyState);
+            delete window[legacyGlobalKey];
+          }
+
           const existingState = window[globalSymbol];
           if (existingState?.version === 3) {
             return;
           }
-          if (existingState?.version === 2) {
-            existingState.observer?.disconnect();
-            if (existingState.intervalId !== null && existingState.intervalId !== undefined) {
-              clearInterval(existingState.intervalId);
-            }
+
+          if (existingState !== undefined) {
+            cleanupPreviousState(existingState);
             delete window[globalSymbol];
           }
 
@@ -173,6 +179,17 @@ def _build_browser_window_id_observer_script() -> str:
             if (state.intervalId !== null) {
               clearInterval(state.intervalId);
               state.intervalId = null;
+            }
+          }
+
+          function cleanupPreviousState(previousState) {
+            previousState?.dispose?.();
+            previousState?.observer?.disconnect?.();
+            if (
+              previousState?.intervalId !== null
+              && previousState?.intervalId !== undefined
+            ) {
+              clearInterval(previousState.intervalId);
             }
           }
 
@@ -256,8 +273,13 @@ def _build_browser_window_id_observer_script() -> str:
           }
         })();
     """
-    return script.replace("__TARGETS__", json.dumps(targets)).replace(
-        "__GLOBAL_KEY__", json.dumps(_BROWSER_WINDOW_ID_OBSERVER_KEY)
+    return (
+        script.replace("__TARGETS__", json.dumps(targets))
+        .replace("__GLOBAL_KEY__", json.dumps(_BROWSER_WINDOW_ID_OBSERVER_KEY))
+        .replace(
+            "__LEGACY_GLOBAL_KEY__",
+            json.dumps(_BROWSER_WINDOW_ID_OBSERVER_LEGACY_GLOBAL),
+        )
     )
 
 

--- a/packages/narada/src/narada/environment.py
+++ b/packages/narada/src/narada/environment.py
@@ -66,18 +66,16 @@ from playwright.async_api import (
     Browser,
     BrowserContext,
     CDPSession,
-    ElementHandle,
     Page,
     Playwright,
     async_playwright,
 )
-from playwright.async_api import TimeoutError as PlaywrightTimeoutError
 from playwright.async_api._context_manager import PlaywrightContextManager
 from pydantic import BaseModel, ValidationError
 from rich.console import Console
 
 from narada.config import BrowserConfig, ProxyConfig
-from narada.utils import assert_never, assert_not_none
+from narada.utils import assert_not_none
 from narada.version import __version__
 
 logger = logging.getLogger(__name__)
@@ -97,6 +95,146 @@ _UNSUPPORTED_BROWSER_INDICATOR_SELECTOR = "#narada-unsupported-browser"
 _EXTENSION_MISSING_INDICATOR_SELECTOR = "#narada-extension-missing"
 _EXTENSION_UNAUTHENTICATED_INDICATOR_SELECTOR = "#narada-extension-unauthenticated"
 _INITIALIZATION_ERROR_INDICATOR_SELECTOR = "#narada-initialization-error"
+_BROWSER_WINDOW_ID_OBSERVER_GLOBAL = "__naradaBrowserWindowIdObserver"
+
+
+type _BrowserInitializationResultType = Literal[
+    "browser_window_id",
+    "unsupported_browser",
+    "extension_missing",
+    "extension_unauthenticated",
+    "initialization_error",
+]
+
+
+class _BrowserInitializationResult(TypedDict, total=False):
+    type: _BrowserInitializationResultType
+    browserWindowId: str
+
+
+def _build_browser_window_id_observer_script() -> str:
+    targets = [
+        {"type": "browser_window_id", "selector": _BROWSER_WINDOW_ID_SELECTOR},
+        {
+            "type": "unsupported_browser",
+            "selector": _UNSUPPORTED_BROWSER_INDICATOR_SELECTOR,
+        },
+        {
+            "type": "extension_missing",
+            "selector": _EXTENSION_MISSING_INDICATOR_SELECTOR,
+        },
+        {
+            "type": "extension_unauthenticated",
+            "selector": _EXTENSION_UNAUTHENTICATED_INDICATOR_SELECTOR,
+        },
+        {
+            "type": "initialization_error",
+            "selector": _INITIALIZATION_ERROR_INDICATOR_SELECTOR,
+        },
+    ]
+    script = """
+        (() => {
+          const targets = __TARGETS__;
+          const globalKey = __GLOBAL_KEY__;
+          const existingState = window[globalKey];
+          if (existingState?.version === 2) {
+            return;
+          }
+          existingState?.observer?.disconnect();
+          if (existingState?.intervalId !== null && existingState?.intervalId !== undefined) {
+            clearInterval(existingState.intervalId);
+          }
+
+          const state = {
+            version: 2,
+            result: null,
+            observer: null,
+            intervalId: null,
+            resolved: false,
+            resolve: null,
+            promise: null,
+            readInitializationResult: null,
+          };
+
+          function cleanup() {
+            if (state.observer !== null) {
+              state.observer.disconnect();
+              state.observer = null;
+            }
+            if (state.intervalId !== null) {
+              clearInterval(state.intervalId);
+              state.intervalId = null;
+            }
+          }
+
+          function readInitializationResult() {
+            for (const target of targets) {
+              const element = document.querySelector(target.selector);
+              if (element === null) {
+                continue;
+              }
+
+              if (target.type !== 'browser_window_id') {
+                return { type: target.type };
+              }
+
+              const browserWindowId = element.textContent?.trim();
+              if (browserWindowId) {
+                return { type: target.type, browserWindowId };
+              }
+            }
+
+            return null;
+          }
+
+          function finishIfReady() {
+            const result = readInitializationResult();
+            if (result === null) {
+              return false;
+            }
+            if (state.resolved) {
+              return true;
+            }
+
+            state.resolved = true;
+            state.result = result;
+            cleanup();
+            state.resolve(result);
+            return true;
+          }
+
+          state.promise = new Promise((resolve) => {
+            state.resolve = resolve;
+          });
+          state.readInitializationResult = readInitializationResult;
+          window[globalKey] = state;
+
+          function startObserving() {
+            if (finishIfReady()) {
+              return;
+            }
+
+            const root = document.documentElement ?? document;
+            state.observer = new MutationObserver(finishIfReady);
+            state.observer.observe(root, {
+              childList: true,
+              subtree: true,
+              characterData: true,
+            });
+            state.intervalId = window.setInterval(finishIfReady, 50);
+          }
+
+          if (document.documentElement !== null) {
+            startObserving();
+          } else {
+            document.addEventListener('DOMContentLoaded', startObserving, { once: true });
+          }
+        })();
+    """
+    return script.replace("__TARGETS__", json.dumps(targets)).replace(
+        "__GLOBAL_KEY__", json.dumps(_BROWSER_WINDOW_ID_OBSERVER_GLOBAL)
+    )
+
 
 type InputRequiredCallback = Callable[[ActiveInputRequest], Awaitable[None] | None]
 
@@ -226,85 +364,93 @@ class _BrowserInitializationHelper:
         self._console = console
 
     @staticmethod
-    async def wait_for_selector_attached(
-        page: Page, selector: str, *, timeout: int
-    ) -> ElementHandle | None:
-        try:
-            return await page.wait_for_selector(
-                selector, state="attached", timeout=timeout
-            )
-        except PlaywrightTimeoutError:
+    async def install_browser_window_id_observer(context: BrowserContext) -> None:
+        await context.add_init_script(script=_build_browser_window_id_observer_script())
+
+    @staticmethod
+    async def wait_for_browser_initialization_result(
+        page: Page, *, timeout: int
+    ) -> _BrowserInitializationResult | None:
+        await page.evaluate(_build_browser_window_id_observer_script())
+        result = await page.evaluate(
+            """
+            async ({ globalKey, timeoutMs }) => {
+              const observerState = window[globalKey];
+              const immediateResult =
+                observerState?.readInitializationResult?.() ?? null;
+              if (immediateResult !== null) {
+                return immediateResult;
+              }
+
+              if (observerState?.promise === undefined) {
+                return null;
+              }
+
+              const timeoutPromise = new Promise((resolve) => {
+                window.setTimeout(() => resolve(null), timeoutMs);
+              });
+
+              return await Promise.race([
+                observerState.promise,
+                timeoutPromise,
+              ]);
+            }
+            """,
+            {
+                "globalKey": _BROWSER_WINDOW_ID_OBSERVER_GLOBAL,
+                "timeoutMs": timeout,
+            },
+        )
+        if not isinstance(result, dict):
             return None
+
+        result_type = result.get("type")
+        if result_type not in {
+            "browser_window_id",
+            "unsupported_browser",
+            "extension_missing",
+            "extension_unauthenticated",
+            "initialization_error",
+        }:
+            return None
+
+        return cast(_BrowserInitializationResult, result)
 
     @staticmethod
     async def wait_for_browser_window_id_silently(page: Page, *, timeout: int) -> str:
-        selectors = [
-            _BROWSER_WINDOW_ID_SELECTOR,
-            _UNSUPPORTED_BROWSER_INDICATOR_SELECTOR,
-            _EXTENSION_MISSING_INDICATOR_SELECTOR,
-            _EXTENSION_UNAUTHENTICATED_INDICATOR_SELECTOR,
-            _INITIALIZATION_ERROR_INDICATOR_SELECTOR,
-        ]
-        tasks: list[asyncio.Task[ElementHandle | None]] = [
-            asyncio.create_task(
-                _BrowserInitializationHelper.wait_for_selector_attached(
-                    page, selector, timeout=timeout
-                )
+        result = (
+            await _BrowserInitializationHelper.wait_for_browser_initialization_result(
+                page,
+                timeout=timeout,
             )
-            for selector in selectors
-        ]
-        (
-            browser_window_id_task,
-            unsupported_browser_indicator_task,
-            extension_missing_indicator_task,
-            extension_unauthenticated_indicator_task,
-            initialization_error_indicator_task,
-        ) = tasks
-
-        done, pending = await asyncio.wait(
-            tasks, timeout=timeout, return_when=asyncio.FIRST_COMPLETED
         )
-
-        for task in pending:
-            task.cancel()
-
-        if len(done) == 0:
+        if result is None:
             raise NaradaTimeoutError("Timed out waiting for browser window ID")
 
-        for task in done:
-            if task == browser_window_id_task:
-                browser_window_id_elem = task.result()
-                if browser_window_id_elem is None:
-                    raise NaradaTimeoutError("Timed out waiting for browser window ID")
+        result_type = result.get("type")
+        if result_type == "browser_window_id":
+            browser_window_id = result.get("browserWindowId")
+            if not isinstance(browser_window_id, str) or not browser_window_id:
+                raise NaradaInitializationError("Browser window ID is empty")
 
-                browser_window_id = await browser_window_id_elem.text_content()
-                if browser_window_id is None:
-                    raise NaradaInitializationError("Browser window ID is empty")
+            return browser_window_id
 
-                return browser_window_id
+        # TODO: Create custom exception types for these cases.
+        if result_type == "unsupported_browser":
+            raise NaradaUnsupportedBrowserError("Unsupported browser")
 
-            # TODO: Create custom exception types for these cases.
-            if task == unsupported_browser_indicator_task and task.result() is not None:
-                raise NaradaUnsupportedBrowserError("Unsupported browser")
+        if result_type == "extension_missing":
+            raise NaradaExtensionMissingError("Narada extension missing")
 
-            if task == extension_missing_indicator_task and task.result() is not None:
-                raise NaradaExtensionMissingError("Narada extension missing")
+        if result_type == "extension_unauthenticated":
+            raise NaradaExtensionUnauthenticatedError(
+                "Sign in to the Narada extension first"
+            )
 
-            if (
-                task == extension_unauthenticated_indicator_task
-                and task.result() is not None
-            ):
-                raise NaradaExtensionUnauthenticatedError(
-                    "Sign in to the Narada extension first"
-                )
+        if result_type == "initialization_error":
+            raise NaradaInitializationError("Initialization error")
 
-            if (
-                task == initialization_error_indicator_task
-                and task.result() is not None
-            ):
-                raise NaradaInitializationError("Initialization error")
-
-        assert_never()
+        raise NaradaInitializationError("Unexpected initialization result")
 
     async def wait_for_browser_window_id_interactively(
         self, page: Page, *, per_attempt_timeout: int
@@ -1045,6 +1191,7 @@ class BrowserEnvironment(BaseBrowserEnvironment):
 
         # Open the initialization page in a new tab in the default context.
         context = browser.contexts[0]
+        await _BrowserInitializationHelper.install_browser_window_id_observer(context)
         initialization_page = await context.new_page()
         await initialization_page.goto(tagged_initialization_url)
 
@@ -1160,6 +1307,9 @@ class BrowserEnvironment(BaseBrowserEnvironment):
                 continue
 
             context = browser.contexts[0]
+            await _BrowserInitializationHelper.install_browser_window_id_observer(
+                context
+            )
 
             # If proxy auth is needed, set up the handler at browser level then navigate to the
             # initialization page. After navigation succeeds, Chrome has cached the proxy
@@ -1652,6 +1802,7 @@ class CloudBrowserEnvironment(BaseBrowserEnvironment):
                     }})();
                 """
             )
+        await _BrowserInitializationHelper.install_browser_window_id_observer(context)
         await initialization_page.goto(
             login_url, timeout=15_000, wait_until="domcontentloaded"
         )

--- a/packages/narada/src/narada/environment.py
+++ b/packages/narada/src/narada/environment.py
@@ -95,7 +95,7 @@ _UNSUPPORTED_BROWSER_INDICATOR_SELECTOR = "#narada-unsupported-browser"
 _EXTENSION_MISSING_INDICATOR_SELECTOR = "#narada-extension-missing"
 _EXTENSION_UNAUTHENTICATED_INDICATOR_SELECTOR = "#narada-extension-unauthenticated"
 _INITIALIZATION_ERROR_INDICATOR_SELECTOR = "#narada-initialization-error"
-_BROWSER_WINDOW_ID_OBSERVER_GLOBAL = "__naradaBrowserWindowIdObserver"
+_BROWSER_WINDOW_ID_OBSERVER_KEY = "narada.sdk.browserWindowIdObserver"
 
 
 type _BrowserInitializationResultType = Literal[
@@ -114,7 +114,6 @@ class _BrowserInitializationResult(TypedDict, total=False):
 
 def _build_browser_window_id_observer_script() -> str:
     targets = [
-        {"type": "browser_window_id", "selector": _BROWSER_WINDOW_ID_SELECTOR},
         {
             "type": "unsupported_browser",
             "selector": _UNSUPPORTED_BROWSER_INDICATOR_SELECTOR,
@@ -131,29 +130,39 @@ def _build_browser_window_id_observer_script() -> str:
             "type": "initialization_error",
             "selector": _INITIALIZATION_ERROR_INDICATOR_SELECTOR,
         },
+        {"type": "browser_window_id", "selector": _BROWSER_WINDOW_ID_SELECTOR},
     ]
     script = """
         (() => {
-          const targets = __TARGETS__;
-          const globalKey = __GLOBAL_KEY__;
-          const existingState = window[globalKey];
-          if (existingState?.version === 2) {
+          if (window.top !== window) {
             return;
           }
-          existingState?.observer?.disconnect();
-          if (existingState?.intervalId !== null && existingState?.intervalId !== undefined) {
-            clearInterval(existingState.intervalId);
+
+          const targets = __TARGETS__;
+          const globalSymbol = Symbol.for(__GLOBAL_KEY__);
+          const existingState = window[globalSymbol];
+          if (existingState?.version === 3) {
+            return;
+          }
+          if (existingState?.version === 2) {
+            existingState.observer?.disconnect();
+            if (existingState.intervalId !== null && existingState.intervalId !== undefined) {
+              clearInterval(existingState.intervalId);
+            }
+            delete window[globalSymbol];
           }
 
           const state = {
-            version: 2,
+            version: 3,
             result: null,
             observer: null,
             intervalId: null,
             resolved: false,
+            disposed: false,
             resolve: null,
             promise: null,
             readInitializationResult: null,
+            dispose: null,
           };
 
           function cleanup() {
@@ -164,6 +173,14 @@ def _build_browser_window_id_observer_script() -> str:
             if (state.intervalId !== null) {
               clearInterval(state.intervalId);
               state.intervalId = null;
+            }
+          }
+
+          function dispose() {
+            state.disposed = true;
+            cleanup();
+            if (window[globalSymbol] === state) {
+              delete window[globalSymbol];
             }
           }
 
@@ -188,6 +205,9 @@ def _build_browser_window_id_observer_script() -> str:
           }
 
           function finishIfReady() {
+            if (state.disposed) {
+              return true;
+            }
             const result = readInitializationResult();
             if (result === null) {
               return false;
@@ -207,7 +227,12 @@ def _build_browser_window_id_observer_script() -> str:
             state.resolve = resolve;
           });
           state.readInitializationResult = readInitializationResult;
-          window[globalKey] = state;
+          state.dispose = dispose;
+          Object.defineProperty(window, globalSymbol, {
+            value: state,
+            configurable: true,
+            writable: true,
+          });
 
           function startObserving() {
             if (finishIfReady()) {
@@ -232,7 +257,7 @@ def _build_browser_window_id_observer_script() -> str:
         })();
     """
     return script.replace("__TARGETS__", json.dumps(targets)).replace(
-        "__GLOBAL_KEY__", json.dumps(_BROWSER_WINDOW_ID_OBSERVER_GLOBAL)
+        "__GLOBAL_KEY__", json.dumps(_BROWSER_WINDOW_ID_OBSERVER_KEY)
     )
 
 
@@ -364,8 +389,8 @@ class _BrowserInitializationHelper:
         self._console = console
 
     @staticmethod
-    async def install_browser_window_id_observer(context: BrowserContext) -> None:
-        await context.add_init_script(script=_build_browser_window_id_observer_script())
+    async def install_browser_window_id_observer(page: Page) -> None:
+        await page.add_init_script(script=_build_browser_window_id_observer_script())
 
     @staticmethod
     async def wait_for_browser_initialization_result(
@@ -375,7 +400,7 @@ class _BrowserInitializationHelper:
         result = await page.evaluate(
             """
             async ({ globalKey, timeoutMs }) => {
-              const observerState = window[globalKey];
+              const observerState = window[Symbol.for(globalKey)];
               const immediateResult =
                 observerState?.readInitializationResult?.() ?? null;
               if (immediateResult !== null) {
@@ -386,18 +411,30 @@ class _BrowserInitializationHelper:
                 return null;
               }
 
+              let timeoutId = null;
               const timeoutPromise = new Promise((resolve) => {
-                window.setTimeout(() => resolve(null), timeoutMs);
+                timeoutId = window.setTimeout(
+                  () => resolve({ type: 'timeout' }),
+                  timeoutMs
+                );
               });
 
-              return await Promise.race([
+              const result = await Promise.race([
                 observerState.promise,
                 timeoutPromise,
               ]);
+              if (timeoutId !== null) {
+                window.clearTimeout(timeoutId);
+              }
+              if (result?.type === 'timeout') {
+                observerState.dispose?.();
+                return null;
+              }
+              return result;
             }
             """,
             {
-                "globalKey": _BROWSER_WINDOW_ID_OBSERVER_GLOBAL,
+                "globalKey": _BROWSER_WINDOW_ID_OBSERVER_KEY,
                 "timeoutMs": timeout,
             },
         )
@@ -1191,8 +1228,10 @@ class BrowserEnvironment(BaseBrowserEnvironment):
 
         # Open the initialization page in a new tab in the default context.
         context = browser.contexts[0]
-        await _BrowserInitializationHelper.install_browser_window_id_observer(context)
         initialization_page = await context.new_page()
+        await _BrowserInitializationHelper.install_browser_window_id_observer(
+            initialization_page
+        )
         await initialization_page.goto(tagged_initialization_url)
 
         browser_window_id = await self._wait_for_browser_window_id_with_lazy_login(
@@ -1307,9 +1346,6 @@ class BrowserEnvironment(BaseBrowserEnvironment):
                 continue
 
             context = browser.contexts[0]
-            await _BrowserInitializationHelper.install_browser_window_id_observer(
-                context
-            )
 
             # If proxy auth is needed, set up the handler at browser level then navigate to the
             # initialization page. After navigation succeeds, Chrome has cached the proxy
@@ -1323,6 +1359,9 @@ class BrowserEnvironment(BaseBrowserEnvironment):
                     )
                 )
                 blank_page = context.pages[0]
+                await _BrowserInitializationHelper.install_browser_window_id_observer(
+                    blank_page
+                )
                 await blank_page.goto(tagged_initialization_url)
                 await proxy_cdp_session.detach()
                 did_initial_navigation = True
@@ -1789,7 +1828,7 @@ class CloudBrowserEnvironment(BaseBrowserEnvironment):
             # Put the backend-owned browser ID into sessionStorage before hydration
             # so AgentCore sessions use the right Firestore route when needed.
             expected_browser_window_id_json = json.dumps(expected_browser_window_id)
-            await context.add_init_script(
+            await initialization_page.add_init_script(
                 script=f"""
                     (() => {{
                       const expectedBrowserWindowId = {expected_browser_window_id_json};
@@ -1802,7 +1841,9 @@ class CloudBrowserEnvironment(BaseBrowserEnvironment):
                     }})();
                 """
             )
-        await _BrowserInitializationHelper.install_browser_window_id_observer(context)
+        await _BrowserInitializationHelper.install_browser_window_id_observer(
+            initialization_page
+        )
         await initialization_page.goto(
             login_url, timeout=15_000, wait_until="domcontentloaded"
         )

--- a/packages/narada/tests/test_browser_environment_login.py
+++ b/packages/narada/tests/test_browser_environment_login.py
@@ -164,3 +164,26 @@ async def test_browser_window_id_wait_times_out_when_dom_observer_finds_no_marke
             page,
             timeout=1_000,
         )
+
+
+def test_browser_window_id_observer_script_limits_global_and_resource_leak_risk() -> (
+    None
+):
+    import inspect
+
+    import narada.environment as environment_module
+
+    script = environment_module._build_browser_window_id_observer_script()
+    wait_source = inspect.getsource(
+        environment_module._BrowserInitializationHelper.wait_for_browser_initialization_result
+    )
+
+    assert "Symbol.for" in script
+    assert "__naradaBrowserWindowIdObserver" not in script
+    assert "window.top !== window" in script
+    assert "function dispose()" in script
+    assert "delete window[globalSymbol]" in script
+    assert "observerState.dispose?.()" in wait_source
+    assert script.index("#narada-initialization-error") < script.index(
+        "#narada-browser-window-id"
+    )

--- a/packages/narada/tests/test_browser_environment_login.py
+++ b/packages/narada/tests/test_browser_environment_login.py
@@ -3,7 +3,13 @@ from unittest.mock import AsyncMock
 import pytest
 from narada import BrowserEnvironment
 from narada.config import BrowserConfig
-from narada_core.errors import NaradaExtensionUnauthenticatedError
+from narada_core.errors import (
+    NaradaExtensionMissingError,
+    NaradaExtensionUnauthenticatedError,
+    NaradaInitializationError,
+    NaradaTimeoutError,
+    NaradaUnsupportedBrowserError,
+)
 
 
 @pytest.mark.asyncio
@@ -79,3 +85,82 @@ async def test_browser_environment_fetches_login_token_after_unauthenticated_sta
         timeout=15_000,
         wait_until="domcontentloaded",
     )
+
+
+@pytest.mark.asyncio
+async def test_browser_window_id_wait_prefers_dom_observer() -> None:
+    import narada.environment as environment_module
+
+    page = AsyncMock()
+    page.evaluate = AsyncMock(
+        side_effect=[
+            None,
+            {"type": "browser_window_id", "browserWindowId": "browser-window-123"},
+        ]
+    )
+
+    browser_window_id = await environment_module._BrowserInitializationHelper.wait_for_browser_window_id_silently(
+        page,
+        timeout=1_000,
+    )
+
+    assert browser_window_id == "browser-window-123"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("observer_result", "expected_error", "match"),
+    [
+        (
+            {"type": "unsupported_browser"},
+            NaradaUnsupportedBrowserError,
+            "Unsupported browser",
+        ),
+        (
+            {"type": "extension_missing"},
+            NaradaExtensionMissingError,
+            "Narada extension missing",
+        ),
+        (
+            {"type": "extension_unauthenticated"},
+            NaradaExtensionUnauthenticatedError,
+            "Sign in to the Narada extension first",
+        ),
+        (
+            {"type": "initialization_error"},
+            NaradaInitializationError,
+            "Initialization error",
+        ),
+    ],
+)
+async def test_browser_window_id_wait_maps_dom_observer_error_markers(
+    observer_result: dict[str, str],
+    expected_error: type[Exception],
+    match: str,
+) -> None:
+    import narada.environment as environment_module
+
+    page = AsyncMock()
+    page.evaluate = AsyncMock(side_effect=[None, observer_result])
+
+    with pytest.raises(expected_error, match=match):
+        await environment_module._BrowserInitializationHelper.wait_for_browser_window_id_silently(
+            page,
+            timeout=1_000,
+        )
+
+
+@pytest.mark.asyncio
+async def test_browser_window_id_wait_times_out_when_dom_observer_finds_no_marker() -> (
+    None
+):
+    import narada.environment as environment_module
+
+    page = AsyncMock()
+    page.evaluate = AsyncMock(side_effect=[None, None])
+
+    with pytest.raises(NaradaTimeoutError, match="Timed out"):
+        await environment_module._BrowserInitializationHelper.wait_for_browser_window_id_silently(
+            page,
+            timeout=1_000,
+        )

--- a/packages/narada/tests/test_browser_environment_login.py
+++ b/packages/narada/tests/test_browser_environment_login.py
@@ -209,7 +209,6 @@ def test_browser_window_id_observer_script_cleans_up_in_js_runtime() -> None:
         const legacyKey = "__naradaBrowserWindowIdObserver";
         const markers = new Map();
         const clearedIntervals = [];
-        let nextIntervalId = 1;
         let lastObserver = null;
         let legacyDisconnected = false;
 
@@ -221,7 +220,9 @@ def test_browser_window_id_observer_script_cleans_up_in_js_runtime() -> None:
 
         const windowObject = {{}};
         windowObject.top = windowObject;
-        windowObject.setInterval = () => nextIntervalId++;
+        windowObject.setInterval = () => {{
+          throw new Error("observer should not poll");
+        }};
         globalThis.window = windowObject;
         globalThis.clearInterval = (intervalId) => {{
           clearedIntervals.push(intervalId);
@@ -264,13 +265,11 @@ def test_browser_window_id_observer_script_cleans_up_in_js_runtime() -> None:
         assert(clearedIntervals.includes(99), "legacy interval cleared");
         assert(state?.version === 3, "v3 state installed");
         assert(typeof state.dispose === "function", "dispose exposed");
-        assert(state.intervalId === 1, "poll interval installed");
         assert(lastObserver !== null, "mutation observer installed");
 
         state.dispose();
         assert(windowObject[symbol] === undefined, "symbol state deleted on dispose");
         assert(lastObserver.disconnected, "observer disconnected on dispose");
-        assert(clearedIntervals.includes(1), "poll interval cleared on dispose");
 
         markers.set("#narada-browser-window-id", {{ textContent: "browser-window-123" }});
         markers.set("#narada-initialization-error", {{ textContent: "" }});
@@ -281,7 +280,6 @@ def test_browser_window_id_observer_script_cleans_up_in_js_runtime() -> None:
           precedenceState.result?.type === "initialization_error",
           "error marker wins over browser window ID"
         );
-        assert(precedenceState.intervalId === null, "no interval left after immediate result");
     """
 
     result = subprocess.run(

--- a/packages/narada/tests/test_browser_environment_login.py
+++ b/packages/narada/tests/test_browser_environment_login.py
@@ -179,11 +179,116 @@ def test_browser_window_id_observer_script_limits_global_and_resource_leak_risk(
     )
 
     assert "Symbol.for" in script
-    assert "__naradaBrowserWindowIdObserver" not in script
+    assert "legacyGlobalKey" in script
     assert "window.top !== window" in script
     assert "function dispose()" in script
     assert "delete window[globalSymbol]" in script
+    assert "delete window[legacyGlobalKey]" in script
     assert "observerState.dispose?.()" in wait_source
     assert script.index("#narada-initialization-error") < script.index(
         "#narada-browser-window-id"
     )
+
+
+def test_browser_window_id_observer_script_cleans_up_in_js_runtime() -> None:
+    import json
+    import shutil
+    import subprocess
+    import textwrap
+
+    import narada.environment as environment_module
+
+    node = shutil.which("node")
+    if node is None:
+        pytest.skip("node is required to execute observer lifecycle harness")
+
+    installer_script = environment_module._build_browser_window_id_observer_script()
+    harness = f"""
+        const installerScript = {json.dumps(installer_script)};
+        const observerKey = "narada.sdk.browserWindowIdObserver";
+        const legacyKey = "__naradaBrowserWindowIdObserver";
+        const markers = new Map();
+        const clearedIntervals = [];
+        let nextIntervalId = 1;
+        let lastObserver = null;
+        let legacyDisconnected = false;
+
+        function assert(condition, message) {{
+          if (!condition) {{
+            throw new Error(message);
+          }}
+        }}
+
+        const windowObject = {{}};
+        windowObject.top = windowObject;
+        windowObject.setInterval = () => nextIntervalId++;
+        globalThis.window = windowObject;
+        globalThis.clearInterval = (intervalId) => {{
+          clearedIntervals.push(intervalId);
+        }};
+
+        globalThis.document = windowObject.document = {{
+          documentElement: {{}},
+          querySelector: (selector) => markers.get(selector) ?? null,
+          addEventListener: () => {{}},
+        }};
+
+        globalThis.MutationObserver = class {{
+          constructor(callback) {{
+            this.callback = callback;
+            this.disconnected = false;
+            lastObserver = this;
+          }}
+          observe() {{}}
+          disconnect() {{
+            this.disconnected = true;
+          }}
+        }};
+
+        windowObject[legacyKey] = {{
+          version: 2,
+          observer: {{
+            disconnect: () => {{
+              legacyDisconnected = true;
+            }},
+          }},
+          intervalId: 99,
+        }};
+
+        eval(installerScript);
+        const symbol = Symbol.for(observerKey);
+        const state = windowObject[symbol];
+
+        assert(windowObject[legacyKey] === undefined, "legacy string global deleted");
+        assert(legacyDisconnected, "legacy observer disconnected");
+        assert(clearedIntervals.includes(99), "legacy interval cleared");
+        assert(state?.version === 3, "v3 state installed");
+        assert(typeof state.dispose === "function", "dispose exposed");
+        assert(state.intervalId === 1, "poll interval installed");
+        assert(lastObserver !== null, "mutation observer installed");
+
+        state.dispose();
+        assert(windowObject[symbol] === undefined, "symbol state deleted on dispose");
+        assert(lastObserver.disconnected, "observer disconnected on dispose");
+        assert(clearedIntervals.includes(1), "poll interval cleared on dispose");
+
+        markers.set("#narada-browser-window-id", {{ textContent: "browser-window-123" }});
+        markers.set("#narada-initialization-error", {{ textContent: "" }});
+        eval(installerScript);
+
+        const precedenceState = windowObject[symbol];
+        assert(
+          precedenceState.result?.type === "initialization_error",
+          "error marker wins over browser window ID"
+        );
+        assert(precedenceState.intervalId === null, "no interval left after immediate result");
+    """
+
+    result = subprocess.run(
+        [node, "-e", textwrap.dedent(harness)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr or result.stdout

--- a/packages/narada/tests/test_client.py
+++ b/packages/narada/tests/test_client.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from unittest.mock import AsyncMock
+
 import narada.environment as environment_module
 import pytest
 from narada import CloudBrowserEnvironment, RemoteBrowserEnvironment
@@ -19,6 +21,7 @@ class _FakePage:
 class _FakeContext:
     def __init__(self, page: _FakePage) -> None:
         self.pages = [page]
+        self.add_init_script = AsyncMock()
 
 
 class _FakeBrowser:

--- a/packages/narada/tests/test_client.py
+++ b/packages/narada/tests/test_client.py
@@ -12,6 +12,7 @@ class _FakePage:
     def __init__(self) -> None:
         self.goto_calls: list[dict[str, object]] = []
         self.url = "about:blank"
+        self.add_init_script = AsyncMock()
 
     async def goto(self, url: str, **kwargs: object) -> None:
         self.url = url

--- a/packages/narada/tests/test_cloud_browser.py
+++ b/packages/narada/tests/test_cloud_browser.py
@@ -80,6 +80,7 @@ def _build_cloud_environment_with_page(page: AsyncMock) -> CloudBrowserEnvironme
         auth_headers={"x-api-key": "test-key"},
         config=BrowserConfig(interactive=False),
     )
+    page.add_init_script = AsyncMock()
     browser = SimpleNamespace(
         contexts=[SimpleNamespace(pages=[page], add_init_script=AsyncMock())]
     )
@@ -367,8 +368,9 @@ async def test_cloud_browser_environment_uses_domcontentloaded_for_login_navigat
         BrowserConfig(interactive=False),
         timeout=30_000,
     )
-    context.add_init_script.assert_awaited_once()
-    assert "MutationObserver" in context.add_init_script.await_args.kwargs["script"]
+    context.add_init_script.assert_not_awaited()
+    page.add_init_script.assert_awaited_once()
+    assert "MutationObserver" in page.add_init_script.await_args.kwargs["script"]
     assert env.browser_window_id == "browser-window-123"
     assert env.cloud_browser_session_id == "session-123"
 
@@ -379,7 +381,6 @@ async def test_cloud_browser_environment_seeds_expected_browser_window_id_before
 ) -> None:
     page = AsyncMock()
     env = _build_cloud_environment_with_page(page)
-    context = env._playwright.chromium.connect_over_cdp.return_value.contexts[0]
     events: list[str] = []
 
     async def add_init_script(*args, **kwargs) -> None:
@@ -388,7 +389,7 @@ async def test_cloud_browser_environment_seeds_expected_browser_window_id_before
     async def goto(*args, **kwargs) -> None:
         events.append("goto")
 
-    context.add_init_script.side_effect = add_init_script
+    page.add_init_script.side_effect = add_init_script
     page.goto.side_effect = goto
     wait_for_browser_window_id = AsyncMock(return_value="backend-window-123")
     monkeypatch.setattr(
@@ -404,8 +405,8 @@ async def test_cloud_browser_environment_seeds_expected_browser_window_id_before
     )
 
     assert events[:3] == ["seed", "seed", "goto"]
-    seeded_script = context.add_init_script.await_args_list[0].kwargs["script"]
-    observer_script = context.add_init_script.await_args_list[1].kwargs["script"]
+    seeded_script = page.add_init_script.await_args_list[0].kwargs["script"]
+    observer_script = page.add_init_script.await_args_list[1].kwargs["script"]
     assert "MutationObserver" in observer_script
     script = seeded_script
     assert "naradaBrowserWindowId" in script

--- a/packages/narada/tests/test_cloud_browser.py
+++ b/packages/narada/tests/test_cloud_browser.py
@@ -367,7 +367,8 @@ async def test_cloud_browser_environment_uses_domcontentloaded_for_login_navigat
         BrowserConfig(interactive=False),
         timeout=30_000,
     )
-    context.add_init_script.assert_not_awaited()
+    context.add_init_script.assert_awaited_once()
+    assert "MutationObserver" in context.add_init_script.await_args.kwargs["script"]
     assert env.browser_window_id == "browser-window-123"
     assert env.cloud_browser_session_id == "session-123"
 
@@ -402,8 +403,11 @@ async def test_cloud_browser_environment_seeds_expected_browser_window_id_before
         expected_browser_window_id="backend-window-123",
     )
 
-    assert events[:2] == ["seed", "goto"]
-    script = context.add_init_script.await_args.kwargs["script"]
+    assert events[:3] == ["seed", "seed", "goto"]
+    seeded_script = context.add_init_script.await_args_list[0].kwargs["script"]
+    observer_script = context.add_init_script.await_args_list[1].kwargs["script"]
+    assert "MutationObserver" in observer_script
+    script = seeded_script
     assert "naradaBrowserWindowId" in script
     assert "backend-window-123" in script
     assert env.browser_window_id == "backend-window-123"

--- a/uv.lock
+++ b/uv.lock
@@ -312,7 +312,7 @@ wheels = [
 
 [[package]]
 name = "narada"
-version = "0.2.3"
+version = "0.2.4a1"
 source = { editable = "packages/narada" }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

- Replace the Playwright selector-based browser initialization waits with a DOM observer installed before navigation.
- Have the observer detect both the browser window ID marker and the existing initialization error markers.
- Bump the `narada` package to `0.2.4a1` for alpha testing.

## Why

Cloud browser initialization was spending several seconds inside Playwright selector waits after the frontend marker was already available. The SDK now waits through a page-local observer instead, while preserving the same SDK exceptions for unsupported browser, missing extension, unauthenticated extension, and initialization error states.

## Validation

- `uv run ruff check packages/narada/src/narada/environment.py packages/narada/tests`
- `uv run --package narada pytest packages/narada/tests`
- `python3 -m py_compile packages/narada/src/narada/environment.py`
- `git diff --check`