### PR TITLE
[Narada Code] Preserve ExecutionTrace context in SDK responses

### DIFF
--- a/packages/narada-pyodide/src/narada/agent.py
+++ b/packages/narada-pyodide/src/narada/agent.py
@@ -226,6 +226,7 @@ class Agent(Generic[_StructuredOutput]):
             action_trace=action_trace,
             workflow_trace=workflow_trace,
             critic_result=critic_result,
+            execution_trace_context=response_content.get("executionTraceContext"),
         )
 
     async def _dispatch_request(

--- a/packages/narada-pyodide/tests/test_cloud_browser.py
+++ b/packages/narada-pyodide/tests/test_cloud_browser.py
@@ -527,6 +527,83 @@ async def test_agent_run_exposes_workflow_trace_alias(
     ]
 
 
+@pytest.mark.parametrize(
+    ("kind", "parent_request_id", "execution_trace_context"),
+    [
+        (
+            "/Operator",
+            None,
+            {
+                "type": "executionTraceContext",
+                "schemaVersion": 1,
+                "traceId": "trace-operator",
+                "segmentId": "segment-operator",
+                "status": "completed",
+            },
+        ),
+        (
+            "/owner@example.com/project/nested.py",
+            "parent-request-123",
+            {
+                "type": "executionTraceContext",
+                "schemaVersion": 1,
+                "traceId": "trace-parent",
+                "segmentId": "segment-executable",
+                "parentSegmentId": "segment-parent",
+                "status": "completed",
+            },
+        ),
+    ],
+    ids=["operator", "parented-project-executable"],
+)
+@pytest.mark.asyncio
+async def test_agent_run_preserves_execution_trace_context(
+    monkeypatch: pytest.MonkeyPatch,
+    kind: str,
+    parent_request_id: str | None,
+    execution_trace_context: dict[str, object],
+) -> None:
+    pyfetch = AsyncMock(
+        side_effect=[
+            _FakeResponse(json_data={"requestId": "child-request-123"}),
+            _FakeResponse(
+                json_data={
+                    "status": "success",
+                    "response": {
+                        "text": "done",
+                        "output": {"type": "text", "content": "done"},
+                        "executionTraceContext": execution_trace_context,
+                    },
+                    "completedAt": "2026-05-08T00:00:00+00:00",
+                    "usage": {"actions": 0, "credits": 0},
+                    "activeInputRequest": None,
+                }
+            ),
+        ]
+    )
+    narada_pkg, _ = _import_pyodide_narada(monkeypatch, pyfetch=pyfetch)
+    monkeypatch.setattr(
+        builtins, "_narada_request_id", parent_request_id, raising=False
+    )
+
+    env = narada_pkg.RemoteBrowserEnvironment(
+        browser_window_id="browser-window-123",
+        cloud_browser_session_id="session-123",
+        api_key="test-api-key",
+    )
+    response = await narada_pkg.Agent(environment=env, kind=kind).run("return a trace")
+
+    assert response.execution_trace_context == execution_trace_context
+    assert response.model_dump(by_alias=True)["executionTraceContext"] == (
+        execution_trace_context
+    )
+    payload = json.loads(pyfetch.await_args_list[0].kwargs["body"])
+    if parent_request_id is None:
+        assert "parentRequestId" not in payload
+    else:
+        assert payload["parentRequestId"] == parent_request_id
+
+
 @pytest.mark.asyncio
 async def test_agent_run_preserves_operator_action_trace_timing(
     monkeypatch: pytest.MonkeyPatch,

--- a/packages/narada/src/narada/agent.py
+++ b/packages/narada/src/narada/agent.py
@@ -218,6 +218,7 @@ class Agent(Generic[_StructuredOutput]):
             action_trace=action_trace,
             workflow_trace=workflow_trace,
             critic_result=critic_result,
+            execution_trace_context=response_content.get("executionTraceContext"),
         )
 
     async def _dispatch_request(

--- a/packages/narada/tests/test_cloud_browser.py
+++ b/packages/narada/tests/test_cloud_browser.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, call
 import pytest
 from narada import (
     Agent,
+    AgentKind,
     CloudBrowserEnvironment,
     LambdaEnvironment,
     RemoteBrowserEnvironment,
@@ -833,6 +834,70 @@ async def test_agent_run_exposes_workflow_trace_alias(
 
     assert response.workflow_trace == workflow_trace
     assert response.model_dump(by_alias=True)["workflowTrace"] == workflow_trace
+
+
+@pytest.mark.parametrize(
+    ("kind", "execution_trace_context"),
+    [
+        (
+            AgentKind.OPERATOR,
+            {
+                "type": "executionTraceContext",
+                "schemaVersion": 1,
+                "traceId": "trace-operator",
+                "segmentId": "segment-operator",
+                "status": "completed",
+            },
+        ),
+        (
+            "/owner@example.com/project/nested.py",
+            {
+                "type": "executionTraceContext",
+                "schemaVersion": 1,
+                "traceId": "trace-parent",
+                "segmentId": "segment-executable",
+                "parentSegmentId": "segment-parent",
+                "status": "completed",
+            },
+        ),
+    ],
+    ids=["operator", "parented-project-executable"],
+)
+@pytest.mark.asyncio
+async def test_agent_run_preserves_execution_trace_context(
+    monkeypatch: pytest.MonkeyPatch,
+    kind: AgentKind | str,
+    execution_trace_context: dict[str, object],
+) -> None:
+    env = RemoteBrowserEnvironment(
+        browser_window_id="browser-window-123",
+        auth_headers={"x-api-key": "test-key"},
+    )
+    monkeypatch.setattr(
+        env,
+        "_dispatch_request",
+        AsyncMock(
+            return_value={
+                "requestId": "request-123",
+                "status": "success",
+                "response": {
+                    "text": "done",
+                    "output": {"type": "text", "content": "done"},
+                    "executionTraceContext": execution_trace_context,
+                },
+                "completedAt": "2026-01-01T00:00:01Z",
+                "usage": {"actions": 0, "credits": 0},
+                "activeInputRequest": None,
+            }
+        ),
+    )
+
+    response = await Agent(environment=env, kind=kind).run("return a trace")
+
+    assert response.execution_trace_context == execution_trace_context
+    assert response.model_dump(by_alias=True)["executionTraceContext"] == (
+        execution_trace_context
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Preserve the existing Remote Dispatch executionTraceContext on returned AgentResponse objects in both CPython and Pyodide.

This is a narrow public-SDK compatibility boundary for generic ExecutionTrace propagation. It adds , project-executable endpoint, interrupt handle, hidden credential, or compatibility facade.

## Testing

- CPython focused cloud-browser tests: 22 passed
- Pyodide focused cloud-browser tests: 33 passed
- Ruff format and lint passed
- wheel builds and isolated imports passed
- fresh exact-SHA SDK boundary review: PASS

## Codex sibling refs

- frontend: https://github.com/NaradaAI/frontend/pull/1956
- caddie: branch:codex/h03-caddie-stack-build
- desktop-automation-app:
- api-docs:
