### PR TITLE
pass api key id

### DIFF
--- a/packages/narada-pyodide/pyproject.toml
+++ b/packages/narada-pyodide/pyproject.toml
@@ -1,7 +1,7 @@
 
 [project]
 name = "narada-pyodide"
-version = "0.1.4"
+version = "0.1.7"
 description = "Pyodide-compatible Python client SDK for Narada"
 license = "Apache-2.0"
 readme = "README.md"

--- a/packages/narada-pyodide/src/narada/environment.py
+++ b/packages/narada-pyodide/src/narada/environment.py
@@ -200,6 +200,9 @@ async def _build_auth_headers(
     headers["Authorization"] = f"Bearer {await _narada_get_id_token()}"
     headers["X-Narada-User-ID"] = user_id
     headers["X-Narada-Env"] = env
+    remote_dispatch_api_key_id = os.environ.get(_REMOTE_DISPATCH_API_KEY_ID_ENV_VAR)
+    if remote_dispatch_api_key_id:
+        headers["x-api-key-id"] = remote_dispatch_api_key_id
     return headers
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -356,7 +356,7 @@ requires-dist = [{ name = "pydantic", specifier = "==2.12.5" }]
 
 [[package]]
 name = "narada-pyodide"
-version = "0.1.4"
+version = "0.1.7"
 source = { editable = "packages/narada-pyodide" }
 dependencies = [
     { name = "narada-core" },


### PR DESCRIPTION
Forward API-key origin through Pyodide so Cloud Browser spend can be attributed to the SDK key that initiated an Agent Studio workflow. `narada-pyodide` now reads the existing `NARADA_REMOTE_DISPATCH_API_KEY_ID` runtime context and forwards it as `x-api-key-id` on authenticated requests when present. This preserves attribution for SDK-originated Pyodide Cloud Browser sessions, while UI-initiated runs, which have no origin key ID, remain unchanged. 