### PR TITLE
Expose agent model tiers in the Python SDK

### DIFF
--- a/packages/narada-core/pyproject.toml
+++ b/packages/narada-core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "narada-core"
-version = "0.1.6"
+version = "0.1.7"
 description = "Code shared by the `narada` and `narada-pyodide` packages."
 license = "Apache-2.0"
 readme = "README.md"

--- a/packages/narada-core/src/narada_core/models.py
+++ b/packages/narada-core/src/narada_core/models.py
@@ -23,6 +23,13 @@ class AgentKind(Enum):
                 return "/coreAgent "
 
 
+class AgentModelTier(StrEnum):
+    """Selects the product model tier for a Narada agent invocation."""
+
+    DEFAULT = "default"
+    MINI = "mini"
+
+
 class ReasoningEffort(StrEnum):
     """Controls how much reasoning a built-in Narada agent uses before responding."""
 

--- a/packages/narada-pyodide/pyproject.toml
+++ b/packages/narada-pyodide/pyproject.toml
@@ -1,14 +1,14 @@
 
 [project]
 name = "narada-pyodide"
-version = "0.1.7"
+version = "0.1.8"
 description = "Pyodide-compatible Python client SDK for Narada"
 license = "Apache-2.0"
 readme = "README.md"
 authors = [{ name = "Narada", email = "support@narada.ai" }]
 requires-python = ">=3.12"
 dependencies = [
-    "narada-core==0.1.6",
+    "narada-core==0.1.7",
     # Must be a supported version in https://pyodide.org/en/stable/usage/packages-in-pyodide.html
     "packaging==24.2",
 ]

