### PR TITLE
Expose reasoning effort for all built-in agents

### DIFF
--- a/packages/narada-core/pyproject.toml
+++ b/packages/narada-core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "narada-core"
-version = "0.1.5"
+version = "0.1.6"
 description = "Code shared by the `narada` and `narada-pyodide` packages."
 license = "Apache-2.0"
 readme = "README.md"

--- a/packages/narada-core/src/narada_core/models.py
+++ b/packages/narada-core/src/narada_core/models.py
@@ -24,10 +24,7 @@ class AgentKind(Enum):
 
 
 class ReasoningEffort(StrEnum):
-    """Controls how much reasoning the Core Agent uses before responding.
-
-    Only `AgentKind.CORE_AGENT` supports this option; other agents raise `ValueError`.
-    """
+    """Controls how much reasoning a built-in Narada agent uses before responding."""
 
     NONE = "none"
     LOW = "low"

--- a/packages/narada-pyodide/pyproject.toml
+++ b/packages/narada-pyodide/pyproject.toml
@@ -1,14 +1,14 @@
 
 [project]
 name = "narada-pyodide"
-version = "0.1.5"
+version = "0.1.6"
 description = "Pyodide-compatible Python client SDK for Narada"
 license = "Apache-2.0"
 readme = "README.md"
 authors = [{ name = "Narada", email = "support@narada.ai" }]
 requires-python = ">=3.12"
 dependencies = [
-    "narada-core==0.1.5",
+    "narada-core==0.1.6",
     # Must be a supported version in https://pyodide.org/en/stable/usage/packages-in-pyodide.html
     "packaging==24.2",
 ]

--- a/packages/narada-pyodide/src/narada/agent.py
+++ b/packages/narada-pyodide/src/narada/agent.py
@@ -83,8 +83,6 @@ class Agent(Generic[_StructuredOutput]):
         self.environment = environment
         self.kind = kind
 
-    # `reasoning` is only valid with the Core Agent; these two overloads make
-    # that constraint type-checkable when callers construct a core-agent instance.
     @overload
     async def run(
         self,
@@ -162,6 +160,12 @@ class Agent(Generic[_StructuredOutput]):
         timeout: int = 1000,
     ) -> AgentResponse:
         """Invokes an agent in the bound Narada environment."""
+        if reasoning is not None and not isinstance(self.kind, AgentKind):
+            raise ValueError(
+                "`reasoning` is only supported for built-in `AgentKind` values; "
+                "named Agent Studio agents own reasoning per workflow step"
+            )
+
         remote_dispatch_response = await self._dispatch_request(
             prompt=prompt,
             clear_chat=clear_chat,
@@ -254,70 +258,29 @@ class Agent(Generic[_StructuredOutput]):
         timeout: int = 1000,
     ) -> Response:
         dispatch_agent = self.kind if agent is None else agent
