### PR TITLE
Forward Pyodide client instance routing

### DIFF
--- a/packages/narada-pyodide/src/narada/environment.py
+++ b/packages/narada-pyodide/src/narada/environment.py
@@ -113,6 +113,9 @@ _ResponseModel = TypeVar("_ResponseModel", bound=BaseModel)
 # can report active input-required status.
 _REMOTE_DISPATCH_REQUEST_ID_ENV_VAR = "NARADA_REMOTE_DISPATCH_REQUEST_ID"
 _REMOTE_DISPATCH_API_KEY_ID_ENV_VAR = "NARADA_REMOTE_DISPATCH_API_KEY_ID"
+_REMOTE_DISPATCH_TARGET_CLIENT_INSTANCE_ID_ENV_VAR = (
+    "NARADA_REMOTE_DISPATCH_TARGET_CLIENT_INSTANCE_ID"
+)
 
 type InputRequiredCallback = Callable[[ActiveInputRequest], Awaitable[None] | None]
 
@@ -294,6 +297,10 @@ class Environment(ABC):
 
     @property
     def _dispatch_browser_window_id(self) -> str | None:
+        return None
+
+    @property
+    def _dispatch_target_client_instance_id(self) -> str | None:
         return None
 
     async def _fetch_sdk_config(self) -> _SdkConfig | None:
@@ -578,6 +585,9 @@ class Environment(ABC):
         browser_window_id = self._dispatch_browser_window_id
         if browser_window_id is not None:
             body["browserWindowId"] = browser_window_id
+        target_client_instance_id = self._dispatch_target_client_instance_id
+        if target_client_instance_id is not None:
+            body["targetClientInstanceId"] = target_client_instance_id
         parent_run_ids = self._current_parent_run_ids()
         if parent_run_ids:
             body["parentRunIds"] = parent_run_ids
@@ -957,6 +967,10 @@ class BrowserEnvironment(BaseBrowserEnvironment):
 
     def __str__(self) -> str:
         return f"BrowserEnvironment(browser_window_id={self.browser_window_id})"
+
+    @property
+    def _dispatch_target_client_instance_id(self) -> str | None:
+        return os.environ.get(_REMOTE_DISPATCH_TARGET_CLIENT_INSTANCE_ID_ENV_VAR)
 
     @override
     def _current_parent_run_ids(self) -> list[str] | None:

--- a/packages/narada-pyodide/tests/test_cloud_browser.py
+++ b/packages/narada-pyodide/tests/test_cloud_browser.py
@@ -287,6 +287,9 @@ async def test_remote_browser_environment_close_stops_cloud_session(
 async def test_remote_browser_environment_dispatch_omits_parent_run_ids(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    monkeypatch.setenv(
+        "NARADA_REMOTE_DISPATCH_TARGET_CLIENT_INSTANCE_ID", "local-client-instance"
+    )
     pyfetch = AsyncMock(
         side_effect=[
             _FakeResponse(json_data={"requestId": "req-123"}),
@@ -316,6 +319,7 @@ async def test_remote_browser_environment_dispatch_omits_parent_run_ids(
     assert payload["cloudBrowserSessionId"] == "session-123"
     assert payload["prompt"] == "/Operator hello from cloud browser"
     assert "parentRunIds" not in payload
+    assert "targetClientInstanceId" not in payload
 
 
 @pytest.mark.asyncio
@@ -1189,6 +1193,9 @@ async def test_local_browser_environment_dispatch_uses_latest_parent_run_ids(
     monkeypatch.setenv("NARADA_API_KEY", "test-api-key")
     monkeypatch.setenv("NARADA_BROWSER_WINDOW_ID", "browser-window-123")
     monkeypatch.setenv(
+        "NARADA_REMOTE_DISPATCH_TARGET_CLIENT_INSTANCE_ID", "client-instance-123"
+    )
+    monkeypatch.setenv(
         "NARADA_EXECUTION_TRACE_CONTEXT",
         json.dumps(
             {
@@ -1239,6 +1246,8 @@ async def test_local_browser_environment_dispatch_uses_latest_parent_run_ids(
     second_post = json.loads(pyfetch.await_args_list[3].kwargs["body"])
     assert first_post["parentRunIds"] == ["run-a"]
     assert second_post["parentRunIds"] == ["run-b", "run-c"]
+    assert first_post["targetClientInstanceId"] == "client-instance-123"
+    assert second_post["targetClientInstanceId"] == "client-instance-123"
     assert first_post["executionTraceContext"] == {
         "type": "executionTraceInheritanceContext",
         "schemaVersion": 1,


### PR DESCRIPTION
## Summary

Updates `narada-pyodide` to forward the current frontend runtime ID in local browser remote-dispatch requests.

- Read `NARADA_REMOTE_DISPATCH_TARGET_CLIENT_INSTANCE_ID` in `BrowserEnvironment`.
- Add it as `targetClientInstanceId` to `/remote-dispatch` requests.
- Keep the field private to the routing implementation.
- Do not forward the current page target from `RemoteBrowserEnvironment` or cloud environments, since those environments route to a different browser runtime.

This ensures nested `Agent.run()` calls started by a local Python Agent Studio workflow return to the same frontend runtime that initiated the workflow.

## Testing

- Verified local `BrowserEnvironment` forwards `targetClientInstanceId`.
- Verified `RemoteBrowserEnvironment` does not inherit or forward the local target.
- Focused pytest tests passed.
- Ruff formatting and lint checks passed.

## Codex sibling refs

- frontend: branch:pavlo/target-client-instance-routing
- caddie: branch:pavlo/target-client-instance-routing
- architecture-docs: branch:pavlo/target-client-instance-routing