--- a/packages/narada-pyodide/src/narada/__init__.py
+++ b/packages/narada-pyodide/src/narada/__init__.py
@@ -9,6 +9,7 @@ from narada_core.errors import (
 )
 from narada_core.models import (
     AgentKind,
+    AgentModelTier,
     CriticConfig,
     File,
     ReasoningEffort,
@@ -34,6 +35,7 @@ __all__ = [
     "HitlInputMetadata",
     "Agent",
     "AgentKind",
+    "AgentModelTier",
     "BaseBrowserEnvironment",
     "BrowserEnvironment",
     "CloudBrowserEnvironment",

--- a/packages/narada-pyodide/src/narada/agent.py
+++ b/packages/narada-pyodide/src/narada/agent.py
@@ -168,6 +168,13 @@ class Agent(Generic[_StructuredOutput]):
                 "`reasoning` is only supported for built-in `AgentKind` values; "
                 "named Agent Studio agents own reasoning per workflow step"
             )
+        if self.model_tier != AgentModelTier.DEFAULT and not isinstance(
+            self.kind, AgentKind
+        ):
+            raise ValueError(
+                "`model_tier` is only supported for built-in `AgentKind` values; "
+                "named Agent Studio agents own model tiers per workflow step"
+            )
 
         remote_dispatch_response = await self._dispatch_request(
             prompt=prompt,

--- a/packages/narada-pyodide/src/narada/agent.py
+++ b/packages/narada-pyodide/src/narada/agent.py
@@ -51,6 +51,7 @@ from narada_core.actions.models import (
 )
 from narada_core.models import (
     AgentKind,
+    AgentModelTier,
     CriticConfig,
     File,
     McpServer,
@@ -79,9 +80,11 @@ class Agent(Generic[_StructuredOutput]):
         *,
         environment: Environment,
         kind: AgentKind | str = AgentKind.OPERATOR,
+        model_tier: AgentModelTier = AgentModelTier.DEFAULT,
     ) -> None:
         self.environment = environment
         self.kind = kind
+        self.model_tier = model_tier
 
     @overload
     async def run(
@@ -168,6 +171,7 @@ class Agent(Generic[_StructuredOutput]):
 
         remote_dispatch_response = await self._dispatch_request(
             prompt=prompt,
+            model_tier=self.model_tier,
             clear_chat=clear_chat,
             generate_gif=generate_gif,
             output_schema=output_schema,
@@ -237,6 +241,7 @@ class Agent(Generic[_StructuredOutput]):
         *,
         prompt: str,
         agent: AgentKind | str | None = None,
+        model_tier: AgentModelTier = AgentModelTier.DEFAULT,
         reasoning: ReasoningEffort | None = None,
         clear_chat: bool | None = None,
         generate_gif: bool | None = None,
@@ -261,6 +266,7 @@ class Agent(Generic[_StructuredOutput]):
         return await self.environment._dispatch_request(
             prompt=prompt,
             agent=dispatch_agent,
+            model_tier=model_tier,
             reasoning=reasoning,
             clear_chat=clear_chat,
             generate_gif=generate_gif,

--- a/packages/narada-pyodide/src/narada/environment.py
+++ b/packages/narada-pyodide/src/narada/environment.py
@@ -44,6 +44,7 @@ from narada_core.errors import (
 )
 from narada_core.models import (
     AgentKind,
+    AgentModelTier,
     File,
     McpServer,
     ReasoningEffort,
@@ -421,6 +422,7 @@ class Environment(ABC):
         *,
         prompt: str,
         agent: AgentKind | str = AgentKind.OPERATOR,
+        model_tier: AgentModelTier = AgentModelTier.DEFAULT,
         reasoning: ReasoningEffort | None = None,
         clear_chat: bool | None = None,
         generate_gif: bool | None = None,
@@ -448,6 +450,7 @@ class Environment(ABC):
         *,
         prompt: str,
         agent: AgentKind | str = AgentKind.OPERATOR,
+        model_tier: AgentModelTier = AgentModelTier.DEFAULT,
         reasoning: ReasoningEffort | None = None,
         clear_chat: bool | None = None,
         generate_gif: bool | None = None,
@@ -474,6 +477,7 @@ class Environment(ABC):
         *,
         prompt: str,
         agent: AgentKind | str = AgentKind.OPERATOR,
+        model_tier: AgentModelTier = AgentModelTier.DEFAULT,
         reasoning: ReasoningEffort | None = None,
         clear_chat: bool | None = None,
         generate_gif: bool | None = None,
@@ -574,6 +578,8 @@ class Environment(ABC):
             body["callbackHeaders"] = callback_headers
         if reasoning is not None:
             body["reasoningMode"] = reasoning.value
+        if model_tier is not AgentModelTier.DEFAULT:
+            body["modelTier"] = model_tier.value
 
         try:
             seen_input_ids: set[str] = set()

--- a/packages/narada-pyodide/tests/test_cloud_browser.py
+++ b/packages/narada-pyodide/tests/test_cloud_browser.py
@@ -476,6 +476,44 @@ async def test_agent_run_forwards_clear_chat(
     payload = json.loads(pyfetch.await_args_list[0].kwargs["body"])
     assert payload["clearChat"] is True
     assert "reasoningMode" not in payload
+    assert "modelTier" not in payload
+
+
+@pytest.mark.asyncio
+async def test_agent_run_forwards_mini_model_tier(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pyfetch = AsyncMock(
+        side_effect=[
+            _FakeResponse(json_data={"requestId": "child-request-123"}),
+            _FakeResponse(
+                json_data={
+                    "status": "success",
+                    "response": {
+                        "text": "done",
+                        "output": {"type": "text", "content": "done"},
+                    },
+                    "completedAt": "2026-05-08T00:00:00+00:00",
+                    "usage": {"actions": 0, "credits": 0},
+                    "hitlInputMetadata": None,
+                }
+            ),
+        ]
+    )
+    narada_pkg, _ = _import_pyodide_narada(monkeypatch, pyfetch=pyfetch)
+
+    env = narada_pkg.RemoteBrowserEnvironment(
+        browser_window_id="browser-window-123",
+        cloud_browser_session_id="session-123",
+        api_key="test-api-key",
+    )
+    await narada_pkg.Agent(
+        environment=env,
+        model_tier=narada_pkg.AgentModelTier.MINI,
+    ).run("fast task")
+
+    payload = json.loads(pyfetch.await_args_list[0].kwargs["body"])
+    assert payload["modelTier"] == "mini"
 
 
 @pytest.mark.asyncio

--- a/packages/narada-pyodide/tests/test_cloud_browser.py
+++ b/packages/narada-pyodide/tests/test_cloud_browser.py
@@ -12,7 +12,7 @@ from narada_core.actions.models import (
     DEFAULT_HITL_TIMEOUT_SECONDS,
     PromptForUserInputVariable,
 )
-from narada_core.models import AgentKind, ReasoningEffort
+from narada_core.models import AgentKind, AgentModelTier, ReasoningEffort
 from packaging.version import InvalidVersion
 
 PROJECT_ROOT = Path(__file__).resolve().parents[3]
@@ -514,6 +514,24 @@ async def test_agent_run_forwards_mini_model_tier(
 
     payload = json.loads(pyfetch.await_args_list[0].kwargs["body"])
     assert payload["modelTier"] == "mini"
+
+
+@pytest.mark.asyncio
+async def test_agent_run_rejects_model_tier_for_named_agent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pyfetch = AsyncMock()
+    narada_pkg, _ = _import_pyodide_narada(monkeypatch, pyfetch=pyfetch)
+    agent = narada_pkg.Agent(
+        environment=object(),
+        kind="/owner/custom-agent",
+        model_tier=AgentModelTier.MINI,
+    )
+
+    with pytest.raises(ValueError, match="named Agent Studio agents own model tiers"):
+        await agent.run("analyze")
+
+    pyfetch.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/packages/narada/README.md
+++ b/packages/narada/README.md
@@ -58,7 +58,7 @@ async def main() -> None:
 
         print("Response:", response.model_dump_json(indent=2))
 
-        # Use the product's lower-cost, faster model tier when appropriate.
+        # Use the product's lower-cost tier when appropriate.
         mini_response = await mini_agent.run(prompt="Summarize the completed task.")
         print("Mini response:", mini_response.model_dump_json(indent=2))
     finally:

--- a/packages/narada/README.md
+++ b/packages/narada/README.md
@@ -39,13 +39,14 @@ agent to download a file for you from arxiv:
 ```python
 import asyncio
 
-from narada import Agent, BrowserEnvironment
+from narada import Agent, AgentModelTier, BrowserEnvironment
 
 
 async def main() -> None:
     # Create the browser environment. It initializes lazily on the first action.
     env = BrowserEnvironment()
     agent = Agent(environment=env)
+    mini_agent = Agent(environment=env, model_tier=AgentModelTier.MINI)
 
     try:
         # Run a task in this browser environment.
@@ -56,6 +57,10 @@ async def main() -> None:
         )
 
         print("Response:", response.model_dump_json(indent=2))
+
+        # Use the product's lower-cost, faster model tier when appropriate.
+        mini_response = await mini_agent.run(prompt="Summarize the completed task.")
+        print("Mini response:", mini_response.model_dump_json(indent=2))
     finally:
         await env.close()
 

--- a/packages/narada/README.md
+++ b/packages/narada/README.md
@@ -69,6 +69,9 @@ if __name__ == "__main__":
     asyncio.run(main())
 ```
 
+`model_tier` applies to built-in `AgentKind` invocations. Named Agent Studio workflows own model
+tiers in their persisted Agent steps and reject a top-level Mini override.
+
 This would then result in the following trajectory:
 
 <p align="center">

--- a/packages/narada/pyproject.toml
+++ b/packages/narada/pyproject.toml
@@ -1,13 +1,13 @@
 [project]
 name = "narada"
-version = "0.2.9"
+version = "0.2.10"
 description = "Python client SDK for Narada"
 license = "Apache-2.0"
 readme = "README.md"
 authors = [{ name = "Narada", email = "support@narada.ai" }]
 requires-python = ">=3.12"
 dependencies = [
-    "narada-core==0.1.6",
+    "narada-core==0.1.7",
     "aiohttp>=3.12.13",
     "playwright>=1.53.0",
     "rich>=14.0.0",

--- a/packages/narada/src/narada/__init__.py
+++ b/packages/narada/src/narada/__init__.py
@@ -14,6 +14,7 @@ from narada_core.errors import (
 )
 from narada_core.models import (
     AgentKind,
+    AgentModelTier,
     CriticConfig,
     File,
     ReasoningEffort,
@@ -40,6 +41,7 @@ __all__ = [
     "HitlInputMetadata",
     "Agent",
     "AgentKind",
+    "AgentModelTier",
     "BaseBrowserEnvironment",
     "BrowserConfig",
     "BrowserEnvironment",

--- a/packages/narada/src/narada/agent.py
+++ b/packages/narada/src/narada/agent.py
@@ -51,6 +51,7 @@ from narada_core.actions.models import (
 )
 from narada_core.models import (
     AgentKind,
+    AgentModelTier,
     CriticConfig,
     File,
     McpServer,
@@ -77,9 +78,11 @@ class Agent(Generic[_StructuredOutput]):
         *,
         environment: Environment,
         kind: AgentKind | str = AgentKind.OPERATOR,
+        model_tier: AgentModelTier = AgentModelTier.DEFAULT,
     ) -> None:
         self.environment = environment
         self.kind = kind
+        self.model_tier = model_tier
 
     @overload
     async def run(
@@ -166,6 +169,7 @@ class Agent(Generic[_StructuredOutput]):
 
         remote_dispatch_response = await self._dispatch_request(
             prompt=prompt,
+            model_tier=self.model_tier,
             clear_chat=clear_chat,
             generate_gif=generate_gif,
             output_schema=output_schema,
@@ -229,6 +233,7 @@ class Agent(Generic[_StructuredOutput]):
         *,
         prompt: str,
         agent: AgentKind | str | None = None,
+        model_tier: AgentModelTier = AgentModelTier.DEFAULT,
         reasoning: ReasoningEffort | None = None,
         clear_chat: bool | None = None,
         generate_gif: bool | None = None,
@@ -253,6 +258,7 @@ class Agent(Generic[_StructuredOutput]):
         return await self.environment._dispatch_request(
             prompt=prompt,
             agent=dispatch_agent,
+            model_tier=model_tier,
             reasoning=reasoning,
             clear_chat=clear_chat,
             generate_gif=generate_gif,

--- a/packages/narada/src/narada/agent.py
+++ b/packages/narada/src/narada/agent.py
@@ -166,6 +166,13 @@ class Agent(Generic[_StructuredOutput]):
                 "`reasoning` is only supported for built-in `AgentKind` values; "
                 "named Agent Studio agents own reasoning per workflow step"
             )
+        if self.model_tier != AgentModelTier.DEFAULT and not isinstance(
+            self.kind, AgentKind
+        ):
+            raise ValueError(
+                "`model_tier` is only supported for built-in `AgentKind` values; "
+                "named Agent Studio agents own model tiers per workflow step"
+            )
 
         remote_dispatch_response = await self._dispatch_request(
             prompt=prompt,

--- a/packages/narada/src/narada/environment.py
+++ b/packages/narada/src/narada/environment.py
@@ -57,6 +57,7 @@ from narada_core.errors import (
 )
 from narada_core.models import (
     AgentKind,
+    AgentModelTier,
     File,
     McpServer,
     ReasoningEffort,
@@ -846,6 +847,7 @@ class Environment(ABC):
         *,
         prompt: str,
         agent: AgentKind | str = AgentKind.OPERATOR,
+        model_tier: AgentModelTier = AgentModelTier.DEFAULT,
         reasoning: ReasoningEffort | None = None,
         clear_chat: bool | None = None,
         generate_gif: bool | None = None,
@@ -873,6 +875,7 @@ class Environment(ABC):
         *,
         prompt: str,
         agent: AgentKind | str = AgentKind.OPERATOR,
+        model_tier: AgentModelTier = AgentModelTier.DEFAULT,
         reasoning: ReasoningEffort | None = None,
         clear_chat: bool | None = None,
         generate_gif: bool | None = None,
@@ -899,6 +902,7 @@ class Environment(ABC):
         *,
         prompt: str,
         agent: AgentKind | str = AgentKind.OPERATOR,
+        model_tier: AgentModelTier = AgentModelTier.DEFAULT,
         reasoning: ReasoningEffort | None = None,
         clear_chat: bool | None = None,
         generate_gif: bool | None = None,
@@ -985,6 +989,8 @@ class Environment(ABC):
             body["callbackHeaders"] = callback_headers
         if reasoning is not None:
             body["reasoningMode"] = reasoning.value
+        if model_tier is not AgentModelTier.DEFAULT:
+            body["modelTier"] = model_tier.value
 
         try:
             seen_input_ids: set[str] = set()

--- a/packages/narada/tests/test_agent.py
+++ b/packages/narada/tests/test_agent.py
@@ -143,6 +143,18 @@ async def test_agent_run_rejects_top_level_reasoning_for_named_agent() -> None:
 
 
 @pytest.mark.asyncio
+async def test_agent_run_rejects_model_tier_for_named_agent() -> None:
+    agent = Agent(
+        environment=_CountingEnvironment(),
+        kind="/owner/custom-agent",
+        model_tier=AgentModelTier.MINI,
+    )
+
+    with pytest.raises(ValueError, match="named Agent Studio agents own model tiers"):
+        await agent.run("analyze")
+
+
+@pytest.mark.asyncio
 async def test_agent_run_forwards_clear_chat(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/packages/narada/tests/test_agent.py
+++ b/packages/narada/tests/test_agent.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Any
 
 import pytest
-from narada import Agent, AgentKind, Environment, ReasoningEffort
+from narada import Agent, AgentKind, AgentModelTier, Environment, ReasoningEffort
 
 
 class _FakeResponse:
@@ -159,3 +159,38 @@ async def test_agent_run_forwards_clear_chat(
     await agent.run("fresh task", clear_chat=True)
 
     assert fake_session.dispatched_bodies[0]["clearChat"] is True
+
+
+@pytest.mark.asyncio
+async def test_agent_run_forwards_mini_model_tier(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import narada.environment as environment_module
+
+    fake_session = _RemoteDispatchFakeClientSession()
+    monkeypatch.setattr(
+        environment_module.aiohttp, "ClientSession", lambda: fake_session
+    )
+
+    await Agent(
+        environment=_CountingEnvironment(),
+        model_tier=AgentModelTier.MINI,
+    ).run("fast task")
+
+    assert fake_session.dispatched_bodies[0]["modelTier"] == "mini"
+
+
+@pytest.mark.asyncio
+async def test_agent_run_omits_default_model_tier_for_backward_compatibility(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import narada.environment as environment_module
+
+    fake_session = _RemoteDispatchFakeClientSession()
+    monkeypatch.setattr(
+        environment_module.aiohttp, "ClientSession", lambda: fake_session
+    )
+
+    await Agent(environment=_CountingEnvironment()).run("default task")
+
+    assert "modelTier" not in fake_session.dispatched_bodies[0]

--- a/uv.lock
+++ b/uv.lock
@@ -312,7 +312,7 @@ wheels = [
 
 [[package]]
 name = "narada"
-version = "0.2.9"
+version = "0.2.10"
 source = { editable = "packages/narada" }
 dependencies = [
     { name = "aiohttp" },
@@ -345,7 +345,7 @@ dev = [
 
 [[package]]
 name = "narada-core"
-version = "0.1.6"
+version = "0.1.7"
 source = { editable = "packages/narada-core" }
 dependencies = [
     { name = "pydantic" },
@@ -356,7 +356,7 @@ requires-dist = [{ name = "pydantic", specifier = "==2.12.5" }]
 
 [[package]]
 name = "narada-pyodide"
-version = "0.1.7"
+version = "0.1.8"
 source = { editable = "packages/narada-pyodide" }
 dependencies = [
     { name = "narada-core" },


### PR DESCRIPTION
## Summary

- add the public `AgentModelTier` enum with Default and Mini product tiers
- expose the tier on `Agent` in both CPython and Pyodide
- send `modelTier=mini` through remote dispatch while omitting Default for backward compatibility
- scope `model_tier` to direct built-in `AgentKind` invocations
- reject Mini for named Agent Studio workflows because their persisted Agent steps own model tiers; accepting it would otherwise be a silent no-op
- update package versions, dependency pins, lockfile, tests, and SDK usage documentation

## Compatibility and rollout

Default requests preserve the existing wire shape by omitting `modelTier`. Mini requires the linked Caddie remote-dispatch support. Publish `narada-core==0.1.7`, `narada-pyodide==0.1.8`, and `narada==0.2.10` before merging the standalone frontend browser pin: https://github.com/NaradaAI/frontend/pull/2066

## Testing

- CPython and Pyodide focused Agent tests: 45 passed
- Ruff lint/format and `git diff --check` passed
- isolated package builds passed
- independent final frontend/SDK boundary review: PASS

## Codex sibling refs

- caddie: https://github.com/NaradaAI/caddie/pull/6983
- frontend: https://github.com/NaradaAI/frontend/pull/2065
- desktop-automation-app:
- api-docs:

## Related contract docs

- https://github.com/NaradaAI/architecture-docs/pull/82