-        # Branch on `reasoning` so each call site binds a single, typed overload
-        # of `_dispatch_request`. The validation also lives in `_dispatch_request`
-        # itself (defense in depth + reachable when callers go straight to the
-        # low-level API), so the redundancy here is intentional.
-        if reasoning is None:
-            remote_dispatch_response = await self.environment._dispatch_request(
-                prompt=prompt,
-                agent=dispatch_agent,
-                clear_chat=clear_chat,
-                generate_gif=generate_gif,
-                output_schema=output_schema,
-                previous_request_id=previous_request_id,
-                chat_history=chat_history,
-                additional_context=additional_context,
-                attachment=attachment,
-                time_zone=time_zone,
-                user_resource_credentials=user_resource_credentials,
-                mcp_servers=mcp_servers,
-                secret_variables=secret_variables,
-                input_variables=input_variables,
-                callback_url=callback_url,
-                callback_secret=callback_secret,
-                callback_headers=callback_headers,
-                on_input_required=on_input_required,
-                critic_context=critic_context,
-                timeout=timeout,
-            )
-        else:
-            if dispatch_agent is not AgentKind.CORE_AGENT:
-                raise ValueError(
-                    "`reasoning` is only supported with `kind=AgentKind.CORE_AGENT` "
-                    f"(got kind={dispatch_agent!r})"
-                )
-            # The CORE_AGENT-specific overloads of `_dispatch_request` split on
-            # a narrower `output_schema` discriminator (None vs `type[T]`),
-            # which the impl's `type[BaseModel] | None` union doesn't cleanly
-            # narrow into without further branching. The public `run()`
-            # overloads above already give callers correct return-type
-            # narrowing, so the internal forward call bypasses overload
-            # disambiguation on this single dimension.
-            remote_dispatch_response = await self.environment._dispatch_request(  # pyright: ignore[reportCallIssue]
-                prompt=prompt,
-                agent=dispatch_agent,
-                reasoning=reasoning,
-                clear_chat=clear_chat,
-                generate_gif=generate_gif,
-                output_schema=output_schema,  # pyright: ignore[reportArgumentType]
-                previous_request_id=previous_request_id,
-                chat_history=chat_history,
-                additional_context=additional_context,
-                attachment=attachment,
-                time_zone=time_zone,
-                user_resource_credentials=user_resource_credentials,
-                mcp_servers=mcp_servers,
-                secret_variables=secret_variables,
-                input_variables=input_variables,
-                callback_url=callback_url,
-                callback_secret=callback_secret,
-                callback_headers=callback_headers,
-                on_input_required=on_input_required,
-                critic_context=critic_context,
-                timeout=timeout,
-            )
-        return remote_dispatch_response
+        return await self.environment._dispatch_request(
+            prompt=prompt,
+            agent=dispatch_agent,
+            reasoning=reasoning,
+            clear_chat=clear_chat,
+            generate_gif=generate_gif,
+            output_schema=output_schema,
+            previous_request_id=previous_request_id,
+            chat_history=chat_history,
+            additional_context=additional_context,
+            attachment=attachment,
+            time_zone=time_zone,
+            user_resource_credentials=user_resource_credentials,
+            mcp_servers=mcp_servers,
+            secret_variables=secret_variables,
+            input_variables=input_variables,
+            callback_url=callback_url,
+            callback_secret=callback_secret,
+            callback_headers=callback_headers,
+            on_input_required=on_input_required,
+            critic_context=critic_context,
+            timeout=timeout,
+        )
 
     def _browser_environment(self) -> BaseBrowserEnvironment:
         if not isinstance(self.environment, BaseBrowserEnvironment):

--- a/packages/narada-pyodide/src/narada/environment.py
+++ b/packages/narada-pyodide/src/narada/environment.py
@@ -412,67 +412,13 @@ class Environment(ABC):
             "mimeType": mime_type,
         }
 
