### PR TITLE
Preserve operator action trace timing

### DIFF
--- a/packages/narada-core/pyproject.toml
+++ b/packages/narada-core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "narada-core"
-version = "0.1.3"
+version = "0.1.4"
 description = "Code shared by the `narada` and `narada-pyodide` packages."
 license = "Apache-2.0"
 readme = "README.md"

--- a/packages/narada-core/src/narada_core/models.py
+++ b/packages/narada-core/src/narada_core/models.py
@@ -96,6 +96,11 @@ _MaybeStructuredOutput = TypeVar("_MaybeStructuredOutput", bound=BaseModel | Non
 class OperatorActionTraceItem(TypedDict):
     url: str
     action: str
+    credits: NotRequired[float]
+    startTs: NotRequired[int]
+    endTs: NotRequired[int]
+    durationMs: NotRequired[int]
+    children: NotRequired[list["OperatorActionTraceItem"]]
 
 
 class GoToUrlTrace(TypedDict):

--- a/packages/narada-core/src/narada_core/tracing/model.py
+++ b/packages/narada-core/src/narada_core/tracing/model.py
@@ -44,7 +44,10 @@ class OperatorActionTraceItem(BaseModel):
             return self
         if self.end_ts < self.start_ts:
             raise ValueError("endTs must be greater than or equal to startTs")
-        if self.duration_ms is not None and self.duration_ms != self.end_ts - self.start_ts:
+        if (
+            self.duration_ms is not None
+            and self.duration_ms != self.end_ts - self.start_ts
+        ):
             raise ValueError("durationMs must equal endTs minus startTs")
         return self
 

--- a/packages/narada-core/src/narada_core/tracing/model.py
+++ b/packages/narada-core/src/narada_core/tracing/model.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
-from typing import Annotated, Any, Literal
+from typing import Annotated, Any, Literal, Self
 
 from pydantic import (
     BaseModel,
+    ConfigDict,
     Field,
     NonNegativeInt,
     TypeAdapter,
@@ -27,8 +28,25 @@ def _normalize_agent_type(agent_type: object) -> str:
 
 
 class OperatorActionTraceItem(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
     url: str
     action: str
+    credits: float | None = None
+    start_ts: NonNegativeInt | None = Field(default=None, alias="startTs")
+    end_ts: NonNegativeInt | None = Field(default=None, alias="endTs")
+    duration_ms: NonNegativeInt | None = Field(default=None, alias="durationMs")
+    children: list[OperatorActionTraceItem] | None = None
+
+    @model_validator(mode="after")
+    def validate_timing(self) -> Self:
+        if self.start_ts is None or self.end_ts is None:
+            return self
+        if self.end_ts < self.start_ts:
+            raise ValueError("endTs must be greater than or equal to startTs")
+        if self.duration_ms is not None and self.duration_ms != self.end_ts - self.start_ts:
+            raise ValueError("durationMs must equal endTs minus startTs")
+        return self
 
 
 class GoToUrlTrace(BaseModel):

--- a/packages/narada-pyodide/pyproject.toml
+++ b/packages/narada-pyodide/pyproject.toml
@@ -1,14 +1,14 @@
 
 [project]
 name = "narada-pyodide"
-version = "0.1.3"
+version = "0.1.4"
 description = "Pyodide-compatible Python client SDK for Narada"
 license = "Apache-2.0"
 readme = "README.md"
 authors = [{ name = "Narada", email = "support@narada.ai" }]
 requires-python = ">=3.12"
 dependencies = [
-    "narada-core==0.1.3",
+    "narada-core==0.1.4",
     # Must be a supported version in https://pyodide.org/en/stable/usage/packages-in-pyodide.html
     "packaging==24.2",
 ]

--- a/packages/narada-pyodide/tests/test_cloud_browser.py
+++ b/packages/narada-pyodide/tests/test_cloud_browser.py
@@ -528,6 +528,68 @@ async def test_agent_run_exposes_workflow_trace_alias(
 
 
 @pytest.mark.asyncio
+async def test_agent_run_preserves_operator_action_trace_timing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    action_trace = [
+        {
+            "url": "https://example.com/form",
+            "action": "Clicked Save",
+            "credits": 1.0,
+            "startTs": 1_000,
+            "endTs": 1_240,
+            "durationMs": 240,
+            "children": [
+                {
+                    "url": "https://example.com/form",
+                    "action": "Validated Save",
+                    "startTs": 1_050,
+                    "endTs": 1_150,
+                    "durationMs": 100,
+                }
+            ],
+        }
+    ]
+    pyfetch = AsyncMock(
+        side_effect=[
+            _FakeResponse(json_data={"requestId": "child-request-123"}),
+            _FakeResponse(
+                json_data={
+                    "status": "success",
+                    "response": {
+                        "text": "done",
+                        "output": {"type": "text", "content": "done"},
+                        "actionTrace": action_trace,
+                    },
+                    "completedAt": "2026-05-08T00:00:00+00:00",
+                    "usage": {"actions": 1, "credits": 1.0},
+                    "activeInputRequest": None,
+                }
+            ),
+        ]
+    )
+    narada_pkg, _ = _import_pyodide_narada(monkeypatch, pyfetch=pyfetch)
+
+    env = narada_pkg.RemoteBrowserEnvironment(
+        browser_window_id="browser-window-123",
+        cloud_browser_session_id="session-123",
+        api_key="test-api-key",
+    )
+    response = await narada_pkg.Agent(environment=env).run("return a trace")
+
+    assert response.action_trace is not None
+    assert response.action_trace[0].start_ts == 1_000
+    assert response.action_trace[0].end_ts == 1_240
+    assert response.action_trace[0].duration_ms == 240
+    assert response.action_trace[0].children is not None
+    assert response.action_trace[0].children[0].duration_ms == 100
+    assert (
+        response.model_dump(by_alias=True, exclude_none=True)["action_trace"]
+        == action_trace
+    )
+
+
+@pytest.mark.asyncio
 async def test_agent_run_emits_combined_critic_workflow_trace(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/packages/narada/pyproject.toml
+++ b/packages/narada/pyproject.toml
@@ -1,13 +1,13 @@
 [project]
 name = "narada"
-version = "0.2.6"
+version = "0.2.7"
 description = "Python client SDK for Narada"
 license = "Apache-2.0"
 readme = "README.md"
 authors = [{ name = "Narada", email = "support@narada.ai" }]
 requires-python = ">=3.12"
 dependencies = [
-    "narada-core==0.1.3",
+    "narada-core==0.1.4",
     "aiohttp>=3.12.13",
     "playwright>=1.53.0",
     "rich>=14.0.0",

--- a/packages/narada/tests/test_action_trace.py
+++ b/packages/narada/tests/test_action_trace.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import pytest
+from narada_core.tracing.model import parse_action_trace
+from pydantic import ValidationError
+
+
+def test_operator_action_trace_uses_pythonic_timing_attributes_and_wire_aliases() -> None:
+    trace = parse_action_trace(
+        [
+            {
+                "url": "https://example.com/form",
+                "action": "Clicked Save",
+                "startTs": 1_000,
+                "endTs": 1_240,
+                "durationMs": 240,
+                "children": [
+                    {
+                        "url": "https://example.com/form",
+                        "action": "Validated Save",
+                        "startTs": 1_050,
+                        "endTs": 1_150,
+                        "durationMs": 100,
+                    }
+                ],
+            }
+        ]
+    )
+
+    item = trace[0]
+    assert item.start_ts == 1_000
+    assert item.end_ts == 1_240
+    assert item.duration_ms == 240
+    assert item.children is not None
+    assert item.children[0].duration_ms == 100
+    assert item.model_dump(by_alias=True, exclude_none=True)["startTs"] == 1_000
+
+
+@pytest.mark.parametrize(
+    "timing",
+    [
+        {"startTs": 1_240, "endTs": 1_000, "durationMs": 0},
+        {"startTs": 1_000, "endTs": 1_240, "durationMs": 0},
+    ],
+)
+def test_operator_action_trace_rejects_inconsistent_timing(timing: dict[str, int]) -> None:
+    with pytest.raises(ValidationError):
+        parse_action_trace(
+            [
+                {
+                    "url": "https://example.com/form",
+                    "action": "Clicked Save",
+                    **timing,
+                }
+            ]
+        )
+
+
+def test_operator_action_trace_accepts_legacy_untimed_rows() -> None:
+    trace = parse_action_trace(
+        [{"url": "https://example.com/form", "action": "Clicked Save"}]
+    )
+
+    assert trace[0].start_ts is None
+    assert trace[0].end_ts is None
+    assert trace[0].duration_ms is None

--- a/packages/narada/tests/test_action_trace.py
+++ b/packages/narada/tests/test_action_trace.py
@@ -5,7 +5,9 @@ from narada_core.tracing.model import parse_action_trace
 from pydantic import ValidationError
 
 
-def test_operator_action_trace_uses_pythonic_timing_attributes_and_wire_aliases() -> None:
+def test_operator_action_trace_uses_pythonic_timing_attributes_and_wire_aliases() -> (
+    None
+):
     trace = parse_action_trace(
         [
             {
@@ -43,7 +45,9 @@ def test_operator_action_trace_uses_pythonic_timing_attributes_and_wire_aliases(
         {"startTs": 1_000, "endTs": 1_240, "durationMs": 0},
     ],
 )
-def test_operator_action_trace_rejects_inconsistent_timing(timing: dict[str, int]) -> None:
+def test_operator_action_trace_rejects_inconsistent_timing(
+    timing: dict[str, int],
+) -> None:
     with pytest.raises(ValidationError):
         parse_action_trace(
             [

--- a/packages/narada/tests/test_cloud_browser.py
+++ b/packages/narada/tests/test_cloud_browser.py
@@ -836,6 +836,67 @@ async def test_agent_run_exposes_workflow_trace_alias(
 
 
 @pytest.mark.asyncio
+async def test_agent_run_preserves_operator_action_trace_timing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    action_trace = [
+        {
+            "url": "https://example.com/form",
+            "action": "Clicked Save",
+            "credits": 1.0,
+            "startTs": 1_000,
+            "endTs": 1_240,
+            "durationMs": 240,
+            "children": [
+                {
+                    "url": "https://example.com/form",
+                    "action": "Validated Save",
+                    "startTs": 1_050,
+                    "endTs": 1_150,
+                    "durationMs": 100,
+                }
+            ],
+        }
+    ]
+    env = RemoteBrowserEnvironment(
+        browser_window_id="browser-window-123",
+        cloud_browser_session_id="session-123",
+        auth_headers={"x-api-key": "test-key"},
+    )
+    monkeypatch.setattr(
+        env,
+        "_dispatch_request",
+        AsyncMock(
+            return_value={
+                "requestId": "request-123",
+                "status": "success",
+                "response": {
+                    "text": "done",
+                    "output": {"type": "text", "content": "done"},
+                    "actionTrace": action_trace,
+                },
+                "completedAt": "2026-01-01T00:00:01Z",
+                "usage": {"actions": 1, "credits": 1.0},
+                "activeInputRequest": None,
+            }
+        ),
+    )
+
+    response = await Agent(environment=env).run("return a trace")
+
+    assert response.action_trace is not None
+    assert response.action_trace[0].start_ts == 1_000
+    assert response.action_trace[0].end_ts == 1_240
+    assert response.action_trace[0].duration_ms == 240
+    assert response.action_trace[0].children is not None
+    assert response.action_trace[0].children[0].duration_ms == 100
+    assert (
+        response.model_dump(by_alias=True, exclude_none=True)["action_trace"]
+        == action_trace
+    )
+
+
+@pytest.mark.asyncio
 async def test_agent_run_appends_critic_workflow_trace(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -312,7 +312,7 @@ wheels = [
 
 [[package]]
 name = "narada"
-version = "0.2.6"
+version = "0.2.7"
 source = { editable = "packages/narada" }
 dependencies = [
     { name = "aiohttp" },
@@ -345,7 +345,7 @@ dev = [
 
 [[package]]
 name = "narada-core"
-version = "0.1.3"
+version = "0.1.4"
 source = { editable = "packages/narada-core" }
 dependencies = [
     { name = "pydantic" },
@@ -356,7 +356,7 @@ requires-dist = [{ name = "pydantic", specifier = "==2.12.5" }]
 
 [[package]]
 name = "narada-pyodide"
-version = "0.1.3"
+version = "0.1.4"
 source = { editable = "packages/narada-pyodide" }
 dependencies = [
     { name = "narada-core" },


### PR DESCRIPTION
## Summary

- Add optional Operator action trace fields for `credits`, `startTs`, `endTs`, `durationMs`, and nested `children`.
- Preserve backend-provided timing through both CPython and Pyodide SDK responses.
- Remove the earlier SDK-side workflow trace duration enrichment and its tests.

## Testing

- `uvx ruff check packages/narada-core/src/narada_core/models.py packages/narada-core/src/narada_core/tracing/model.py packages/narada/tests/test_cloud_browser.py packages/narada-pyodide/tests/test_cloud_browser.py`
- `uv run pytest packages/narada/tests/test_cloud_browser.py -k action_trace_timing`
- `uv run pytest packages/narada-pyodide/tests/test_cloud_browser.py -k action_trace_timing`
- `git diff --check`

## Codex sibling refs

- frontend: https://github.com/NaradaAI/frontend/pull/1944
- caddie: https://github.com/NaradaAI/caddie/pull/6775
- architecture-docs: https://github.com/NaradaAI/architecture-docs/pull/55