-    # `reasoning` is only valid with the Core Agent; these two overloads make
-    # that constraint type-checkable. Generic-agent calls fall through to the
-    # general overloads below, which do not accept a `reasoning` argument.
-    @overload
-    async def _dispatch_request(
-        self,
-        *,
-        prompt: str,
-        agent: Literal[AgentKind.CORE_AGENT],
-        reasoning: ReasoningEffort | None = None,
-        clear_chat: bool | None = None,
-        generate_gif: bool | None = None,
-        output_schema: None = None,
-        previous_request_id: str | None = None,
-        chat_history: list[RemoteDispatchChatHistoryItem] | None = None,
-        additional_context: dict[str, str] | None = None,
-        attachment: File | IO[Any] | None = None,
-        time_zone: str = "America/Los_Angeles",
-        user_resource_credentials: UserResourceCredentials | None = None,
-        mcp_servers: list[McpServer] | None = None,
-        secret_variables: dict[str, str] | None = None,
-        input_variables: Mapping[str, Any] | None = None,
-        callback_url: str | None = None,
-        callback_secret: str | None = None,
-        callback_headers: dict[str, Any] | None = None,
-        on_input_required: InputRequiredCallback | None = None,
-        timeout: int = 1000,
-    ) -> Response[None]: ...
-
-    @overload
-    async def _dispatch_request(
-        self,
-        *,
-        prompt: str,
-        agent: Literal[AgentKind.CORE_AGENT],
-        reasoning: ReasoningEffort | None = None,
-        clear_chat: bool | None = None,
-        generate_gif: bool | None = None,
-        output_schema: type[_StructuredOutput],
-        previous_request_id: str | None = None,
-        chat_history: list[RemoteDispatchChatHistoryItem] | None = None,
-        additional_context: dict[str, str] | None = None,
-        attachment: File | IO[Any] | None = None,
-        time_zone: str = "America/Los_Angeles",
-        user_resource_credentials: UserResourceCredentials | None = None,
-        mcp_servers: list[McpServer] | None = None,
-        secret_variables: dict[str, str] | None = None,
-        input_variables: Mapping[str, Any] | None = None,
-        callback_url: str | None = None,
-        callback_secret: str | None = None,
-        callback_headers: dict[str, Any] | None = None,
-        on_input_required: InputRequiredCallback | None = None,
-        timeout: int = 1000,
-    ) -> Response[_StructuredOutput]: ...
-
     @overload
     async def _dispatch_request(
         self,
         *,
         prompt: str,
         agent: AgentKind | str = AgentKind.OPERATOR,
+        reasoning: ReasoningEffort | None = None,
         clear_chat: bool | None = None,
         generate_gif: bool | None = None,
         output_schema: None = None,
@@ -499,6 +445,7 @@ class Environment(ABC):
         *,
         prompt: str,
         agent: AgentKind | str = AgentKind.OPERATOR,
+        reasoning: ReasoningEffort | None = None,
         clear_chat: bool | None = None,
         generate_gif: bool | None = None,
         output_schema: type[_StructuredOutput],
@@ -548,16 +495,8 @@ class Environment(ABC):
 
         The higher-level `Agent.run` method should be preferred for most use cases.
         """
-        # The overloads enforce this at type-check time when callers use
-        # ``AgentKind.CORE_AGENT``; the runtime check covers string-form agents
-        # (``agent="..."``) and callers without a type checker.
         await self._ensure_initialized()
 
-        if reasoning is not None and agent is not AgentKind.CORE_AGENT:
-            raise ValueError(
-                "`reasoning` is only supported with `agent=AgentKind.CORE_AGENT` "
-                f"(got agent={agent!r})"
-            )
         # Trace instrumentation: the entire method body is wrapped so that any
         # exit (successful return, timeout, or non-timeout failure) produces a
         # ``subAgentCall`` trace event with matching status. See `_trace.py`.

--- a/packages/narada-pyodide/tests/test_cloud_browser.py
+++ b/packages/narada-pyodide/tests/test_cloud_browser.py
@@ -12,6 +12,7 @@ from narada_core.actions.models import (
     DEFAULT_HITL_TIMEOUT_SECONDS,
     PromptForUserInputVariable,
 )
+from narada_core.models import AgentKind, ReasoningEffort
 from packaging.version import InvalidVersion
 
 PROJECT_ROOT = Path(__file__).resolve().parents[3]
@@ -474,6 +475,74 @@ async def test_agent_run_forwards_clear_chat(
 
     payload = json.loads(pyfetch.await_args_list[0].kwargs["body"])
     assert payload["clearChat"] is True
+    assert "reasoningMode" not in payload
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("kind", "reasoning", "expected_prompt"),
+    [
+        (AgentKind.PRODUCTIVITY, ReasoningEffort.NONE, "analyze"),
+        (AgentKind.OPERATOR, ReasoningEffort.LOW, "/Operator analyze"),
+        (AgentKind.CORE_AGENT, ReasoningEffort.MEDIUM, "/coreAgent analyze"),
+    ],
+)
+async def test_agent_run_forwards_reasoning_for_every_agent_kind(
+    monkeypatch: pytest.MonkeyPatch,
+    kind: AgentKind | str,
+    reasoning: ReasoningEffort,
+    expected_prompt: str,
+) -> None:
+    pyfetch = AsyncMock(
+        side_effect=[
+            _FakeResponse(json_data={"requestId": "child-request-123"}),
+            _FakeResponse(
+                json_data={
+                    "status": "success",
+                    "response": {
+                        "text": "done",
+                        "output": {"type": "text", "content": "done"},
+                    },
+                    "completedAt": "2026-05-08T00:00:00+00:00",
+                    "usage": {"actions": 0, "credits": 0},
+                    "hitlInputMetadata": None,
+                }
+            ),
+        ]
+    )
+    narada_pkg, _ = _import_pyodide_narada(monkeypatch, pyfetch=pyfetch)
+
+    env = narada_pkg.RemoteBrowserEnvironment(
+        browser_window_id="browser-window-123",
+        cloud_browser_session_id="session-123",
+        api_key="test-api-key",
+    )
+    await narada_pkg.Agent(environment=env, kind=kind).run(
+        "analyze",
+        reasoning=reasoning,
+    )
+
+    payload = json.loads(pyfetch.await_args_list[0].kwargs["body"])
+    assert payload["prompt"] == expected_prompt
+    assert payload["reasoningMode"] == reasoning.value
+
+
+@pytest.mark.asyncio
+async def test_agent_run_rejects_top_level_reasoning_for_named_agent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    narada_pkg, _ = _import_pyodide_narada(monkeypatch, pyfetch=AsyncMock())
+    env = narada_pkg.RemoteBrowserEnvironment(
+        browser_window_id="browser-window-123",
+        cloud_browser_session_id="session-123",
+        api_key="test-api-key",
+    )
+
+    with pytest.raises(ValueError, match="named Agent Studio agents"):
+        await narada_pkg.Agent(environment=env, kind="/owner/custom-agent").run(
+            "analyze",
+            reasoning=narada_pkg.ReasoningEffort.HIGH,
+        )
 
 
 @pytest.mark.asyncio

--- a/packages/narada/pyproject.toml
+++ b/packages/narada/pyproject.toml
@@ -1,13 +1,13 @@
 [project]
 name = "narada"
-version = "0.2.8"
+version = "0.2.9"
 description = "Python client SDK for Narada"
 license = "Apache-2.0"
 readme = "README.md"
 authors = [{ name = "Narada", email = "support@narada.ai" }]
 requires-python = ">=3.12"
 dependencies = [
-    "narada-core==0.1.5",
+    "narada-core==0.1.6",
     "aiohttp>=3.12.13",
     "playwright>=1.53.0",
     "rich>=14.0.0",

--- a/packages/narada/src/narada/agent.py
+++ b/packages/narada/src/narada/agent.py
@@ -81,8 +81,6 @@ class Agent(Generic[_StructuredOutput]):
         self.environment = environment
         self.kind = kind
 
-    # `reasoning` is only valid with the Core Agent; these two overloads make
-    # that constraint type-checkable when callers construct a core-agent instance.
     @overload
     async def run(
         self,
@@ -160,6 +158,12 @@ class Agent(Generic[_StructuredOutput]):
         timeout: int = 1000,
     ) -> AgentResponse:
         """Invokes an agent in the bound Narada environment."""
+        if reasoning is not None and not isinstance(self.kind, AgentKind):
+            raise ValueError(
+                "`reasoning` is only supported for built-in `AgentKind` values; "
+                "named Agent Studio agents own reasoning per workflow step"
+            )
+
         remote_dispatch_response = await self._dispatch_request(
             prompt=prompt,
             clear_chat=clear_chat,
@@ -246,70 +250,29 @@ class Agent(Generic[_StructuredOutput]):
         timeout: int = 1000,
     ) -> Response:
         dispatch_agent = self.kind if agent is None else agent
-        # Branch on `reasoning` so each call site binds a single, typed overload
-        # of `_dispatch_request`. The validation also lives in `_dispatch_request`
-        # itself (defense in depth + reachable when callers go straight to the
-        # low-level API), so the redundancy here is intentional.
-        if reasoning is None:
-            remote_dispatch_response = await self.environment._dispatch_request(
-                prompt=prompt,
-                agent=dispatch_agent,
-                clear_chat=clear_chat,
-                generate_gif=generate_gif,
-                output_schema=output_schema,
-                previous_request_id=previous_request_id,
-                chat_history=chat_history,
-                additional_context=additional_context,
-                attachment=attachment,
-                time_zone=time_zone,
-                user_resource_credentials=user_resource_credentials,
-                mcp_servers=mcp_servers,
-                secret_variables=secret_variables,
-                input_variables=input_variables,
-                callback_url=callback_url,
-                callback_secret=callback_secret,
-                callback_headers=callback_headers,
-                on_input_required=on_input_required,
-                critic_context=critic_context,
-                timeout=timeout,
-            )
-        else:
-            if dispatch_agent is not AgentKind.CORE_AGENT:
-                raise ValueError(
-                    "`reasoning` is only supported with `kind=AgentKind.CORE_AGENT` "
-                    f"(got kind={dispatch_agent!r})"
-                )
-            # The CORE_AGENT-specific overloads of `_dispatch_request` split on
-            # a narrower `output_schema` discriminator (None vs `type[T]`),
-            # which the impl's `type[BaseModel] | None` union doesn't cleanly
-            # narrow into without further branching. The public `run()`
-            # overloads above already give callers correct return-type
-            # narrowing, so the internal forward call bypasses overload
-            # disambiguation on this single dimension.
-            remote_dispatch_response = await self.environment._dispatch_request(  # pyright: ignore[reportCallIssue]
-                prompt=prompt,
-                agent=dispatch_agent,
-                reasoning=reasoning,
-                clear_chat=clear_chat,
-                generate_gif=generate_gif,
-                output_schema=output_schema,  # pyright: ignore[reportArgumentType]
-                previous_request_id=previous_request_id,
-                chat_history=chat_history,
-                additional_context=additional_context,
-                attachment=attachment,
-                time_zone=time_zone,
-                user_resource_credentials=user_resource_credentials,
-                mcp_servers=mcp_servers,
-                secret_variables=secret_variables,
-                input_variables=input_variables,
-                callback_url=callback_url,
-                callback_secret=callback_secret,
-                callback_headers=callback_headers,
-                on_input_required=on_input_required,
-                critic_context=critic_context,
-                timeout=timeout,
-            )
-        return remote_dispatch_response
+        return await self.environment._dispatch_request(
+            prompt=prompt,
+            agent=dispatch_agent,
+            reasoning=reasoning,
+            clear_chat=clear_chat,
+            generate_gif=generate_gif,
+            output_schema=output_schema,
+            previous_request_id=previous_request_id,
+            chat_history=chat_history,
+            additional_context=additional_context,
+            attachment=attachment,
+            time_zone=time_zone,
+            user_resource_credentials=user_resource_credentials,
+            mcp_servers=mcp_servers,
+            secret_variables=secret_variables,
+            input_variables=input_variables,
+            callback_url=callback_url,
+            callback_secret=callback_secret,
+            callback_headers=callback_headers,
+            on_input_required=on_input_required,
+            critic_context=critic_context,
+            timeout=timeout,
+        )
 
     def _browser_environment(self) -> BaseBrowserEnvironment:
         if not isinstance(self.environment, BaseBrowserEnvironment):

--- a/packages/narada/src/narada/environment.py
+++ b/packages/narada/src/narada/environment.py
@@ -840,67 +840,13 @@ class Environment(ABC):
             "mimeType": mime_type,
         }
 
-    # `reasoning` is only valid with the Core Agent; these two overloads make
-    # that constraint type-checkable. Generic-agent calls fall through to the
-    # general overloads below, which do not accept a `reasoning` argument.
-    @overload
-    async def _dispatch_request(
-        self,
-        *,
-        prompt: str,
-        agent: Literal[AgentKind.CORE_AGENT],
-        reasoning: ReasoningEffort | None = None,
-        clear_chat: bool | None = None,
-        generate_gif: bool | None = None,
-        output_schema: None = None,
-        previous_request_id: str | None = None,
-        chat_history: list[RemoteDispatchChatHistoryItem] | None = None,
-        additional_context: dict[str, str] | None = None,
-        attachment: File | IO[Any] | None = None,
-        time_zone: str = "America/Los_Angeles",
-        user_resource_credentials: UserResourceCredentials | None = None,
-        mcp_servers: list[McpServer] | None = None,
-        secret_variables: dict[str, str] | None = None,
-        input_variables: Mapping[str, Any] | None = None,
-        callback_url: str | None = None,
-        callback_secret: str | None = None,
-        callback_headers: Mapping[str, Any] | None = None,
-        on_input_required: InputRequiredCallback | None = None,
-        timeout: int = 1000,
-    ) -> Response[None]: ...
-
-    @overload
-    async def _dispatch_request(
-        self,
-        *,
-        prompt: str,
-        agent: Literal[AgentKind.CORE_AGENT],
-        reasoning: ReasoningEffort | None = None,
-        clear_chat: bool | None = None,
-        generate_gif: bool | None = None,
-        output_schema: type[_StructuredOutput],
-        previous_request_id: str | None = None,
-        chat_history: list[RemoteDispatchChatHistoryItem] | None = None,
-        additional_context: dict[str, str] | None = None,
-        attachment: File | IO[Any] | None = None,
-        time_zone: str = "America/Los_Angeles",
-        user_resource_credentials: UserResourceCredentials | None = None,
-        mcp_servers: list[McpServer] | None = None,
-        secret_variables: dict[str, str] | None = None,
-        input_variables: Mapping[str, Any] | None = None,
-        callback_url: str | None = None,
-        callback_secret: str | None = None,
-        callback_headers: Mapping[str, Any] | None = None,
-        on_input_required: InputRequiredCallback | None = None,
-        timeout: int = 1000,
-    ) -> Response[_StructuredOutput]: ...
-
     @overload
     async def _dispatch_request(
         self,
         *,
         prompt: str,
         agent: AgentKind | str = AgentKind.OPERATOR,
+        reasoning: ReasoningEffort | None = None,
         clear_chat: bool | None = None,
         generate_gif: bool | None = None,
         output_schema: None = None,
@@ -927,6 +873,7 @@ class Environment(ABC):
         *,
         prompt: str,
         agent: AgentKind | str = AgentKind.OPERATOR,
+        reasoning: ReasoningEffort | None = None,
         clear_chat: bool | None = None,
         generate_gif: bool | None = None,
         output_schema: type[_StructuredOutput],
@@ -978,14 +925,6 @@ class Environment(ABC):
         """
         await self._ensure_initialized()
 
-        # The overloads enforce this at type-check time when callers use
-        # ``AgentKind.CORE_AGENT``; the runtime check covers string-form agents
-        # (``agent="..."``) and callers without a type checker.
-        if reasoning is not None and agent is not AgentKind.CORE_AGENT:
-            raise ValueError(
-                "`reasoning` is only supported with `agent=AgentKind.CORE_AGENT` "
-                f"(got agent={agent!r})"
-            )
         deadline = time.monotonic() + timeout
 
         agent_prefix = (

--- a/packages/narada/tests/test_agent.py
+++ b/packages/narada/tests/test_agent.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Any
 
 import pytest
-from narada import Agent, Environment
+from narada import Agent, AgentKind, Environment, ReasoningEffort
 
 
 class _FakeResponse:
@@ -100,6 +100,46 @@ async def test_agent_run_reruns_but_environment_initialization_is_cached(
         "/Operator first",
         "/Operator second",
     ]
+    assert all("reasoningMode" not in body for body in fake_session.dispatched_bodies)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("kind", "reasoning", "expected_prompt"),
+    [
+        (AgentKind.PRODUCTIVITY, ReasoningEffort.NONE, "analyze"),
+        (AgentKind.OPERATOR, ReasoningEffort.LOW, "/Operator analyze"),
+        (AgentKind.CORE_AGENT, ReasoningEffort.MEDIUM, "/coreAgent analyze"),
+    ],
+)
+async def test_agent_run_forwards_reasoning_for_every_agent_kind(
+    monkeypatch: pytest.MonkeyPatch,
+    kind: AgentKind | str,
+    reasoning: ReasoningEffort,
+    expected_prompt: str,
+) -> None:
+    import narada.environment as environment_module
+
+    fake_session = _RemoteDispatchFakeClientSession()
+    monkeypatch.setattr(
+        environment_module.aiohttp, "ClientSession", lambda: fake_session
+    )
+
+    await Agent(environment=_CountingEnvironment(), kind=kind).run(
+        "analyze",
+        reasoning=reasoning,
+    )
+
+    assert fake_session.dispatched_bodies[0]["prompt"] == expected_prompt
+    assert fake_session.dispatched_bodies[0]["reasoningMode"] == reasoning.value
+
+
+@pytest.mark.asyncio
+async def test_agent_run_rejects_top_level_reasoning_for_named_agent() -> None:
+    agent = Agent(environment=_CountingEnvironment(), kind="/owner/custom-agent")
+
+    with pytest.raises(ValueError, match="named Agent Studio agents"):
+        await agent.run("analyze", reasoning=ReasoningEffort.HIGH)
 
 
 @pytest.mark.asyncio

--- a/uv.lock
+++ b/uv.lock
@@ -312,7 +312,7 @@ wheels = [
 
 [[package]]
 name = "narada"
-version = "0.2.8"
+version = "0.2.9"
 source = { editable = "packages/narada" }
 dependencies = [
     { name = "aiohttp" },
@@ -345,7 +345,7 @@ dev = [
 
 [[package]]
 name = "narada-core"
-version = "0.1.5"
+version = "0.1.6"
 source = { editable = "packages/narada-core" }
 dependencies = [
     { name = "pydantic" },
@@ -356,7 +356,7 @@ requires-dist = [{ name = "pydantic", specifier = "==2.12.5" }]
 
 [[package]]
 name = "narada-pyodide"
-version = "0.1.5"
+version = "0.1.6"
 source = { editable = "packages/narada-pyodide" }
 dependencies = [
     { name = "narada-core" },


### PR DESCRIPTION
## Summary

- allow `Agent.run(reasoning=...)` for Productivity, Operator, and Core in both CPython and Pyodide
- preserve omission semantics so agent defaults remain intact unless callers explicitly send none/low/medium/high
- keep named Agent Studio workflows on their existing per-step reasoning policy
- update coordinated package versions and the lockfile for the Pyodide consumer
- pin the exact architecture contract revision

## Testing

- `uv run pytest packages/narada/tests/test_agent.py packages/narada-pyodide/tests/test_cloud_browser.py -q` — 40 passed
- `uv run pytest packages/narada-pyodide/tests` — 34 passed
- `uv run pytest packages/narada/tests` — 110 passed; 2 pre-existing macOS failures in Windows-only process tests (`subprocess.CREATE_NEW_PROCESS_GROUP`)
- `uv run ruff format --check --diff`
- `uv run ruff check`
- `uv lock --check`
- `uv build --all-packages`

## Codex sibling refs

- caddie: https://github.com/NaradaAI/caddie/pull/6846
- frontend: https://github.com/NaradaAI/frontend/pull/1983
- architecture-docs: https://github.com/NaradaAI/architecture-docs/pull/67
